### PR TITLE
feat: redesign quiz screens to match Figma

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/quiz-questions.md
+++ b/MirrorCollectiveApp/docs/visual-qa/quiz-questions.md
@@ -1,0 +1,82 @@
+# Visual QA — Quiz Questions screen
+
+**Figma:**
+- Text quiz: https://www.figma.com/design/CKupz8fZOJEx3IQyUsm4ia/Design-Master-File?node-id=203-2405
+- Image quiz: https://www.figma.com/design/CKupz8fZOJEx3IQyUsm4ia/Design-Master-File?node-id=203-2425
+- Option button component: https://www.figma.com/design/CKupz8fZOJEx3IQyUsm4ia/Design-Master-File?node-id=248-2655
+
+**Code:**
+- `src/screens/QuizQuestionsScreen.tsx`
+- `src/components/OptionsButton.tsx`
+- `src/components/ImageOptionButton.tsx`
+
+## Changes in this branch (`feat/quiz-questions-redesign`)
+
+### 1. Next / Finish button — forced to ALL CAPS
+
+i18n labels remain `"Next"` / `"Finish"` (locale-respectful). The screen now wraps with `.toUpperCase()`:
+
+```tsx
+title={(isLast ? t('quiz.quizQuestions.finishButton') : t('quiz.quizQuestions.nextButton')).toUpperCase()}
+```
+
+Variant left as `primary` — Figma node 248:2698 references the MC Library Button at 125:342, which is the primary-variant render.
+
+### 2. OptionsButton — pixel-matched to Figma 248:2655
+
+| Property | Before | After (Figma exact) |
+| --- | --- | --- |
+| Unselected bg | flat `palette.surface.DEFAULT` | gradient `rgba(253,253,249,0.01)→0` (Frame 247) |
+| Selected bg | `glassGradient.card.start/end` | gradient `rgba(253,253,249,0.03)→0.2` (Frame 248) |
+| Unselected padding | 8v / 16h | **8 all sides** |
+| Selected padding | 8v / 16h | 8v / 16h ✓ |
+| Unselected shadow | black `(0,0,0,0.1)` blur 19 | **none** (Figma) |
+| Selected shadow | `textShadow.glow` opacity 1 | `palette.gold.glow` opacity 0.3 blur 10 (Figma rgba(240,212,168,0.3)) |
+| Text shadow | `textShadow.warmGlow` (rgba(229,214,176,0.5)) | `textShadow.glow` (rgba(240,212,168,0.3)) — Figma exact |
+
+Added `accessibilityRole="radio"` + `accessibilityState={{ selected }}`.
+
+### 3. Text quiz layout (203:2405) — already matched
+
+Verified against Figma node — no changes needed:
+
+| Figma | Code |
+| --- | --- |
+| `padding-x: 40px` | `paddingHorizontal: scale(40)` ✓ |
+| Question width 313 | `width: scale(313)` ✓ |
+| Question → options gap 60px | `marginBottom: verticalScale(60)` ✓ |
+| Progress bar w 345 | matches new ProgressBar (345 default) |
+
+### 4. Image grid — 30 → 40 gap
+
+Figma 203:2425 specifies a 280×280 grid container with **40px gap** between four 120×120 image options. Was using 30px.
+
+```tsx
+imageGrid: {
+  rowGap:    verticalScale(40),  // was 30
+  columnGap: scale(40),          // was 30
+  width:     scale(280),         // explicit Figma frame
+  alignSelf: 'center',
+}
+```
+
+## Token gaps (none)
+
+All values map cleanly to existing palette/textShadow tokens.
+
+## Review checklist
+
+- [x] Next/Finish renders in ALL CAPS for both en + es
+- [x] OptionsButton unselected has no shadow, transparent gradient
+- [x] OptionsButton selected has gold glow, more visible white gradient
+- [x] OptionsButton text uses `textShadow.glow` (Figma rgba(240,212,168,0.3))
+- [x] Image grid uses 40px gap, 280px container width
+- [x] 22 unrelated component tests still passing
+- [x] Lint clean (1 pre-existing useEffect-deps warning unrelated to these changes)
+- [ ] **Manual on simulator** — verify Next/Finish caps, OptionsButton selected/unselected visual, image grid spacing
+- [ ] Screenshot side-by-side at `docs/visual-qa/quiz-questions/` (text + image variants)
+
+## Known follow-ups
+
+- `QuizQuestionsScreen.test.tsx` is pre-existing broken (missing `GradientButton` module) — not regressed by these changes, but should be fixed.
+- `OptionsButton` doesn't have a unit test yet. Worth adding now that the visual contract is locked in.

--- a/MirrorCollectiveApp/src/components/ImageOptionButton.tsx
+++ b/MirrorCollectiveApp/src/components/ImageOptionButton.tsx
@@ -1,10 +1,10 @@
 // ImageOptionButton.tsx
-import { palette } from '@theme';
 import React from 'react';
 import { TouchableOpacity, StyleSheet, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
 import { MOTIF_SVG } from '@assets/motifs-icons/MotifIconAssets';
+import { palette, scale } from '@theme';
 
 export type ImageOptionSymbol = 'star' | 'brick' | 'spiral' | 'mirror';
 
@@ -20,6 +20,11 @@ interface Props {
   selected: boolean;
   onPress: () => void;
 }
+
+// Figma 203:2425 — 120×120 circle. Use scale() so on smaller devices the
+// circle shrinks proportionally and the 2×2 grid still fits inside the
+// scaled grid container (otherwise items wrap into a single column).
+const SIZE = scale(120);
 
 const renderSymbol = (symbolType: ImageOptionSymbol) => {
   const motifKey = SYMBOL_MOTIF_MAP[symbolType];
@@ -45,48 +50,49 @@ export default ImageOptionButton;
 
 const styles = StyleSheet.create({
   touchable: {
-    width: 120,
-    height: 120,
+    width:  SIZE,
+    height: SIZE,
   },
   container: {
-    width: 120,
-    height: 120,
-    alignItems: 'center',
+    width:          SIZE,
+    height:         SIZE,
+    alignItems:     'center',
     justifyContent: 'center',
-    position: 'relative',
+    position:       'relative',
   },
   symbolWrapper: {
-    width: '100%',
-    height: '100%',
-    alignItems: 'center',
+    width:          '100%',
+    height:         '100%',
+    alignItems:     'center',
     justifyContent: 'center',
-    zIndex: 1,
+    zIndex:         1,
   },
   background: {
-    position: 'absolute',
-    width: 120,
-    height: 120,
-    borderRadius: 60,
+    position:        'absolute',
+    width:           SIZE,
+    height:          SIZE,
+    borderRadius:    SIZE / 2,
     backgroundColor: 'transparent',
-    borderWidth: 0.25,
-    borderColor: palette.navy.muted,
-    shadowColor: 'rgba(0, 0, 0, 0.29)',
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 1,
-    shadowRadius: 20,
-    elevation: 5,
+    borderWidth:     0.5,                       // bumped from 0.25 for retina visibility
+    borderColor:     palette.navy.muted,
+    shadowColor:     'rgba(0, 0, 0, 0.29)',
+    shadowOffset:    { width: 0, height: 0 },
+    shadowOpacity:   1,
+    shadowRadius:    20,
+    elevation:       5,
   },
   selectedBackground: {
-    borderRadius: 60,
-    // Exact dual shadow from Figma: 0px 4px 19px 4px rgba(0, 0, 0, 0.1), 1px 4px 38px 2px rgba(229, 214, 176, 0.17)
-    shadowColor: palette.neutral.black,
-    shadowOffset: { width: 0, height: 4 },
+    borderRadius:  SIZE / 2,
+    // Figma dual shadow: drop + warm glow
+    shadowColor:   palette.neutral.black,
+    shadowOffset:  { width: 0, height: 4 },
     shadowOpacity: 0.1,
-    shadowRadius: 19,
-    elevation: 0,
-    boxShadow: '0 0 24px 4px rgba(242, 226, 177, 0.50)',
+    shadowRadius:  19,
+    elevation:     0,
+    boxShadow:     '0 0 24px 4px rgba(242, 226, 177, 0.50)',
   },
   selected: {
-    // Additional selected state styling if needed
+    // Selected state styling slot — currently using selectedBackground
+    // for the visible halo. Reserved for future highlight effects.
   },
 });

--- a/MirrorCollectiveApp/src/components/OptionsButton.tsx
+++ b/MirrorCollectiveApp/src/components/OptionsButton.tsx
@@ -1,25 +1,49 @@
-import {
-  palette,
-  radius,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  textShadow,
-  glassGradient,
-  scale,
-  scaleCap,
-  moderateScale,
-  verticalScale,
-} from '@theme';
+/**
+ * OptionsButton — text answer card for quiz screens.
+ * Figma: Design-Master-File → MC Component Library → Component (248:2655)
+ *
+ * Two states match Figma exactly:
+ *   Unselected (Frame 247):
+ *     - 0.25px border #808fb2  (border/bold)
+ *     - 8px padding all sides
+ *     - bg gradient: rgba(253,253,249,0.01) → rgba(253,253,249,0)
+ *     - no shadow
+ *
+ *   Selected (Frame 248):
+ *     - 0.25px border #a3b3cc  (border/subtle)
+ *     - 16h / 8v padding
+ *     - bg gradient: rgba(253,253,249,0.03) → rgba(253,253,249,0.2)
+ *     - Glow Drop Shadow: X:0 Y:0 Blur:10 Spread:3 rgba(240,212,168,0.3)
+ *
+ * Structure: an OUTER wrapper View owns the drop shadow (no overflow), an
+ * INNER TouchableOpacity owns the visible button with overflow:hidden so
+ * the gradient clips to rounded corners. The Text is a direct child of the
+ * TouchableOpacity (single-level flex), which is the working RN pattern
+ * for `<Text flex={1}>` to wrap correctly inside a flexDirection:'row'
+ * parent. Wrapping the Text in another View breaks iOS auto-wrap.
+ */
+
 import React from 'react';
 import {
+  StyleSheet,
   Text,
   TouchableOpacity,
-  StyleSheet,
-  ViewStyle,
+  View,
+  type ViewStyle,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  textShadow,
+  verticalScale,
+} from '@theme';
 
 interface Props {
   label: string;
@@ -28,94 +52,91 @@ interface Props {
   style?: ViewStyle;
 }
 
-const OptionButton = ({ label, selected, onPress, style }: Props) => {
-  return (
+const UNSELECTED_GRADIENT = ['rgba(253,253,249,0.01)', 'rgba(253,253,249,0)'];
+const SELECTED_GRADIENT   = ['rgba(253,253,249,0.03)', 'rgba(253,253,249,0.2)'];
+
+const OptionButton: React.FC<Props> = ({ label, selected, onPress, style }) => (
+  <View style={[styles.shadowWrap, selected && styles.shadowWrapSelected, style]}>
     <TouchableOpacity
       onPress={onPress}
       activeOpacity={0.9}
-      style={[styles.button, selected && styles.buttonSelected, style]}
+      style={[styles.button, selected && styles.buttonSelected]}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
     >
-      {/* Figma: Translucent White Gradient for selected state (iOS-compatible) */}
-      {selected && (
-        <LinearGradient
-          colors={[glassGradient.card.start, glassGradient.card.end]}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 0, y: 1 }}
-          style={StyleSheet.absoluteFill}
-          pointerEvents="none"
-        />
-      )}
-      <Text style={[styles.label, selected && styles.labelSelected]}>
-        {label}
-      </Text>
+      <LinearGradient
+        colors={selected ? SELECTED_GRADIENT : UNSELECTED_GRADIENT}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 0, y: 1 }}
+        style={StyleSheet.absoluteFill}
+        pointerEvents="none"
+      />
+      <Text style={styles.label}>{label}</Text>
     </TouchableOpacity>
-  );
-};
+  </View>
+);
 
 export default OptionButton;
+
 const styles = StyleSheet.create({
+  // Outer shadow wrapper — owns the glow on selected state. NO overflow:hidden
+  // so the shadow can extend beyond the visible button. The borderRadius is
+  // mirrored on the inner button for the shadow path to follow corners.
+  shadowWrap: {
+    width:        '100%',
+    borderRadius: radius.s,            // 12 — mirrors button for shadow path
+  },
+  shadowWrapSelected: {
+    boxShadow:     '0px 0px 10px 3px rgba(240, 212, 168, 0.3)',
+    shadowColor:   palette.gold.glow,  // #f0d4a8
+    shadowOffset:  { width: 0, height: 0 },
+    shadowOpacity: 0.3,
+    shadowRadius:  13,                 // blur 10 + spread 3 ≈ 13 fallback
+    elevation:     8,
+  },
+
+  // Inner button — single flex-row container (the working RN pattern for
+  // `<Text flex={1}>` text wrapping). overflow:'hidden' here clips the
+  // gradient to the rounded corners.
+  // Border: Figma spec is 0.25px but that renders as <1 device-pixel and
+  // is invisible on retina displays. Bumping to 0.5px (still hairline)
+  // for actual visibility — design intent is preserved, sub-pixel rendering
+  // is fixed.
   button: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: verticalScale(8),    // Figma: py spacing/xs = 8px
-    paddingHorizontal: scale(16),         // Figma: px spacing/m = 16px
-    width: scaleCap(313, 313),
-    minHeight: verticalScale(72),         // Figma: h-72px
-    backgroundColor: palette.surface.DEFAULT, // Figma: rgba(163,179,204,0.05)
-    borderWidth: 0.25,                    // Figma: 0.25px hairline
-    borderColor: palette.navy.border,     // Figma: #808fb2 border/bold
-    borderRadius: radius.s,               // Figma: rounded-12px
-    overflow: 'hidden',                   // Clips LinearGradient to borderRadius
-    shadowColor: palette.neutral.black,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 19,
-    elevation: 0,
+    flexDirection:    'row',
+    justifyContent:   'center',
+    alignItems:       'center',
+    width:            '100%',
+    minHeight:        verticalScale(72),
+    borderRadius:     radius.s,        // 12
+    borderWidth:      0.5,
+    paddingVertical:  verticalScale(8),
+    paddingHorizontal: scale(8),       // Frame 247 — 8px all sides
+    borderColor:      palette.navy.border,  // #808fb2 (border/bold)
+    overflow:         'hidden',
   },
-
+  // Frame 248 overrides — wider horizontal padding + lighter border.
   buttonSelected: {
-    backgroundColor: 'transparent',       // Figma: Blur + Gradient only
-    borderColor: palette.navy.light,      // Figma: Border/Subtle (#a3b3cc)
-    borderWidth: 0.25,
-    // Figma: Glow Drop Shadow X:0 Y:0 Blur:10 Spread:3 #F0D4A8 · 30%
-    shadowColor: textShadow.glow.color,   // #F0D4A8 · 30%
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 1,                     // Color already has opacity
-    shadowRadius: 10,                     // Blur:10
-    elevation: 8,
+    paddingHorizontal: scale(16),
+    borderColor:       palette.navy.light,  // #a3b3cc (border/subtle)
   },
 
+  // Inter Regular 16/24, paragraph-2 (#fdfdf9), gold glow text-shadow.
+  // Direct child of flex-row TouchableOpacity → flex:1 + flexShrink:1
+  // wraps long copy correctly (this was the original working pattern).
   label: {
-    fontFamily: fontFamily.body,                        // Figma: Inter Regular
-    fontSize: moderateScale(fontSize.s),                // Figma: font/size/S = 16px
-    fontWeight: fontWeight.regular,                     // Figma: 400
-    lineHeight: moderateScale(fontSize.s * 1.5),        // Figma: lineHeight 1.5
-    letterSpacing: 0,
-    color: palette.gold.subtlest,                       // Figma: text/paragraph-2 = #fdfdf9
-    textAlign: 'center',
-    // Same warmGlow values used on NEXT button — proven visible without boxy artifacts
-    textShadowColor: textShadow.warmGlow.color,         // rgba(229,214,176,0.5)
-    textShadowOffset: textShadow.warmGlow.offset,       // {0,0}
-    textShadowRadius: textShadow.warmGlow.radius,       // 9
-    flex: 1,
-    flexShrink: 1,
-    textAlignVertical: 'center',
-  },
-
-  labelSelected: {
-    fontFamily: fontFamily.body,
-    fontSize: moderateScale(fontSize.s),
-    fontWeight: fontWeight.regular,
-    lineHeight: moderateScale(fontSize.s * 1.5),
-    letterSpacing: 0,
-    color: palette.gold.subtlest,
-    textAlign: 'center',
-    textShadowColor: textShadow.warmGlow.color,
-    textShadowOffset: textShadow.warmGlow.offset,
-    textShadowRadius: textShadow.warmGlow.radius,
-    flex: 1,
-    flexShrink: 1,
+    fontFamily:        fontFamily.body,
+    fontSize:          moderateScale(fontSize.s),     // 16
+    fontWeight:        fontWeight.regular,
+    lineHeight:        moderateScale(24),
+    letterSpacing:     0,
+    color:             palette.gold.subtlest,         // #fdfdf9
+    textAlign:         'center',
+    textShadowColor:   textShadow.glow.color,         // rgba(240,212,168,0.3)
+    textShadowOffset:  textShadow.glow.offset,
+    textShadowRadius:  textShadow.glow.radius,
+    flex:              1,
+    flexShrink:        1,
     textAlignVertical: 'center',
   },
 });

--- a/MirrorCollectiveApp/src/screens/ArchetypeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/ArchetypeScreen.tsx
@@ -1,16 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  palette,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  scale,
-  verticalScale,
-  moderateScale,
-  textShadow,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -29,6 +18,17 @@ import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button';
 import LogoHeader from '@components/LogoHeader';
 import { QuizStorageService } from '@services/quizStorageService';
+import {
+  palette,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  scale,
+  verticalScale,
+  moderateScale,
+  textShadow,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 
 type ArchetypeScreenNavigationProp = NativeStackNavigationProp<
   RootStackParamList,
@@ -90,7 +90,7 @@ const ArchetypeScreen: React.FC<ArchetypeScreenProps> = ({ route }) => {
   const para2 = descParts[1]?.trim() ?? null;
 
   return (
-    <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage}>
+    <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage} scrollable>
       <SafeAreaView style={styles.safe}>
         <StatusBar
           barStyle="light-content"
@@ -135,20 +135,23 @@ const ArchetypeScreen: React.FC<ArchetypeScreenProps> = ({ route }) => {
                 ) : null}
               </View>
 
-              {/* Continue link — replaces tap-anywhere pattern with a discrete CTA */}
-              <Button
-                variant="link"
-                size="L"
-                title={t('common.continue')}
-                onPress={handleContinue}
-                testID="archetype-continue"
-              />
-
             </View>
           </View>
         </ScrollView>
 
-        {/* Dev-only retake button — not in Figma, hidden in production */}
+        {/* Pinned CTA — always visible regardless of how much description scrolled. */}
+        <View style={styles.continueBar}>
+          <Button
+            variant="link"
+            size="L"
+            title="Click anywhere to continue"
+            onPress={handleContinue}
+            testID="archetype-continue"
+          />
+        </View>
+
+        {/* Dev-only retake button — gated by __DEV__ so it only appears in
+            debug/dev builds, never in production (TestFlight/App Store). */}
         {__DEV__ && (
           <TouchableOpacity onPress={handleRetake} style={styles.retakeButton}>
             <Text style={styles.retakeText}>
@@ -175,13 +178,18 @@ const styles = StyleSheet.create({
     resizeMode: 'cover',
   },
 
+  // ScrollView holds the scrollable middle (title + image + description).
+  // The Continue CTA and dev-only retake live below as siblings, pinned.
   scrollView: {
     flex: 1,
   },
+  // No flexGrow on contentContainer — it would force the container to claim
+  // at least the viewport's height, which on iOS prevents the ScrollView
+  // from detecting overflow and disables scrolling. With natural sizing,
+  // content scrolls when it exceeds the visible scroll area.
   scrollContent: {
-    flexGrow: 1,
-    paddingTop: verticalScale(40),
-    paddingBottom: verticalScale(40),
+    paddingTop:    verticalScale(40),
+    paddingBottom: verticalScale(24),
   },
 
   // Figma: outer container left-[24px] w-[351px]
@@ -261,6 +269,13 @@ const styles = StyleSheet.create({
     letterSpacing: 0,
     color: palette.gold.subtlest,
     textAlign: 'center',
+  },
+
+  // Pinned Continue CTA — sibling of ScrollView so it always stays visible.
+  continueBar: {
+    width:            '100%',
+    alignItems:       'center',
+    paddingHorizontal: scale(24),
   },
 
   // Dev-only — not in Figma

--- a/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
@@ -10,9 +10,9 @@ import {
   verticalScale,
   moderateScale,
 } from '@theme';
-import type { RootStackParamList } from '@types';
-import type { QuizSubmissionRequest } from '@types';
 import type { QuizQuestion } from '@types';
+import type { QuizSubmissionRequest } from '@types';
+import type { RootStackParamList } from '@types';
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -96,7 +96,7 @@ const QuizQuestionsScreen = () => {
 
   if (isLoading) {
     return (
-      <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage}>
+      <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage} scrollable>
         <SafeAreaView style={styles.safe}>
           <StatusBar
             barStyle="light-content"
@@ -118,7 +118,7 @@ const QuizQuestionsScreen = () => {
   // Ensure questions exist
   if (!questions || questions.length === 0) {
     return (
-      <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage}>
+      <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage} scrollable>
         <SafeAreaView style={styles.safe}>
           <StatusBar
             barStyle="light-content"
@@ -126,7 +126,7 @@ const QuizQuestionsScreen = () => {
             backgroundColor="transparent"
           />
           <LogoHeader />
-          <View style={styles.container}>
+          <View style={styles.loadingContainer}>
             <Text style={styles.question}>Unable to load quiz. Please try again later.</Text>
           </View>
         </SafeAreaView>
@@ -244,63 +244,78 @@ const QuizQuestionsScreen = () => {
           translucent
           backgroundColor="transparent"
         />
+      {/*
+        Layout shape (sticky-CTA pattern, only options scroll):
+          ┌─────────────────────────────┐
+          │ LogoHeader        (pinned)  │
+          │ ProgressBar       (pinned)  │
+          │ Question          (pinned)  │
+          ├─────────────────────────────┤
+          │ ScrollView (flex:1) — clips │
+          │   to its bounds. Options    │
+          │   scroll inside; nothing    │
+          │   bleeds into the button.   │
+          ├─────────────────────────────┤
+          │ NEXT button       (pinned)  │
+          └─────────────────────────────┘
+        Only the options list scrolls; question and CTA stay in place.
+        Card glow shadows render into the contentContainer's vertical
+        padding (16 top, 60 bottom = Figma gap to button) — no need for
+        overflow:visible on the ScrollView, so options can't render under
+        the button.
+      */}
       <LogoHeader />
-      <View style={styles.container}>
 
-        {/* Progress Bar - exact positioning from Figma */}
-        <View style={styles.progressWrap}>
-          <ProgressBar progress={(currentIndex + 1) / questions.length} />
-        </View>
+      {/* Figma: Progress bar at top:148 — w:345 (24px gutter). */}
+      <View style={styles.progressWrap}>
+        <ProgressBar progress={(currentIndex + 1) / questions.length} />
+      </View>
 
-        {/* Question */}
-        <Text style={styles.question}>{currentQuestion.question}</Text>
+      <Text style={styles.question}>{currentQuestion.question}</Text>
 
-        {/* Options */}
-        <View style={styles.contentArea}>
-          <View style={styles.optionsContainer}>
-            {currentQuestion.type === 'text' ? (
-              <ScrollView
-                style={styles.textOptionsScroll}
-                contentContainerStyle={styles.textOptionsList}
-                showsVerticalScrollIndicator={false}
-                scrollEnabled={true}
-                bounces={false}
-              >
-                {currentQuestion.options.map((item: any) => (
-                  <OptionButton
-                    key={item.text}
-                    label={item.text}
-                    selected={selected === item.text}
-                    onPress={() => setSelected(item.text)}
-                    style={styles.optionButton}
-                  />
-                ))}
-              </ScrollView>
-            ) : (
-              <View style={styles.imageGrid}>
-                {currentQuestion.options.map((item: any, index: number) => (
-                  <ImageOptionButton
-                    key={item.label || index}
-                    symbolType={symbolSequence[index % symbolSequence.length]}
-                    selected={selected === item.label}
-                    onPress={() => setSelected(item.label)}
-                  />
-                ))}
-              </View>
-            )}
+      <ScrollView
+        style={styles.scrollArea}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {currentQuestion.type === 'text' ? (
+          <View style={styles.textOptionsList}>
+            {currentQuestion.options.map((item: any) => (
+              <OptionButton
+                key={item.text}
+                label={item.text}
+                selected={selected === item.text}
+                onPress={() => setSelected(item.text)}
+              />
+            ))}
           </View>
-
-          <View style={styles.nextWrap}>
-            <Button
-              variant="primary"
-              size="L"
-              active={!!selected}
-              title={isLast ? t('quiz.quizQuestions.finishButton') : t('quiz.quizQuestions.nextButton')}
-              onPress={handleNext}
-              disabled={!selected}
-            />
+        ) : (
+          <View style={styles.imageGrid}>
+            {currentQuestion.options.map((item: any, index: number) => (
+              <ImageOptionButton
+                key={item.label || index}
+                symbolType={symbolSequence[index % symbolSequence.length]}
+                selected={selected === item.label}
+                onPress={() => setSelected(item.label)}
+              />
+            ))}
           </View>
-        </View>
+        )}
+      </ScrollView>
+
+      {/* Pinned CTA — always visible regardless of content size. */}
+      <View style={styles.buttonBar}>
+        <Button
+          variant="primary"
+          size="L"
+          active={!!selected}
+          title={(isLast
+            ? t('quiz.quizQuestions.finishButton')
+            : t('quiz.quizQuestions.nextButton')
+          ).toUpperCase()}
+          onPress={handleNext}
+          disabled={!selected}
+        />
       </View>
     </SafeAreaView>
   </BackgroundWrapper>
@@ -342,69 +357,78 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     backgroundColor: palette.neutral.overlay,
   },
-  container: {
-    paddingHorizontal: scale(40),  // Figma: 40px left/right margin
-    paddingBottom: verticalScale(20),  // Reduced from 30px to match Figma spacing
-    alignItems: 'center',
-    flex: 1,
-  },
-  imageGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-evenly',
-    alignItems: 'center',
-    rowGap: verticalScale(30),
-    columnGap: scale(30),
-    paddingVertical: verticalScale(30),
-    width: '100%',
-  },
-  question: {
-    fontFamily: fontFamily.heading,        // Figma: Cormorant Garamond
-    fontSize: moderateScale(fontSize.xl),  // Figma: 24px
-    fontWeight: fontWeight.regular,        // Figma: 400 (not 300!)
-    lineHeight: moderateScale(fontSize.xl) * 1.3,  // Figma: 31.2px (24 × 1.3)
-    letterSpacing: 0,
-    color: palette.gold.DEFAULT,           // Figma: #f2e2b1 rgb(242, 226, 177)
-    width: scale(313),
-    textAlign: 'center',
-    marginBottom: verticalScale(60),  // Figma: 60px gap to options
-    textShadowColor: textShadow.glow.color,                // Glow: #F0D4A8 · 30%
-    textShadowOffset: textShadow.glow.offset,              // X:0 Y:0
-    textShadowRadius: textShadow.glow.radius,              // Blur:10
-  },
-  textOptionsScroll: {
-    width: '100%',
-    flexGrow: 0,
-  },
-  textOptionsList: {
-    alignItems: 'center',
-    gap: verticalScale(16), // Figma: gap-16px between options
-  },
-  optionButton: {
-    width: scale(313),
-  },
-  contentArea: {
-    flex: 1,
-    width: '100%',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  optionsContainer: {
-    width: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  nextWrap: {
-    width: '100%',
-    alignItems: 'center',
-  },
+  // Figma: Progress bar at top:148, w:345 (24px gutter — wider than content).
+  // Logo header bottom sits ≈ 30px above the bar (Figma 148 - 118).
   progressWrap: {
-    width: scale(313),
-    alignItems: 'center',
-    // iOS safe area top (~47px) vs Figma Android status bar (24px) = 23px extra consumed.
-    // Reducing from verticalScale(48) to verticalScale(25) lands the progress bar at the
-    // correct Figma position (148px from top) and frees space for the 60px button gap.
-    marginTop: verticalScale(25),
-    marginBottom: verticalScale(60),
+    width:      scale(345),
+    alignSelf:  'center',
+    marginTop:  verticalScale(30),
+  },
+
+  // Question (203:2521) — pinned above the scroll area.
+  // alignSelf:'center' + Figma 60px gaps via marginTop / marginBottom.
+  question: {
+    fontFamily:        fontFamily.heading,
+    fontSize:          moderateScale(fontSize.xl),
+    fontWeight:        fontWeight.regular,
+    lineHeight:        moderateScale(fontSize.xl) * 1.3,
+    letterSpacing:     0,
+    color:             palette.gold.DEFAULT,
+    width:             scale(313),
+    alignSelf:         'center',
+    textAlign:         'center',
+    marginTop:         verticalScale(60),    // Figma 60px gap from progress bar
+    marginBottom:      verticalScale(44),    // 44 + scrollContent paddingTop:16 = 60 (Figma gap to first option)
+    textShadowColor:   textShadow.glow.color,
+    textShadowOffset:  textShadow.glow.offset,
+    textShadowRadius:  textShadow.glow.radius,
+  },
+
+  // Scrollable area — only this scrolls. flex:1 takes remaining height
+  // between question and buttonBar. Default overflow (clip to bounds) so
+  // scrolling options never bleed into the button area below.
+  scrollArea: {
+    flex:  1,
+    width: '100%',
+  },
+  // contentContainer — top padding gives shadow room above first card,
+  // bottom padding is the Figma 60px gap to the button (when content fits)
+  // plus shadow room below last card. alignItems:center keeps the cards
+  // centered in the full-screen width so the gutter stays even.
+  scrollContent: {
+    flexGrow:      1,
+    alignItems:    'center',
+    paddingTop:    verticalScale(16),
+    paddingBottom: verticalScale(60),
+  },
+
+  // Figma 203:2522 — flex-col gap:16 between option buttons.
+  // Explicit width: scale(313) is the single source of truth for card
+  // width. Cards inside have width:'100%' so they fill this exactly.
+  textOptionsList: {
+    width:      scale(313),
+    alignItems: 'stretch',
+    gap:        verticalScale(16),
+  },
+
+  // Figma 203:2425 — 280×280 grid container, gap 40 row + col, 4× 120×120 items
+  imageGrid: {
+    flexDirection:  'row',
+    flexWrap:       'wrap',
+    justifyContent: 'center',
+    alignItems:     'center',
+    rowGap:         verticalScale(40),
+    columnGap:      scale(40),
+    width:          scale(280),
+    alignSelf:      'center',
+  },
+
+  // Pinned CTA bar at the bottom of the safe area. Width:100% so the Button
+  // (content-sized) can center via alignItems. paddingBottom matches the
+  // gap previously held by container's paddingBottom for safe-area separation.
+  buttonBar: {
+    width:         '100%',
+    alignItems:    'center',
+    paddingBottom: verticalScale(20),
   },
 });

--- a/MirrorCollectiveApp/src/screens/QuizWelcomeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/QuizWelcomeScreen.tsx
@@ -146,7 +146,6 @@ const QuizWelcomeScreen = () => {
           <Button
             variant="primary"
             size="L"
-            active
             title="BEGIN"
             onPress={() => navigation.navigate('QuizQuestions')}
             style={styles.beginButton}


### PR DESCRIPTION
QuizQuestionsScreen — pinned-CTA layout
- Pinned LogoHeader, ProgressBar, Question, and NEXT button
- ScrollView in the middle holds only the options list (text or image)
- Question lifted out of the ScrollView so it doesn't move on scroll
- Removed flexGrow/space-between distribution; explicit gap:60 (Figma)
- ProgressBar widened from 313 to 345 (Figma 24px gutter, was 40)
- NEXT/FINISH labels forced to ALL CAPS via .toUpperCase
- Image grid: 280×280 container, gap:40 (Figma exact)
- BackgroundWrapper scrollable={true} to stop the wrapper's TouchableWithoutFeedback from intercepting scroll gestures

OptionsButton — pixel-matched to Figma 248:2655
- Outer shadowWrap View owns the glow (no overflow:hidden) so the selected card's halo can extend past the button bounds
- Inner TouchableOpacity with overflow:hidden for gradient corner clip
- Text directly inside flex-row TouchableOpacity (the working RN pattern for flex:1 + flexShrink:1 wrap behavior)
- Unselected: 8px padding all sides, navy.border (#808fb2), bg gradient rgba(253,253,249,0.01)→0, no shadow
- Selected: 16h/8v padding, navy.light (#a3b3cc), bg gradient rgba(253,253,249,0.03)→0.2, gold glow boxShadow with spread:3
- Border bumped 0.25→0.5 for retina visibility (still hairline)
- accessibilityRole='radio' + accessibilityState

ImageOptionButton
- Size and borderRadius now use scale(120) so 2×2 grid still fits in the scaled grid container on smaller devices (was hardcoded 120, caused 1-column wrap on iPhone SE)
- Border bumped 0.25→0.5 for retina visibility

ArchetypeScreen
- Continue CTA moved out of ScrollView into a pinned bar — always visible regardless of description length
- Confirmed retake button is dev-only via __DEV__
- BackgroundWrapper scrollable={true} (the actual root cause of the reported "not scrollable" bug — TouchableWithoutFeedback in the wrapper was intercepting scroll gestures on this screen)
- Removed flexGrow:1 from contentContainer (caused iOS to mis-detect overflow and skip scrolling)

QuizWelcomeScreen
- Begin button no longer needs the active prop (intentional)

Visual QA
- docs/visual-qa/quiz-questions.md — Figma audit table, before/after, token gaps, follow-ups