### PR TITLE
feat: Echo Vault redesign + secondary button + AppVideoScreen + Echo …

### DIFF
--- a/MirrorCollectiveApp/App.tsx
+++ b/MirrorCollectiveApp/App.tsx
@@ -25,6 +25,7 @@ import ChooseRecipientScreen from '@screens/echoVault/ChooseRecipientScreen';
 import EchoAudioPlaybackScreen from '@screens/echoVault/EchoAudioPlaybackScreen';
 import EchoDetailScreen from '@screens/echoVault/EchoDetailScreen';
 import MirrorEchoVaultHomeScreen from '@screens/echoVault/EchoVaultHomeScreen';
+import EchoInboxScreen from '@screens/echoVault/EchoInboxScreen';
 import MirrorEchoVaultLibraryScreen from '@screens/echoVault/EchoVaultLibraryScreen';
 import EchoVideoPlaybackScreen from '@screens/echoVault/EchoVideoPlaybackScreen';
 import ManageGuardianScreen from '@screens/echoVault/ManageGuardianScreen';
@@ -226,6 +227,7 @@ const AuthenticatedNavigator = ({ initialRouteName = 'EnterMirror' }: Authentica
     {/* Echo Vault Screens */}
     <Stack.Screen name="MirrorEchoVaultHome" component={MirrorEchoVaultHomeScreen} />
     <Stack.Screen name="MirrorEchoVaultLibrary" component={MirrorEchoVaultLibraryScreen} />
+    <Stack.Screen name="EchoInboxScreen" component={EchoInboxScreen} />
     <Stack.Screen name="NewEchoScreen" component={NewEchoScreen} />
     <Stack.Screen name="NewEchoComposeScreen" component={NewEchoComposeScreen} />
     <Stack.Screen name="NewEchoAudioScreen" component={NewEchoAudioScreen} />

--- a/MirrorCollectiveApp/src/components/Button/Button.tsx
+++ b/MirrorCollectiveApp/src/components/Button/Button.tsx
@@ -1,3 +1,14 @@
+import React, { type ReactNode } from 'react';
+import {
+  TouchableOpacity,
+  Text,
+  View,
+  StyleSheet,
+  type ViewStyle,
+  type TextStyle,
+} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+
 import {
   moderateScale,
   scaleCap,
@@ -11,16 +22,6 @@ import {
   borderWidth,
   glassGradient,
 } from '@theme';
-import React, { type ReactNode } from 'react';
-import {
-  TouchableOpacity,
-  Text,
-  View,
-  StyleSheet,
-  type ViewStyle,
-  type TextStyle,
-} from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
 
 import StarIcon from '../StarIcon';
 
@@ -197,10 +198,27 @@ const PrimaryButton = ({
 
 // ---------------------------------------------------------------------------
 // MC Secondary Button
-// Visually identical to Primary today (both render the QuizWelcome-style
-// solid navy card surface). If a designer-distinct secondary visual is
-// needed later, branch from here.
+// Figma node 125:436 — Style=Secondary, Size=L, State=Inactive
+//
+// Differs from Primary in two ways:
+//   1. Background: "Translucent White Gradient" rgba(253,253,249,0.03)→0.20
+//      (Primary uses "Transparent White Gradient" 0.01→0 which is near-invisible)
+//   2. Text: NO warm-glow shadow (Primary has 0px 0px 9px rgba(229,214,176,0.5))
+//
+// Layer contract (mirrors OptionsButton shell/frame pattern):
+//   <View mcGlowWrapper>          ← shadow lives here, no clipping
+//     <View activeGlowLayer/>     ← active-state glow (optional)
+//     <TouchableOpacity mcBase>   ← border, radius, overflow:hidden
+//       <LinearGradient>          ← Translucent White Gradient (clipped by overflow)
+//       icon + label + icon
+//     </TouchableOpacity>
+//   </View>
 // ---------------------------------------------------------------------------
+
+const SECONDARY_GRADIENT = [
+  glassGradient.echoPrimary.start,  // rgba(253,253,249,0.03)
+  glassGradient.echoPrimary.end,    // rgba(253,253,249,0.20)
+];
 
 const SecondaryButton = ({
   title,
@@ -227,6 +245,7 @@ const SecondaryButton = ({
         testID={testID}
         style={[
           styles.mcBase,
+          styles.mcSecondaryBase,
           {
             paddingVertical: sz.paddingVertical,
             paddingHorizontal: sz.paddingHorizontal,
@@ -236,10 +255,17 @@ const SecondaryButton = ({
           },
         ]}
       >
+        <LinearGradient
+          colors={SECONDARY_GRADIENT}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 0, y: 1 }}
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+        />
         {leftIcon}
         <Text
           style={[
-            styles.mcLabel,
+            styles.mcSecondaryLabel,
             { fontSize: moderateScale(sz.fontSize, 0.3), lineHeight: sz.lineHeight },
             textStyle,
           ]}
@@ -436,19 +462,33 @@ const styles = StyleSheet.create({
     ...ACTIVE_GLOW_SHADOW,
   },
 
-  // Shared label style for primary + secondary
-  // Figma: "Heading S/XS (Cormorant)" — Cormorant Garamond Regular at the
-  // size set per `SIZE[size].fontSize`. Cormorant ascends taller than Inter,
-  // so the larger 24/20 sizes are intentional and match the design height.
+  // Primary label — Cormorant Regular, gold, WITH warm-glow text shadow.
+  // Figma: Primary inactive text-shadow 0px 0px 9px rgba(229,214,176,0.5)
   mcLabel: {
-    fontFamily: fontFamily.heading,           // Figma: Cormorant Garamond Regular
+    fontFamily: fontFamily.heading,
     fontWeight: '400',
-    color: palette.gold.DEFAULT,              // Figma: Bg/Brand = #f2e1b0
+    color: palette.gold.DEFAULT,
     textAlign: 'center',
     includeFontPadding: false,
     textShadowColor: textShadow.warmGlow.color,
     textShadowOffset: textShadow.warmGlow.offset,
     textShadowRadius: textShadow.warmGlow.radius,
+  },
+
+  // Secondary base — transparent so LinearGradient shows through.
+  // mcBase's solid navy fill is replaced by the gradient.
+  mcSecondaryBase: {
+    backgroundColor: 'transparent',
+  },
+
+  // Secondary label — identical to mcLabel EXCEPT no text shadow.
+  // Figma node 125:436: secondary removes the warm-glow shadow on text.
+  mcSecondaryLabel: {
+    fontFamily: fontFamily.heading,
+    fontWeight: '400',
+    color: palette.gold.DEFAULT,
+    textAlign: 'center',
+    includeFontPadding: false,
   },
 
   // Link container — no background/border; Figma: Link L:122×40, Link S:114×40

--- a/MirrorCollectiveApp/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/MirrorCollectiveApp/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1168,6 +1168,9 @@ exports[`Button structural snapshots secondary · L · active 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 52,
@@ -1177,6 +1180,27 @@ exports[`Button structural snapshots secondary · L · active 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1186,12 +1210,6 @@ exports[`Button structural snapshots secondary · L · active 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 23.670229007633587,
@@ -1234,6 +1252,9 @@ exports[`Button structural snapshots secondary · L · default 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 52,
@@ -1243,6 +1264,27 @@ exports[`Button structural snapshots secondary · L · default 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1252,12 +1294,6 @@ exports[`Button structural snapshots secondary · L · default 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 23.670229007633587,
@@ -1303,6 +1339,9 @@ exports[`Button structural snapshots secondary · L · disabled 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 52,
@@ -1312,6 +1351,27 @@ exports[`Button structural snapshots secondary · L · disabled 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1321,12 +1381,6 @@ exports[`Button structural snapshots secondary · L · disabled 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 23.670229007633587,
@@ -1386,6 +1440,9 @@ exports[`Button structural snapshots secondary · S · active 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 42,
@@ -1395,6 +1452,27 @@ exports[`Button structural snapshots secondary · S · active 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1404,12 +1482,6 @@ exports[`Button structural snapshots secondary · S · active 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 19.72519083969466,
@@ -1452,6 +1524,9 @@ exports[`Button structural snapshots secondary · S · default 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 42,
@@ -1461,6 +1536,27 @@ exports[`Button structural snapshots secondary · S · default 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1470,12 +1566,6 @@ exports[`Button structural snapshots secondary · S · default 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 19.72519083969466,
@@ -1521,6 +1611,9 @@ exports[`Button structural snapshots secondary · S · disabled 1`] = `
           "overflow": "hidden",
         },
         {
+          "backgroundColor": "transparent",
+        },
+        {
           "borderRadius": 16,
           "gap": 8,
           "minHeight": 42,
@@ -1530,6 +1623,27 @@ exports[`Button structural snapshots secondary · S · disabled 1`] = `
       ]
     }
   >
+    <LinearGradient
+      colors={
+        [
+          "rgba(253, 253, 249, 0.03)",
+          "rgba(253, 253, 249, 0.20)",
+        ]
+      }
+      end={
+        {
+          "x": 0,
+          "y": 1,
+        }
+      }
+      pointerEvents="none"
+      start={
+        {
+          "x": 0,
+          "y": 0,
+        }
+      }
+    />
     <Text
       style={
         [
@@ -1539,12 +1653,6 @@ exports[`Button structural snapshots secondary · S · disabled 1`] = `
             "fontWeight": "400",
             "includeFontPadding": false,
             "textAlign": "center",
-            "textShadowColor": "rgba(229, 214, 176, 0.5)",
-            "textShadowOffset": {
-              "height": 0,
-              "width": 0,
-            },
-            "textShadowRadius": 9,
           },
           {
             "fontSize": 19.72519083969466,

--- a/MirrorCollectiveApp/src/screens/AppVideoScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/AppVideoScreen.tsx
@@ -1,5 +1,16 @@
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import {
+  palette,
+  fontFamily,
+  fontSize,
+  spacing,
+  radius,
+  scale,
+  verticalScale,
+  moderateScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -15,17 +26,6 @@ import Video from 'react-native-video';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button';
 import LogoHeader from '@components/LogoHeader';
-import {
-  palette,
-  fontFamily,
-  fontSize,
-  spacing,
-  radius,
-  scale,
-  verticalScale,
-  moderateScale,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 
 
 const VIDEO_URL =

--- a/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
@@ -412,6 +412,11 @@ const styles = StyleSheet.create({
   },
 
   // Figma 203:2425 — 280×280 grid container, gap 40 row + col, 4× 120×120 items
+  // The +2 buffer is a sub-pixel rounding fix: scale(120)*2 + scale(40) is
+  // mathematically equal to scale(280), but on devices like iPhone 17 Pro
+  // floating-point drift in JS multiplication makes the row total exceed the
+  // container width by a fraction of a pixel, forcing each item onto its own
+  // row. The 2px headroom is invisible visually and breaks the tie.
   imageGrid: {
     flexDirection:  'row',
     flexWrap:       'wrap',
@@ -419,7 +424,7 @@ const styles = StyleSheet.create({
     alignItems:     'center',
     rowGap:         verticalScale(40),
     columnGap:      scale(40),
-    width:          scale(280),
+    width:          scale(280) + 2,
     alignSelf:      'center',
   },
 

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
@@ -1,0 +1,527 @@
+/**
+ * Echo Inbox Screen
+ * Figma: Design-Master-File → Echo inbox (1436:1830)
+ *
+ * Shows echoes that have been entrusted TO the current user (received echoes).
+ * Tabs: SENDER (who sent the echo) | CATEGORY (echo category)
+ * Layout mirrors EchoVaultLibraryScreen but with:
+ *   - Back arrow header instead of LogoHeader
+ *   - No avatar circles in rows (Figma shows no avatars)
+ *   - SENDER tab shows sender name on right (per user: "sender view similar to recipient view")
+ *   - getInboxEchoes() API call
+ *
+ * Tokens (from Figma 1436:1830 variable defs):
+ *   Heading M: Cormorant Regular 28/32 — "ECHO INBOX" title
+ *   Body S Regular: Inter Regular 16/24 — subtitle
+ *   Heading XS: Cormorant Regular 20/24 — row titles
+ *   Body S Light: Inter Light 16/24 — right labels
+ *   Body S Light Italic: Inter Light Italic 14/1.5 — date subtitles
+ *   Border/Inverse-1 #60739f — card border (navy.medium)
+ *   Border/Subtle #a3b3cc — row dividers, active tab underline
+ */
+
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Path } from 'react-native-svg';
+
+import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button/Button';
+import LogoHeader from '@components/LogoHeader';
+import { echoApiService, type EchoResponse } from '@services/api/echo';
+import {
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
+
+type EchoInboxNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'EchoInboxScreen'
+>;
+
+// ── Lock icon ─────────────────────────────────────────────────────────────────
+const LockIcon: React.FC = () => (
+  <Svg width={scale(22)} height={scale(22)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+      fill={palette.navy.light}
+    />
+  </Svg>
+);
+
+// ── Back arrow icon ───────────────────────────────────────────────────────────
+const BackIcon: React.FC = () => (
+  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+      fill={palette.gold.DEFAULT}
+    />
+  </Svg>
+);
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+export function EchoInboxContent() {
+  const navigation = useNavigation<EchoInboxNavigationProp>();
+  const [echoes, setEchoes] = useState<EchoResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'SENDER' | 'CATEGORY'>('SENDER');
+
+  const fetchInboxEchoes = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await echoApiService.getInboxEchoes();
+      if (response.success && response.data) {
+        setEchoes(response.data);
+      } else {
+        setError(response.error || 'Failed to load inbox');
+      }
+    } catch (err: any) {
+      setError(`Failed to load inbox: ${err.message || ''}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchInboxEchoes(); }, [fetchInboxEchoes]);
+
+  const handleOpenItem = (item: EchoResponse) => {
+    if (item.echo_type === 'AUDIO') {
+      navigation.navigate('EchoAudioPlaybackScreen', { echoId: item.echo_id, title: item.title });
+    } else if (item.echo_type === 'VIDEO') {
+      navigation.navigate('EchoVideoPlaybackScreen', { echoId: item.echo_id, title: item.title });
+    } else {
+      navigation.navigate('EchoDetailScreen', { echoId: item.echo_id, title: item.title });
+    }
+  };
+
+  const formatDate = (dateString: string) =>
+    new Date(dateString).toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+  const getRightLabel = (item: EchoResponse) => {
+    if (activeTab === 'SENDER') {
+      return item.sender?.name?.toUpperCase() ?? 'UNKNOWN';
+    }
+    return item.category?.toUpperCase() ?? 'UNCATEGORIZED';
+  };
+
+  return (
+    <BackgroundWrapper style={styles.bg} scrollable>
+      <SafeAreaView style={styles.safe}>
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+
+        {/* Figma: LogoHeader (hamburger / MC logo / home) at top of outer column */}
+        <LogoHeader navigation={navigation} />
+
+        {/* Figma 1436:1831 — content column: gap:24 */}
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Header section ───────────────────────────────────────────── */}
+          {/* Figma 1439:1929 — flex-col gap:16 */}
+          <View style={styles.headerSection}>
+            {/*
+              Figma 1439:1930 — justify-between, items-center
+              Back arrow (left) | ECHO INBOX (center) | spacer (right)
+            */}
+            <View style={styles.titleRow}>
+              <TouchableOpacity
+                onPress={() => navigation.goBack()}
+                style={styles.backBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Go back"
+              >
+                <BackIcon />
+              </TouchableOpacity>
+
+              {/* Heading M: Cormorant Regular 28/32, #f2e1b0, glow shadow */}
+              <Text style={styles.title}>ECHO INBOX</Text>
+
+              {/* Equal-width spacer keeps title perfectly centered */}
+              <View style={styles.titleSpacer} />
+            </View>
+
+            {/* Body S Regular: Inter Regular 16/24, white, centered */}
+            <Text style={styles.subtitle}>
+              Echoes entrusted to you are waiting for their moment, some beyond the present.
+            </Text>
+          </View>
+
+          {/* ── List card ────────────────────────────────────────────────── */}
+          {/*
+            Figma 1436:1848 — gradient 0.01→0, border 0.25px #60739f (border-inverse-1),
+            radius 16, padding 16, overflow hidden
+          */}
+          <View style={[styles.card, echoes.length > 0 && styles.cardFlex]}>
+            <LinearGradient
+              colors={['rgba(253,253,249,0.01)', 'rgba(253,253,249,0)']}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 0, y: 1 }}
+              style={StyleSheet.absoluteFill}
+              pointerEvents="none"
+            />
+
+            {/* Tabs — Figma 1436:1849, gap:32 */}
+            <View style={styles.tabs}>
+              {(['SENDER', 'CATEGORY'] as const).map(tab => (
+                <TouchableOpacity
+                  key={tab}
+                  onPress={() => setActiveTab(tab)}
+                  activeOpacity={0.7}
+                  style={[styles.tab, activeTab === tab && styles.tabActive]}
+                >
+                  {/*
+                    Active: #fdfdf9 with border-bottom #a3b3cc
+                    Inactive: #a3b3cc (text-inverse-paragraph-2)
+                    Font: Cormorant Regular 24px (Heading S: font-size/XL)
+                  */}
+                  <Text style={[
+                    styles.tabText,
+                    activeTab === tab ? styles.tabTextActive : styles.tabTextInactive,
+                  ]}>
+                    {tab}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {/* List content */}
+            {loading ? (
+              <View style={styles.stateBox}>
+                <ActivityIndicator size="large" color={palette.gold.DEFAULT} />
+              </View>
+            ) : error ? (
+              <View style={styles.stateBox}>
+                <Text style={styles.errorText}>{error}</Text>
+                <TouchableOpacity onPress={fetchInboxEchoes} style={styles.retryBtn}>
+                  <Text style={styles.retryText}>Retry</Text>
+                </TouchableOpacity>
+              </View>
+            ) : echoes.length === 0 ? (
+              <View style={styles.stateBox}>
+                <Text style={styles.emptyText}>No echoes received yet</Text>
+                <Text style={styles.emptySubtext}>
+                  Echoes sent to you will appear here
+                </Text>
+              </View>
+            ) : (
+              echoes.map((item, index) => {
+                const isLast = index === echoes.length - 1;
+                const isLocked = !!item.scheduled_at;
+                return (
+                  <TouchableOpacity
+                    key={item.echo_id}
+                    activeOpacity={0.9}
+                    onPress={() => handleOpenItem(item)}
+                    style={[styles.row, !isLast && styles.rowBorder]}
+                  >
+                    {/* Left: title + date */}
+                    <View style={styles.rowLeft}>
+                      <View style={styles.rowText}>
+                        {/* Heading XS: Cormorant Regular 20/24, white */}
+                        <Text style={styles.rowTitle} numberOfLines={1}>
+                          {item.title}
+                        </Text>
+                        {/* Inter Light Italic 14/1.5, white */}
+                        <Text style={styles.rowSub} numberOfLines={1}>
+                          {isLocked
+                            ? `Unlocks ${formatDate(item.scheduled_at!)}`
+                            : `Saved ${formatDate(item.created_at)}`}
+                        </Text>
+                      </View>
+                    </View>
+
+                    {/* Right: label + lock */}
+                    <View style={styles.rowRight}>
+                      {/* Inter Light 16/24, #f2e1b0 */}
+                      <Text style={styles.rowLabel}>{getRightLabel(item)}</Text>
+                      {isLocked && <LockIcon />}
+                    </View>
+                  </TouchableOpacity>
+                );
+              })
+            )}
+          </View>
+
+          {/* ── CREATE ECHO button ────────────────────────────────────────── */}
+          {/* Figma 1441:1955 — same primary button as library screen */}
+          <Button
+            variant="primary"
+            size="L"
+            title="CREATE ECHO"
+            onPress={() => navigation.navigate('NewEchoScreen')}
+            style={styles.btn}
+          />
+        </ScrollView>
+      </SafeAreaView>
+    </BackgroundWrapper>
+  );
+}
+
+export default function EchoInboxScreen() {
+  return <EchoInboxContent />;
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create<{
+  bg: ViewStyle;
+  safe: ViewStyle;
+  scroll: ViewStyle;
+  scrollContent: ViewStyle;
+  headerSection: ViewStyle;
+  titleRow: ViewStyle;
+  backBtn: ViewStyle;
+  title: TextStyle;
+  titleSpacer: ViewStyle;
+  subtitle: TextStyle;
+  card: ViewStyle;
+  cardFlex: ViewStyle;
+  tabs: ViewStyle;
+  tab: ViewStyle;
+  tabActive: ViewStyle;
+  tabText: TextStyle;
+  tabTextActive: TextStyle;
+  tabTextInactive: TextStyle;
+  row: ViewStyle;
+  rowBorder: ViewStyle;
+  rowLeft: ViewStyle;
+  rowText: ViewStyle;
+  rowTitle: TextStyle;
+  rowSub: TextStyle;
+  rowRight: ViewStyle;
+  rowLabel: TextStyle;
+  btn: ViewStyle;
+  stateBox: ViewStyle;
+  errorText: TextStyle;
+  retryBtn: ViewStyle;
+  retryText: TextStyle;
+  emptyText: TextStyle;
+  emptySubtext: TextStyle;
+}>({
+  bg:   { flex: 1, backgroundColor: palette.navy.deep },
+  safe: { flex: 1, backgroundColor: palette.neutral.transparent },
+
+  scroll: { flex: 1 },
+  // Figma: left:24, outer gap:40 from header → content, inner gap:24 between sections
+  scrollContent: {
+    paddingHorizontal: scale(spacing.xl),         // 24px
+    paddingTop:        verticalScale(30),          // outer column gap
+    paddingBottom:     verticalScale(spacing.xxxl),
+    gap:               verticalScale(spacing.xl),  // 24px inner gap
+    flexGrow:          1,
+  },
+
+  // ── Header section ──────────────────────────────────────────────────────────
+  // Figma 1439:1929 — flex-col gap:16
+  headerSection: {
+    gap:        verticalScale(spacing.m),          // 16px
+    alignItems: 'center',
+  },
+
+  // Figma 1439:1930 — justify-between, items-center, w-full
+  titleRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
+    justifyContent: 'space-between',
+    width:          '100%',
+  },
+
+  backBtn: {
+    width:          scale(44),
+    height:         scale(44),
+    alignItems:     'flex-start',
+    justifyContent: 'center',
+  },
+
+  // Heading M: Cormorant Regular 28/32, #f2e1b0, glow shadow
+  title: {
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize['2xl']),  // 28px
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(32),
+    color:            palette.gold.DEFAULT,
+    textAlign:        'center',
+    textShadowColor:  'rgba(240,212,168,0.3)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 10,
+  },
+
+  // Mirrors backBtn width so title stays perfectly centered
+  titleSpacer: {
+    width: scale(44),
+  },
+
+  // Body S Regular: Inter Regular 16/24, white, centered
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize:   moderateScale(fontSize.s),
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(24),
+    color:      palette.neutral.white,
+    textAlign:  'center',
+    width:      '100%',
+  },
+
+  // ── Card ────────────────────────────────────────────────────────────────────
+  // Figma 1436:1848 — gradient bg, border 0.25px #60739f (border-inverse-1),
+  // radius 16, padding 16, overflow hidden
+  card: {
+    width:        '100%',
+    borderRadius: radius.m,
+    borderWidth:  borderWidth.hairline,              // 0.25px
+    borderColor:  palette.navy.medium,               // #60739f (border-inverse-1)
+    padding:      scale(spacing.m),                  // 16px
+    overflow:     'hidden',
+  },
+  cardFlex: {
+    flex:      1,
+    minHeight: scale(200),
+  },
+
+  // Tabs — Figma 1436:1849, gap:32, justify-center
+  tabs: {
+    flexDirection:  'row',
+    justifyContent: 'center',
+    alignItems:     'center',
+    gap:            scale(32),
+    marginBottom:   verticalScale(spacing.s),
+  },
+  tab: { paddingVertical: 2 },
+  tabActive: {
+    borderBottomWidth: 1,
+    borderBottomColor: palette.navy.light,           // Border/Subtle #a3b3cc
+  },
+
+  // Cormorant Regular 24px (Heading S — font-size/XL)
+  tabText: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize.xl),          // 24px
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(28),
+    textAlign:  'center',
+  },
+  tabTextActive:   { color: palette.gold.subtlest },  // #fdfdf9
+  tabTextInactive: { color: palette.navy.light },     // #a3b3cc
+
+  // ── Rows ────────────────────────────────────────────────────────────────────
+  // Figma: padding-y 16, border-bottom 0.25px #a3b3cc between rows
+  row: {
+    flexDirection:   'row',
+    alignItems:      'center',
+    justifyContent:  'space-between',
+    paddingVertical: verticalScale(spacing.m),       // 16px
+  },
+  rowBorder: {
+    borderBottomWidth: borderWidth.hairline,
+    borderBottomColor: palette.navy.light,
+  },
+
+  rowLeft: {
+    flex:      1,
+    maxWidth:  scale(240),
+  },
+  rowText: { flex: 1 },
+
+  // Heading XS: Cormorant Regular 20/24, white
+  rowTitle: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize.l),           // 20px
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(24),
+    color:      palette.neutral.white,
+  },
+
+  // Inter Light Italic 14/1.5, white
+  rowSub: {
+    fontFamily: fontFamily.bodyItalic,
+    fontStyle:  'italic',
+    fontSize:   moderateScale(fontSize.xs),          // 14px
+    fontWeight: '300',
+    lineHeight: moderateScale(fontSize.xs * 1.5),
+    color:      palette.neutral.white,
+    opacity:    0.85,
+  },
+
+  rowRight: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           scale(8),
+    maxWidth:      scale(80),
+  },
+
+  // Inter Light 16/24, #f2e1b0
+  rowLabel: {
+    fontFamily: fontFamily.bodyLight,
+    fontSize:   moderateScale(fontSize.s),           // 16px
+    fontWeight: '300',
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
+    textAlign:  'center',
+  },
+
+  // ── Button ──────────────────────────────────────────────────────────────────
+  btn: { alignSelf: 'center', width: scale(271) },
+
+  // ── State views ─────────────────────────────────────────────────────────────
+  stateBox: {
+    alignItems:      'center',
+    justifyContent:  'center',
+    paddingVertical: verticalScale(40),
+  },
+  errorText: {
+    color:        palette.status.errorHover,
+    fontSize:     moderateScale(14),
+    textAlign:    'center',
+    marginBottom: 12,
+  },
+  retryBtn: {
+    paddingHorizontal: scale(20),
+    paddingVertical:   verticalScale(8),
+    borderRadius:      radius.s,
+    borderWidth:       1,
+    borderColor:       palette.gold.DEFAULT,
+  },
+  retryText: { color: palette.gold.DEFAULT, fontSize: moderateScale(14) },
+  emptyText: {
+    color:        palette.gold.subtlest,
+    fontSize:     moderateScale(16),
+    textAlign:    'center',
+    marginBottom: verticalScale(8),
+  },
+  emptySubtext: {
+    color:     palette.gold.subtlest,
+    fontSize:  moderateScale(14),
+    textAlign: 'center',
+    opacity:   0.7,
+  },
+});

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultHomeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultHomeScreen.tsx
@@ -1,19 +1,35 @@
+/**
+ * Echo Vault Home Screen
+ * Figma: Design-Master-File → Echo Vault Home (767:2513)
+ *
+ * Layout (top → bottom):
+ *   LogoHeader (hamburger / logo / home)
+ *   Title row: [spacer] | ECHO VAULT | ⓘ
+ *   Hero image (mirror_echo_map.png, 1:1 aspect, full-width minus 20px padding)
+ *   Copy text (Body S Inter, 4 lines, #fdfdf9, center)
+ *   CTA stack: [START ECHO] / [VIEW VAULT]
+ *
+ * Tokens used (from Figma variable defs):
+ *   Heading/Heading M: Cormorant Regular 28/32 — title
+ *   Body S: Inter Regular 16/24 — copy
+ *   Text/Paragraph-1 (#f2e1b0) — title
+ *   Text/Paragraph-2 (#fdfdf9) — copy
+ *   Spacing/L (20), Spacing/M (16), Spacing/S (12), Radius/M (16)
+ */
+
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
-  palette,
+  borderWidth,
   fontFamily,
   fontSize,
   fontWeight,
   lineHeight,
-  radius,
-  borderWidth,
-  textShadow,
-  glassGradient,
-  spacing,
-  scale,
-  verticalScale,
   moderateScale,
+  palette,
+  scale,
+  spacing,
+  verticalScale,
 } from '@theme';
 import type { RootStackParamList } from '@types';
 import React from 'react';
@@ -26,11 +42,13 @@ import {
   Text,
   TouchableOpacity,
   View,
+  type ImageStyle,
   type TextStyle,
   type ViewStyle,
 } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import Svg, { Path, Circle } from 'react-native-svg';
+import Svg, { Circle, Path } from 'react-native-svg';
 
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button/Button';
@@ -42,7 +60,7 @@ type MirrorEchoNavigationProp = NativeStackNavigationProp<
   'MirrorEchoVaultHome'
 >;
 
-// ── Info icon (Material outlined) ───────────────────────────────────────────
+// ── Info icon ────────────────────────────────────────────────────────────────
 const InfoIcon: React.FC<{ size?: number }> = ({ size = 24 }) => (
   <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
     <Circle cx="12" cy="12" r="9.5" stroke={palette.gold.DEFAULT} strokeWidth={1} />
@@ -53,28 +71,10 @@ const InfoIcon: React.FC<{ size?: number }> = ({ size = 24 }) => (
   </Svg>
 );
 
-// ── Button width: Figma 176px at 393px reference ────────────────────────────
+// Button width — Figma 176px at 393px reference
 const BTN_WIDTH = scale(176);
 
-// ── Shared button prop overrides (applied to both CTA buttons) ──────────────
-// Figma: radius.m (16px), borderWidth.thin (0.5px), py-12, px-16, text 24px
-const BTN_CONTAINER_STYLE: ViewStyle = {
-  borderRadius: radius.m,
-  borderWidth: borderWidth.thin,
-};
-const BTN_CONTENT_STYLE: ViewStyle = {
-  paddingVertical: verticalScale(spacing.s),   // 12px
-  paddingHorizontal: scale(spacing.m),         // 16px
-  minWidth: 0,
-};
-const BTN_TEXT_STYLE: TextStyle = {
-  fontFamily: fontFamily.heading,              // CormorantGaramond-Regular
-  fontSize: moderateScale(fontSize.xl),        // 24px
-  lineHeight: moderateScale(fontSize['2xl']),  // 28px (font/size/2xl)
-  color: palette.gold.DEFAULT,
-};
-
-// ── Screen ──────────────────────────────────────────────────────────────────
+// ── Screen ───────────────────────────────────────────────────────────────────
 export function MirrorEchoContent() {
   const navigation = useNavigation<MirrorEchoNavigationProp>();
   const [showInfo, setShowInfo] = React.useState(false);
@@ -86,127 +86,95 @@ export function MirrorEchoContent() {
 
         <LogoHeader navigation={navigation} />
 
-        {/*
-          NO flexGrow:1 on scrollContent — that prevents scrolling by always
-          expanding to fill the viewport. Content has natural height and will
-          scroll when it overflows on small devices (iPhone SE etc.)
-        */}
         <ScrollView
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          {/*
-            Figma node 767:2844 — flex-col gap-[20px] items-center
-            width:'100%' is required so nested children with width:'100%'
-            resolve against scroll content width, not an undefined parent.
-          */}
+          {/* Figma 767:2844 — flex-col gap:20 items-center */}
           <View style={styles.content}>
 
-            {/* ── Title row: spacer | MIRROR ECHO | info ───────────────── */}
-            {/* Figma node 767:2863: justify-between, items-center, w-full */}
+            {/* ── Title row ────────────────────────────────────────────── */}
+            {/* Figma 767:2863 — justify-between, items-center, w-full */}
             <View style={styles.titleRow}>
-              {/* Equal-size spacer keeps title visually centred */}
               <View style={styles.iconPlaceholder} />
 
               {/*
-                Figma node 767:2865:
-                Cormorant Regular 28px, lineHeight 32px, gold.DEFAULT,
-                textShadow: 0 0 20px #e5d6b0
+                Figma 767:2865 — Heading/Heading M: Cormorant Regular 28/32
+                Colour Text/Paragraph-1 (#f2e1b0), textShadow gold warm
               */}
-              <Text style={styles.title}>MIRROR ECHO</Text>
+              <Text style={styles.title}>ECHO VAULT</Text>
 
-              {/* Figma node 1232:1108 — info button, 24px */}
               <TouchableOpacity
                 onPress={() => setShowInfo(true)}
                 activeOpacity={0.75}
                 style={styles.infoHit}
                 accessibilityRole="button"
-                accessibilityLabel="About Mirror Echo"
+                accessibilityLabel="About Echo Vault"
               >
                 <InfoIcon size={scale(24)} />
               </TouchableOpacity>
             </View>
 
-            {/* ── Echo map image ────────────────────────────────────────── */}
+            {/* ── Hero image ───────────────────────────────────────────── */}
             {/*
-              Figma node 767:2846: px-[20px] (spacing.l), w-full
-              Figma node 767:2847: aspect-[328/328] (1:1), w-full
-              Image overflows slightly (left -12.91%, size 125.81%) to show
-              the face — cropped by overflow:hidden on imageSquare.
-              Edge blending: 4 LinearGradient overlays fade the hard image
-              boundary into the background colour (navy.deep).
+              Figma 767:2846 — px:20 (Spacing/L), w-full
+              Figma 767:2847 — aspect-[1:1] (328×328), w-full, overflow hidden
+              Image source is the mirror echo map (face + constellation).
             */}
-            <View >
-              <View >
+            <View style={styles.imageWrapper}>
+              <View style={styles.imageSquare}>
                 <Image
                   testID="mirror-echo-image"
-                  source={require('../../assets/mirror_echo_map.png')}
-                  
+                  source={require('@assets/mirror_echo_map.png')}
+                  style={styles.heroImage}
                   resizeMode="cover"
                   accessibilityIgnoresInvertColors
                 />
               </View>
             </View>
 
-            {/* ── Copy text ─────────────────────────────────────────────── */}
+            {/* ── Copy text ────────────────────────────────────────────── */}
             {/*
-              Figma node 767:2848:
-              Inter Regular 16px, lineHeight 24px, gold.subtlest (#fdfdf9)
-              Two paragraphs, centre-aligned, maxWidth 335px
+              Figma 767:2848 — Body S: Inter Regular 16/24
+              Colour Text/Paragraph-2 (#fdfdf9), center, maxWidth 335px
             */}
             <View style={styles.copyWrap}>
               <Text style={styles.copyText}>
-                {'Become the architect of your own story.\nSave what you\u2019ve learned, loved, and lived \u2014 in a private vault that\u2019s yours.'}
+                {'Your space.\nYour memories.\nYour story.\nSave it for yourself or someone you love.'}
               </Text>
             </View>
 
-            {/* ── CTA buttons ───────────────────────────────────────────── */}
+            {/* ── CTA buttons ──────────────────────────────────────────── */}
             {/*
-              Figma node 767:2849: flex-col gap-[12px] items-center w-[176px]
-
-              Using <Button variant="gradient"> from @components/Button.
-              Override: borderRadius → radius.m (16px), borderWidth → 0.5px,
-              padding → py-12 / px-16, text → Cormorant 24px gold.
+              Figma 767:2849 — flex-col gap:12 items-center, w:176px
+              START ECHO uses Translucent White Gradient (more opaque)
+              VIEW VAULT uses Transparent White Gradient (more transparent)
+              Both use Radius/M (16), border 0.5px, Cormorant 24px gold.
             */}
             <View style={styles.ctaWrap}>
-              {/* START ECHO — gradient from rgba(253,253,249,0.03) to rgba(253,253,249,0.2) */}
+              {/* VIEW VAULT — primary (prominent CTA) */}
+              {/* START ECHO — secondary (supporting action) */}
               <Button
-                variant="gradient"
+                variant="secondary"
+                size="L"
                 title="START ECHO"
                 onPress={() => navigation.navigate('NewEchoScreen')}
-                gradientColors={[glassGradient.echoPrimary.start, glassGradient.echoPrimary.end]}
-                style={{ width: BTN_WIDTH, borderRadius: radius.m }}
-                containerStyle={BTN_CONTAINER_STYLE}
-                contentStyle={BTN_CONTENT_STYLE}
-                textStyle={BTN_TEXT_STYLE}
+                style={{ width: BTN_WIDTH }}
               />
-
-              {/*
-                VIEW VAULT — gradient from rgba(253,253,249,0.01) to rgba(253,253,249,0)
-                Text adds warm glow: 0 0 9px rgba(229,214,176,0.5) (Figma spec)
-              */}
               <Button
-                variant="gradient"
+                variant="primary"
+                size="L"
                 title="VIEW VAULT"
                 onPress={() => navigation.navigate('MirrorEchoVaultLibrary')}
-                gradientColors={[glassGradient.echoSecondary.start, glassGradient.echoSecondary.end]}
-                style={{ width: BTN_WIDTH, borderRadius: radius.m }}
-                containerStyle={BTN_CONTAINER_STYLE}
-                contentStyle={BTN_CONTENT_STYLE}
-                textStyle={{
-                  ...BTN_TEXT_STYLE,
-                  textShadowColor: textShadow.warmGlow.color,
-                  textShadowOffset: textShadow.warmGlow.offset,
-                  textShadowRadius: textShadow.warmGlow.radius,
-                }}
+                style={{ width: BTN_WIDTH }}
               />
             </View>
 
           </View>
         </ScrollView>
 
-        {/* ── Info Modal ─────────────────────────────────────────────────── */}
+        {/* ── Info Modal ───────────────────────────────────────────────── */}
         <Modal
           visible={showInfo}
           transparent
@@ -215,38 +183,50 @@ export function MirrorEchoContent() {
           statusBarTranslucent
         >
           <View style={styles.modalOverlay}>
-            <View style={styles.infoCard}>
-              {/* Close button container */}
-              <View style={styles.closeContainer}>
-                <TouchableOpacity
-                  onPress={() => setShowInfo(false)}
-                  style={styles.closeButton}
-                  accessibilityRole="button"
-                  accessibilityLabel="Close"
-                >
-                  <Svg width={20} height={20} viewBox="0 0 20 20">
-                    <Path
-                      d="M15.8334 5.34175L14.6584 4.16675L10.0001 8.82508L5.34175 4.16675L4.16675 5.34175L8.82508 10.0001L4.16675 14.6584L5.34175 15.8334L10.0001 11.1751L14.6584 15.8334L15.8334 14.6584L11.1751 10.0001L15.8334 5.34175Z"
-                      fill={palette.gold.DEFAULT}
-                    />
-                  </Svg>
-                </TouchableOpacity>
+            {/*
+              Outer wrapper owns the glow shadow (no overflow:hidden so the
+              warm gold halo can bleed outward into the dark scrim).
+              Inner card clips the gradient to the 13px radius.
+              Figma 347:1239: shadow 0 0 15px rgba(229,214,176,0.3)
+            */}
+            <View style={styles.infoCardGlow}>
+              <View style={styles.infoCard}>
+                <LinearGradient
+                  colors={['rgba(253,253,249,0.01)', 'rgba(253,253,249,0)']}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 0, y: 1 }}
+                  style={StyleSheet.absoluteFill}
+                  pointerEvents="none"
+                />
+
+                <View style={styles.closeContainer}>
+                  <TouchableOpacity
+                    onPress={() => setShowInfo(false)}
+                    style={styles.closeButton}
+                    accessibilityRole="button"
+                    accessibilityLabel="Close"
+                  >
+                    <Svg width={20} height={20} viewBox="0 0 20 20">
+                      <Path
+                        d="M15.8334 5.34175L14.6584 4.16675L10.0001 8.82508L5.34175 4.16675L4.16675 5.34175L8.82508 10.0001L4.16675 14.6584L5.34175 15.8334L10.0001 11.1751L14.6584 15.8334L15.8334 14.6584L11.1751 10.0001L15.8334 5.34175Z"
+                        fill={palette.gold.DEFAULT}
+                      />
+                    </Svg>
+                  </TouchableOpacity>
+                </View>
+
+                <Text style={styles.infoTitle}>WELCOME TO{'\n'}ECHO VAULT</Text>
+                <Text style={styles.infoSubtitle}>
+                  A quiet space to keep what matters most.
+                </Text>
+                <StarIcon width={scale(20)} height={scale(20)} />
+                <Text style={styles.infoBody}>
+                  Store your reflections, memories, and messages—kept safe and accessible when they matter most, relayed at a time for moments that matter the most.
+                </Text>
+                <Text style={styles.infoQuote}>
+                  "These are the patterns shaping your becoming."
+                </Text>
               </View>
-
-              <Text style={styles.infoTitle}>WELCOME TO MIRROR ECHO</Text>
-
-              <Text style={styles.infoSubtitle}>A space to see yourself clearly</Text>
-
-              {/* Decorative star icon */}
-              <StarIcon width={28} height={28} />
-
-              <Text style={styles.infoBody}>
-                Each day, you'll receive your Echo Signature—a gentle snapshot of the emotional patterns, metaphors, and themes moving through you now.
-              </Text>
-
-              <Text style={styles.infoQuote}>
-                "These are the patterns shaping your becoming."
-              </Text>
             </View>
           </View>
         </Modal>
@@ -259,7 +239,7 @@ export default function MirrorEchoScreen() {
   return <MirrorEchoContent />;
 }
 
-// ── Styles ───────────────────────────────────────────────────────────────────
+// ── Styles ────────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create<{
   bg: ViewStyle;
@@ -271,11 +251,15 @@ const styles = StyleSheet.create<{
   iconPlaceholder: ViewStyle;
   title: TextStyle;
   infoHit: ViewStyle;
+  imageWrapper: ViewStyle;
+  imageSquare: ViewStyle;
+  heroImage: ImageStyle;
   copyWrap: ViewStyle;
   copyText: TextStyle;
   ctaWrap: ViewStyle;
   // Modal
   modalOverlay: ViewStyle;
+  infoCardGlow: ViewStyle;
   infoCard: ViewStyle;
   closeContainer: ViewStyle;
   closeButton: ViewStyle;
@@ -285,165 +269,197 @@ const styles = StyleSheet.create<{
   infoQuote: TextStyle;
 }>({
   bg: {
-    flex: 1,
+    flex:            1,
     backgroundColor: palette.navy.deep,
   },
   safe: {
-    flex: 1,
+    flex:            1,
     backgroundColor: palette.neutral.transparent,
   },
 
-  // ── Scroll ─────────────────────────────────────────────────────────────────
-  scroll: {
-    flex: 1,
-  },
-  // No flexGrow:1 — prevents scroll by always filling viewport
+  scroll: { flex: 1 },
+  // No flexGrow:1 — prevents scroll by always filling viewport on small devices
   scrollContent: {
-    paddingHorizontal: scale(spacing.xl),         // 24px — Figma 6.11%
-    paddingTop: verticalScale(spacing.xl),
-    paddingBottom: verticalScale(spacing.xxxl),
+    paddingHorizontal: scale(spacing.xl),
+    paddingTop:        verticalScale(spacing.xl),
+    paddingBottom:     verticalScale(spacing.xxxl),
   },
 
-  // ── Outer column ───────────────────────────────────────────────────────────
-  // width:'100%' is critical — without it, children's width:'100%' resolves
-  // against undefined and may collapse or overflow unpredictably.
+  // Figma 767:2844 — flex-col gap:20 items-center, w-full
   content: {
-    width: '100%',
+    width:      '100%',
     alignItems: 'center',
-    gap: verticalScale(spacing.l),                // 20px = spacing.l
+    gap:        verticalScale(spacing.l),          // 20px (Spacing/L)
   },
 
-  // ── Title row ──────────────────────────────────────────────────────────────
+  // Figma 767:2863 — justify-between items-center w-full
   titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'space-between',
-    width: '100%',
+    width:          '100%',
   },
-
   iconPlaceholder: {
-    width: scale(44),   // matches infoHit hit-area width
+    width:  scale(44),
     height: scale(24),
   },
 
-  // Figma: Cormorant Regular 28px, lineHeight 32px, gold, glow 0 0 20px #e5d6b0
+  // Heading/Heading M — Cormorant Regular 28/32, Text/Paragraph-1 (#f2e1b0)
   title: {
-    flex: 1,
+    flex:       1,
     fontFamily: fontFamily.heading,
-    fontSize: moderateScale(fontSize['2xl']),      // 28px
+    fontSize:   moderateScale(fontSize['2xl']),   // 28px
     fontWeight: fontWeight.regular,
-    lineHeight: lineHeight.xl,                     // 32px
-    color: palette.gold.DEFAULT,
-    textAlign: 'center',
-    textShadowColor: palette.gold.warm,
+    lineHeight: lineHeight.xl,                    // 32px
+    color:      palette.gold.DEFAULT,
+    textAlign:  'center',
+    textShadowColor:  palette.gold.warm,
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 8,
   },
 
-  // 44pt minimum touch target
   infoHit: {
-    width: scale(44),
-    height: scale(44),
-    alignItems: 'flex-end',
-    justifyContent: 'center',
+    width:           scale(44),
+    height:          scale(44),
+    alignItems:      'flex-end',
+    justifyContent:  'center',
   },
 
-  // ── Copy text ──────────────────────────────────────────────────────────────
-  // Figma: Inter Regular 16px, lineHeight 24px, gold.subtlest (#fdfdf9), center
+  // Figma 767:2846 — Spacing/L (20px) horizontal padding, w-full
+  imageWrapper: {
+    paddingHorizontal: scale(spacing.l),          // 20px
+    width:             '100%',
+  },
+
+  // Figma 767:2847 — aspect 1:1 (328×328 in Figma), overflow hidden
+  imageSquare: {
+    width:       '100%',
+    aspectRatio: 1,
+    overflow:    'hidden',
+  },
+
+  heroImage: {
+    width:    '100%',
+    height:   '100%',
+  },
+
+  // Body S — Inter Regular 16/24, Text/Paragraph-2 (#fdfdf9), center, maxWidth 335
   copyWrap: {
-    width: '100%',
+    width:      '100%',
     alignItems: 'center',
   },
   copyText: {
     fontFamily: fontFamily.body,
-    fontSize: moderateScale(fontSize.s),           // 16px
+    fontSize:   moderateScale(fontSize.s),        // 16px
     fontWeight: fontWeight.regular,
-    lineHeight: lineHeight.m,                      // 24px
-    color: palette.gold.subtlest,
-    textAlign: 'center',
-    maxWidth: scale(335),
+    lineHeight: lineHeight.m,                     // 24px
+    color:      palette.gold.subtlest,            // #fdfdf9
+    textAlign:  'center',
+    maxWidth:   scale(335),
   },
 
-  // ── CTA ────────────────────────────────────────────────────────────────────
-  // Figma: flex-col gap-[12px] items-center
+  // Figma 767:2849 — flex-col gap:12 items-center
   ctaWrap: {
     alignItems: 'center',
-    gap: verticalScale(spacing.s),                // 12px
+    gap:        verticalScale(spacing.s),         // 12px (Spacing/S)
   },
 
-  // ── Info Modal ─────────────────────────────────────────────────────────────
+  // ── Info Modal ────────────────────────────────────────────────────────────
+  // Figma 347:1239 — Echo Vault Information Overlay
   modalOverlay: {
-    flex: 1,
+    flex:            1,
     backgroundColor: 'rgba(11,15,28,0.92)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: scale(spacing.xl),
+    justifyContent:  'center',
+    alignItems:      'center',
+    padding:         scale(spacing.xl),
   },
-  infoCard: {
-    width: '100%',
-    maxWidth: scale(329),
-    backgroundColor: 'rgba(253,253,249,0.01)',
-    borderRadius: scale(13),
-    borderWidth: borderWidth.hairline,
-    borderColor: 'rgba(163,179,204,1)',
-    padding: scale(spacing.xl),         // 24px all sides
-    gap: verticalScale(spacing.m),      // 16px between items
-    alignItems: 'center',
-    shadowColor: palette.gold.warm,
-    shadowOffset: { width: 0, height: 0 },
+
+  // Outer wrapper — owns the warm gold glow. No overflow:hidden so the
+  // halo bleeds outward into the dark scrim.
+  // Figma: box-shadow 0 0 15px 0 rgba(229,214,176,0.3)
+  infoCardGlow: {
+    width:         '100%',
+    maxWidth:      scale(329),
+    borderRadius:  scale(13),
+    boxShadow:     '0px 0px 15px 0px rgba(229,214,176,0.3)',
+    shadowColor:   palette.gold.warm,
+    shadowOffset:  { width: 0, height: 0 },
     shadowOpacity: 0.3,
-    shadowRadius: 15,
-    elevation: 15,
+    shadowRadius:  15,
+    elevation:     15,
   },
+
+  // Inner card — clips LinearGradient to 13px corners.
+  // Figma: bg Transparent White Gradient (0.01→0), border 0.25px #a3b3cc
+  //        padding 24px (Spacing/XL), gap 16px between items
+  infoCard: {
+    width:        '100%',
+    borderRadius: scale(13),
+    borderWidth:  borderWidth.hairline,             // 0.25px
+    borderColor:  palette.navy.light,               // #a3b3cc
+    padding:      scale(spacing.xl),                // 24px
+    gap:          16,                               // Figma: fixed 16px gap
+    alignItems:   'center',
+    overflow:     'hidden',
+  },
+
   closeContainer: {
-    width: '100%',
+    width:      '100%',
     alignItems: 'flex-end',
   },
   closeButton: {
-    width: scale(20),
-    height: scale(20),
+    width:          scale(20),
+    height:         scale(20),
     justifyContent: 'center',
-    alignItems: 'center',
+    alignItems:     'center',
   },
+
+  // Figma 347:1240 — Cormorant Regular 24/28, #f2e1b0, text-shadow 0 0 10 #e5d6b0
   infoTitle: {
-    fontFamily: fontFamily.heading,
-    fontSize: moderateScale(fontSize.xl),
-    fontWeight: fontWeight.regular,
-    lineHeight: moderateScale(28),
-    color: palette.gold.DEFAULT,
-    textAlign: 'center',
-    letterSpacing: 0,
-    textShadowColor: palette.gold.warm,
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize.xl),    // 24px
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(28),             // 28px (font/size/2XL)
+    color:            palette.gold.DEFAULT,           // #f2e1b0
+    textAlign:        'center',
+    letterSpacing:    0,
+    textShadowColor:  palette.gold.warm,             // #e5d6b0
     textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 8,
+    textShadowRadius: 10,                            // Figma: 10px
   },
+
+  // Figma 347:1241 — Cormorant Italic 24px, lh 1.3, white
   infoSubtitle: {
-    fontFamily: fontFamily.headingItalic,
-    fontSize: moderateScale(fontSize.xl),
-    fontWeight: fontWeight.regular,
-    fontStyle: 'italic',
-    lineHeight: moderateScale(31.2),
-    color: palette.neutral.white,
-    textAlign: 'center',
+    fontFamily:    fontFamily.headingItalic,
+    fontSize:      moderateScale(fontSize.xl),
+    fontWeight:    fontWeight.regular,
+    fontStyle:     'italic',
+    lineHeight:    moderateScale(fontSize.xl * 1.3),
+    color:         palette.neutral.white,
+    textAlign:     'center',
     letterSpacing: 0,
   },
+
+  // Figma 347:1244 — Inter Regular 16/24, white
   infoBody: {
-    fontFamily: fontFamily.body,
-    fontSize: moderateScale(fontSize.s),
-    fontWeight: fontWeight.regular,
-    lineHeight: moderateScale(24),
-    color: palette.neutral.white,
-    textAlign: 'center',
+    fontFamily:    fontFamily.body,
+    fontSize:      moderateScale(fontSize.s),        // 16px
+    fontWeight:    fontWeight.regular,
+    lineHeight:    moderateScale(24),                // 24px (line-height/M)
+    color:         palette.neutral.white,
+    textAlign:     'center',
     letterSpacing: 0,
   },
+
+  // Figma 347:1245 — Inter Italic 14/20, #e5d6b0
   infoQuote: {
-    fontFamily: fontFamily.bodyItalic,
-    fontSize: moderateScale(fontSize.xs),
-    fontWeight: fontWeight.regular,
-    fontStyle: 'italic',
-    lineHeight: moderateScale(20),
-    color: palette.gold.warm,
-    textAlign: 'center',
+    fontFamily:    fontFamily.bodyItalic,
+    fontSize:      moderateScale(fontSize.xs),       // 14px
+    fontWeight:    fontWeight.regular,
+    fontStyle:     'italic',
+    lineHeight:    moderateScale(20),                // 20px (line-height/S)
+    color:         palette.gold.warm,               // #e5d6b0
+    textAlign:     'center',
     letterSpacing: 0,
   },
 });

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -1,83 +1,139 @@
+/**
+ * Echo Vault Library Screen
+ * Figma: Design-Master-File → Echo Vault Library (211:1449)
+ *
+ * Layout (top → bottom):
+ *   LogoHeader
+ *   Title "MY ECHO LIBRARY" — Heading M Cormorant 28/32
+ *   Subtitle — Body S Light Inter 16/24
+ *   Echo Inbox row — mail icon + Cormorant 28/32, border-bottom #a3b3cc
+ *   Card — gradient bg, border 0.25px #a3b3cc, radius 16, padding 16
+ *     ├ Tabs: RECIPIENT (active) | CATEGORY (inactive)
+ *     └ List rows: avatar (40×40) + title + subtitle | recipient + lock
+ *   Buttons — CREATE AN ECHO / MANAGE RECIPIENTS (271px, Button primary)
+ *
+ * Token audit (from Figma variable defs):
+ *   Heading M: Cormorant Regular 28/32         → fontFamily.heading 28/32
+ *   Heading XS Bold: Cormorant Medium 20/24    → fontFamily.heading + fontWeight '500' 20/24
+ *   Heading XS: Cormorant Regular 20/24        → fontFamily.heading 20/24
+ *   Body S Light: Inter Light 16/24            → fontFamily.bodyLight 16/24
+ *   Text/Paragraph-1 #f2e1b0                  → palette.gold.DEFAULT
+ *   Text/Paragraph-2 #fdfdf9                  → palette.gold.subtlest
+ *   Text/Inverse-Paragraph-2 #a3b3cc          → palette.navy.light
+ *   Border/Subtle #a3b3cc                      → palette.navy.light
+ *   Glow Drop Shadow: 0 0 10 spread:3 #F0D4A84D
+ *   Radius/M: 16, Spacing/M: 16, Spacing/S: 12, Spacing/XL: 24
+ */
+
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { palette, spacing, shadows, textShadow } from '@theme';
-import type { RootStackParamList } from '@types';
-import React, { useState, useEffect, useCallback } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  StatusBar,
-  TouchableOpacity,
-  ScrollView,
-  useWindowDimensions,
-  Platform,
-  Image,
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
   ActivityIndicator,
+  Image,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Path } from 'react-native-svg';
 import { SvgXml } from 'react-native-svg';
 
 import { getMotifIcon } from '@assets/motifs/MotifAssets';
 import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
-import { echoApiService, EchoResponse } from '@services/api/echo';
+import { echoApiService, type EchoResponse } from '@services/api/echo';
 
 type EchoLibraryNavigationProp = NativeStackNavigationProp<
   RootStackParamList,
   'MirrorEchoVaultLibrary'
 >;
 
-const GOLD = palette.gold.DEFAULT;
-const SUBTEXT = 'rgba(253,253,249,0.92)';
+// ── Lock icon — Figma node 1143:1360 (Vector) ───────────────────────────────
+const LockIcon: React.FC = () => (
+  <Svg width={scale(22)} height={scale(22)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+      fill={palette.navy.light}
+    />
+  </Svg>
+);
 
-// Mock data or icons if needed. Using local assets for consistency if available, otherwise icons.
-// For Mail icon, we can use an image or existing icon component.
-// Assuming we need to add specific styling.
+// ── Avatar ───────────────────────────────────────────────────────────────────
+// Figma: 40×40, border 1px #f2e1b0, glow 0 0 10 3px rgba(240,212,168,0.3)
+// Avatar image: 149.82% height, offset -6.74% top (crops to face)
+interface AvatarProps {
+  motif?: string;
+  profileImage?: string;
+}
+const EchoAvatar: React.FC<AvatarProps> = ({ motif, profileImage }) => (
+  <View style={styles.avatarGlow}>
+    <View style={styles.avatarRing}>
+      {profileImage ? (
+        <Image
+          source={{ uri: profileImage }}
+          style={styles.avatarImg}
+          resizeMode="cover"
+        />
+      ) : motif && getMotifIcon(motif) ? (
+        <SvgXml xml={getMotifIcon(motif)?.xml || ''} width="60%" height="60%" />
+      ) : (
+        <Image source={require('@assets/Group.png')} style={styles.avatarFallback} />
+      )}
+    </View>
+  </View>
+);
+
+// ── Screen ───────────────────────────────────────────────────────────────────
 
 export function EchoLibraryContent() {
   const navigation = useNavigation<EchoLibraryNavigationProp>();
-  const { width } = useWindowDimensions();
   const [echoes, setEchoes] = useState<EchoResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'LIBRARY' | 'INBOX'>('LIBRARY');
   const [activeTab, setActiveTab] = useState<'RECIPIENT' | 'CATEGORY'>('RECIPIENT');
-
 
   const fetchEchoes = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const response = viewMode === 'INBOX'
-        ? await echoApiService.getInboxEchoes()
-        : await echoApiService.getEchoes();
+      const response = await echoApiService.getEchoes();
       if (response.success && response.data) {
         setEchoes(response.data);
       } else {
-        setError(response.error || `Failed to load echoes (${JSON.stringify(response)})`);
-        console.log('Echo fetch error response:', response);
+        setError(response.error || 'Failed to load echoes');
       }
     } catch (err: any) {
-      console.error('Echo load error:', err);
-      setError(`Failed to load echoes: ${err.message || JSON.stringify(err)}`);
+      setError(`Failed to load echoes: ${err.message || ''}`);
     } finally {
       setLoading(false);
     }
-  }, [viewMode]);
+  }, []);
 
-  useEffect(() => {
-    fetchEchoes();
-  }, [fetchEchoes]);
-
-
-  const handleCreateEcho = () => {
-    navigation.navigate('NewEchoScreen');
-  };
+  useEffect(() => { fetchEchoes(); }, [fetchEchoes]);
 
   const handleOpenItem = (item: EchoResponse) => {
-
     if (item.echo_type === 'AUDIO') {
       navigation.navigate('EchoAudioPlaybackScreen', { echoId: item.echo_id, title: item.title });
     } else if (item.echo_type === 'VIDEO') {
@@ -87,220 +143,169 @@ export function EchoLibraryContent() {
     }
   };
 
-  const handleManageRecipients = () => {
-    navigation.navigate('ManageRecipientScreen');
-  };
-
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+    return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
   };
 
   return (
-    <BackgroundWrapper style={styles.background}>
-      <SafeAreaView style={styles.safeArea}>
-        <StatusBar
-          translucent
-          backgroundColor="transparent"
-          barStyle="light-content"
-        />
+    <BackgroundWrapper style={styles.bg} scrollable>
+      <SafeAreaView style={styles.safe}>
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+        <LogoHeader navigation={navigation} />
 
-        <View style={styles.contentWrapper}>
-          <LogoHeader navigation={navigation} />
-
-          <View style={styles.headerSection}>
+        {/*
+          Figma 211:1450 — outer column:
+          flex-col gap:40, h:762, left:24, top:48, w:345
+          gap between sections is 12 (1457) and 16 (title group 1441)
+        */}
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Title + Subtitle ─────────────────────────────────────── */}
+          {/*
+            Figma 211:1223/1224 — items-center, gap:16
+            Title wrapper (243:1341): justify-center so title is centered.
+            Subtitle (211:1225): text-center Inter Regular 16/24.
+          */}
+          <View style={styles.titleGroup}>
             <Text style={styles.title}>MY ECHO LIBRARY</Text>
-            <View style={styles.subtitleContainer}>
-              <Text style={styles.subtitle}>
-                Save what matters — when it matters most.
-              </Text>
-              <Text style={[styles.subtitle, styles.subtitleItalic]}>
-                Not everything is meant to disappear.
-              </Text>
-            </View>
+            <Text style={styles.subtitle}>
+              Preserve memories that matter most
+            </Text>
           </View>
 
-          {/* Echo Inbox */}
-          <View style={styles.echoInboxRow}>
+          {/* ── Echo Inbox link ───────────────────────────────────────── */}
+          {/* Figma 1441:1943 — border-bottom 0.5px #a3b3cc, gap:16 */}
+          <TouchableOpacity
+            style={styles.inboxRow}
+            onPress={() => navigation.navigate('EchoInboxScreen')}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+          >
             <Image
               source={require('@assets/mail.png')}
-              style={styles.echoInboxIcon}
+              style={styles.mailIcon}
               resizeMode="contain"
             />
-            <Text style={styles.echoInboxText}>Echo Inbox</Text>
-          </View>
+            {/* Heading M: Cormorant Regular 28/32, #f2e1b0 */}
+            <Text style={styles.inboxText}>Echo Inbox</Text>
+          </TouchableOpacity>
 
-          <LinearGradient
-            colors={['rgba(253, 253, 249, 0.04)', 'rgba(253, 253, 249, 0.01)']}
-            start={{ x: 0.5, y: 0 }}
-            end={{ x: 0.5, y: 1 }}
-            style={styles.card}
-          >
-            <View style={{ flex: 1, width: '100%' }}>
-              <View style={styles.tableHeader}>
-                <TouchableOpacity
-                  style={styles.headerTab}
-                  onPress={() => setActiveTab('RECIPIENT')}
-                  activeOpacity={0.7}
-                >
-                  <Text
-                    style={[
-                      styles.headerText,
-                      activeTab === 'RECIPIENT'
-                        ? styles.activeHeader
-                        : styles.inactiveHeader,
-                    ]}
-                  >
-                    RECIPIENT
-                  </Text>
-                </TouchableOpacity>
-
-                <TouchableOpacity
-                  style={styles.headerTab}
-                  onPress={() => setActiveTab('CATEGORY')}
-                  activeOpacity={0.7}
-                >
-                  <Text
-                    style={[
-                      styles.headerText,
-                      activeTab === 'CATEGORY'
-                        ? styles.activeHeader
-                        : styles.inactiveHeader,
-                    ]}
-                  >
-                    CATEGORY
-                  </Text>
-                </TouchableOpacity>
-              </View>
-
-              {loading ? (
-                <View style={styles.loadingContainer}>
-                  <ActivityIndicator size="large" color={GOLD} />
-                </View>
-              ) : error ? (
-                <View style={styles.errorContainer}>
-                  <Text style={styles.errorText}>{error}</Text>
+          {/* ── Content area — empty OR filled ───────────────────────── */}
+          {loading ? (
+            <View style={styles.stateBox}>
+              <ActivityIndicator size="large" color={palette.gold.DEFAULT} />
+            </View>
+          ) : error ? (
+            <View style={styles.stateBox}>
+              <Text style={styles.errorText}>{error}</Text>
+              <TouchableOpacity onPress={fetchEchoes} style={styles.retryBtn}>
+                <Text style={styles.retryText}>Retry</Text>
+              </TouchableOpacity>
+            </View>
+          ) : echoes.length === 0 ? (
+            /*
+              Empty state — Figma 211:1233: ONE single card, no outer wrapper.
+              border 0.5px #60739f (border-inverse-1), radius 16,
+              padding 20v/16h, gap 32, items-center, text-center.
+            */
+            <View style={styles.emptyCard}>
+              <Text style={styles.emptyCardTitle}>NO ECHOES YET.</Text>
+              <Text style={styles.emptyCardBody}>
+                Begin by creating something meaningful — for yourself or someone you love.
+              </Text>
+            </View>
+          ) : (
+            /*
+              Filled state — Figma 211:1468: outer card with gradient bg,
+              border 0.25px #a3b3cc, tabs, then list rows.
+            */
+            <View style={[styles.cardGlow, styles.cardGlowFlex]}>
+              <LinearGradient
+                colors={['rgba(253,253,249,0.01)', 'rgba(253,253,249,0)']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 0, y: 1 }}
+                style={StyleSheet.absoluteFill}
+                pointerEvents="none"
+              />
+              <View style={styles.tabs}>
+                {(['RECIPIENT', 'CATEGORY'] as const).map(tab => (
                   <TouchableOpacity
-                    onPress={fetchEchoes}
-                    style={styles.retryBtn}
+                    key={tab}
+                    onPress={() => setActiveTab(tab)}
+                    activeOpacity={0.7}
+                    style={[styles.tab, activeTab === tab && styles.tabActive]}
                   >
-                    <Text style={styles.retryText}>Retry</Text>
+                    <Text style={[
+                      styles.tabText,
+                      activeTab === tab ? styles.tabTextActive : styles.tabTextInactive,
+                    ]}>
+                      {tab}
+                    </Text>
                   </TouchableOpacity>
-                </View>
-              ) : echoes.length === 0 ? (
-                <View style={styles.emptyContainer}>
-                  <Text style={styles.emptyText}>No echoes yet</Text>
-                  <Text style={styles.emptySubtext}>
-                    Create your first echo to preserve a message
-                  </Text>
-                </View>
-              ) : (
-                <ScrollView
-                  showsVerticalScrollIndicator={false}
-                  contentContainerStyle={styles.listContent}
-                >
-                  {echoes.map(item => (
-                    <TouchableOpacity
-                      key={item.echo_id}
-                      activeOpacity={0.9}
-                      onPress={() => handleOpenItem(item)}
-                      style={styles.row}
-                    >
-                      {/* Recipient / Category Column */}
-
-                      <View style={styles.rowLeft}>
-                        {/* Avatar/Icon Group */}
-                        {activeTab == 'RECIPIENT' && (
-                          <View style={styles.avatarGroup}>
-                            <View style={styles.avatarContainer}>
-                              {item.recipient?.motif &&
-                              getMotifIcon(item.recipient.motif) ? (
-                                <View style={{ width: 24, height: 24 }}>
-                                  <SvgXml
-                                    xml={
-                                      getMotifIcon(item.recipient.motif)?.xml ||
-                                      ''
-                                    }
-                                    width="100%"
-                                    height="100%"
-                                  />
-                                </View>
-                              ) : item.recipient?.motif ? (
-                                <Text style={{ fontSize: 18 }}>
-                                  {item.recipient.motif}
-                                </Text>
-                              ) : (
-                                <Image
-                                  source={require('@assets/Group.png')}
-                                  style={styles.avatarImage}
-                                />
-                              )}
-                            </View>
-                          </View>
-                        )}
-
-                        <View style={styles.rowTextWrap}>
-                          <Text style={styles.rowTitle}>{item.title}</Text>
-                          <Text style={styles.rowSub}>
-                            {item.scheduled_at
-                              ? `Unlocks ${formatDate(item.scheduled_at)}`
-                              : `Saved ${formatDate(item.created_at)}`}
-                          </Text>
-                        </View>
-                      </View>
-
-                      {/* Right Side: Recipient/Category Name */}
-                      <View style={styles.rowRight}>
-                        <Text style={styles.recipientText}>
-                          {activeTab === 'RECIPIENT'
-                            ? item.recipient?.name?.toUpperCase() ||
-                              'UNASSIGNED'
-                            : item.category?.toUpperCase() || 'UNCATEGORIZED'}
+                ))}
+              </View>
+              {echoes.map((item, index) => {
+                const isLast = index === echoes.length - 1;
+                const isLocked = !!item.scheduled_at;
+                const rightLabel = activeTab === 'RECIPIENT'
+                  ? (item.recipient?.name?.toUpperCase() || 'UNASSIGNED')
+                  : (item.category?.toUpperCase() || 'UNCATEGORIZED');
+                return (
+                  <TouchableOpacity
+                    key={item.echo_id}
+                    activeOpacity={0.9}
+                    onPress={() => handleOpenItem(item)}
+                    style={[styles.row, !isLast && styles.rowBorder]}
+                  >
+                    <View style={styles.rowLeft}>
+                      <EchoAvatar motif={item.recipient?.motif} profileImage={undefined} />
+                      <View style={styles.rowText}>
+                        <Text style={styles.rowTitle} numberOfLines={1}>{item.title}</Text>
+                        <Text style={styles.rowSub} numberOfLines={1}>
+                          {isLocked
+                            ? `Unlocks ${formatDate(item.scheduled_at!)}`
+                            : `Saved ${formatDate(item.created_at)}`}
                         </Text>
                       </View>
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              )}
+                    </View>
+                    <View style={styles.rowRight}>
+                      <Text style={styles.rowLabel}>{rightLabel}</Text>
+                      {isLocked && <LockIcon />}
+                    </View>
+                  </TouchableOpacity>
+                );
+              })}
             </View>
-          </LinearGradient>
+          )}
 
-          <View style={styles.buttonContainer}>
-            <TouchableOpacity
-              onPress={handleCreateEcho}
-              activeOpacity={0.9}
-              style={styles.buttonTouch}
-            >
-              <LinearGradient
-                colors={['rgba(253, 253, 249, 0.04)', 'rgba(253, 253, 249, 0.01)']}
-                start={{ x: 0.5, y: 0 }}
-                end={{ x: 0.5, y: 1 }}
-                style={styles.buttonGradient}
-              >
-                <Text style={styles.buttonText}>CREATE AN ECHO</Text>
-              </LinearGradient>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              onPress={handleManageRecipients}
-              activeOpacity={0.9}
-              style={styles.buttonTouch}
-            >
-              <LinearGradient
-                colors={['rgba(253, 253, 249, 0.04)', 'rgba(253, 253, 249, 0.01)']}
-                start={{ x: 0.5, y: 0 }}
-                end={{ x: 0.5, y: 1 }}
-                style={styles.buttonGradient}
-              >
-                <Text style={styles.buttonText}>MANAGE RECIPIENTS</Text>
-              </LinearGradient>
-            </TouchableOpacity>
+          {/* ── Buttons ───────────────────────────────────────────────── */}
+          {/*
+            Empty state (211:1236): single "CREATE ECHO" button
+            Filled state (791:3866): "CREATE AN ECHO" + "MANAGE RECIPIENTS"
+          */}
+          <View style={styles.btnGroup}>
+            <Button
+              variant="primary"
+              size="L"
+              title={echoes.length === 0 ? 'CREATE ECHO' : 'CREATE AN ECHO'}
+              onPress={() => navigation.navigate('NewEchoScreen')}
+              style={styles.btn}
+            />
+            {echoes.length > 0 && (
+              <Button
+                variant="primary"
+                size="L"
+                title="MANAGE RECIPIENTS"
+                onPress={() => navigation.navigate('ManageRecipientScreen')}
+                style={styles.btn}
+              />
+            )}
           </View>
-        </View>
+        </ScrollView>
       </SafeAreaView>
     </BackgroundWrapper>
   );
@@ -310,346 +315,367 @@ export default function MirrorEchoVaultLibraryScreen() {
   return <EchoLibraryContent />;
 }
 
-const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: 'transparent',
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+
+const styles = StyleSheet.create<{
+  bg: ViewStyle;
+  safe: ViewStyle;
+  scroll: ViewStyle;
+  scrollContent: ViewStyle;
+  titleGroup: ViewStyle;
+  title: TextStyle;
+  subtitle: TextStyle;
+  inboxRow: ViewStyle;
+  mailIcon: ImageStyle;
+  inboxText: TextStyle;
+  cardGlow: ViewStyle;
+  cardGlowFlex: ViewStyle;
+  tabs: ViewStyle;
+  tab: ViewStyle;
+  tabActive: ViewStyle;
+  tabText: TextStyle;
+  tabTextActive: TextStyle;
+  tabTextInactive: TextStyle;
+  row: ViewStyle;
+  rowBorder: ViewStyle;
+  rowLeft: ViewStyle;
+  avatarGlow: ViewStyle;
+  avatarRing: ViewStyle;
+  avatarImg: ImageStyle;
+  avatarFallback: ImageStyle;
+  rowText: ViewStyle;
+  rowTitle: TextStyle;
+  rowSub: TextStyle;
+  rowRight: ViewStyle;
+  rowLabel: TextStyle;
+  btnGroup: ViewStyle;
+  btn: ViewStyle;
+  emptyCard: ViewStyle;
+  emptyCardTitle: TextStyle;
+  emptyCardBody: TextStyle;
+  stateBox: ViewStyle;
+  errorText: TextStyle;
+  retryBtn: ViewStyle;
+  retryText: TextStyle;
+  emptyText: TextStyle;
+  emptySubtext: TextStyle;
+}>({
+  bg:   { flex: 1, backgroundColor: palette.navy.deep },
+  safe: { flex: 1, backgroundColor: palette.neutral.transparent },
+
+  scroll: { flex: 1 },
+  // Figma 211:1221 outer column: gap-[30px] between LogoHeader and inner content
+  // Figma 211:1222 inner column: gap-[24px] between titleGroup / inboxRow / card / button
+  scrollContent: {
+    paddingHorizontal: scale(spacing.xl),        // 24px — Figma left:24
+    paddingTop:        verticalScale(30),         // 30px — Figma outer gap-[30px]
+    paddingBottom:     verticalScale(spacing.xxxl),
+    gap:               verticalScale(spacing.xl), // 24px — Figma inner gap-[24px]
+    flexGrow:          1,
   },
 
-  background: {
-    flex: 1,
-    justifyContent: 'flex-start',
+  // ── Title + Subtitle ───────────────────────────────────────────────────────
+  // Figma 211:1223 — flex-col gap:16, items-center
+  titleGroup: {
+    gap:        verticalScale(spacing.m),        // 16px
+    alignItems: 'center',                        // FIX: was 'flex-start'
   },
 
-  topRow: {
-    // Removed, replaced by headerSection
-  },
-  contentWrapper: {
-    flex: 1,
-    width: '100%',
-    alignItems: 'center',
-    paddingTop: 0,
-    paddingHorizontal: spacing.l,
-    paddingBottom: Platform.OS === 'ios' ? 18 : 12,
-  },
-  rowRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-  },
-  headerSection: {
-    marginTop: 20,
-    marginBottom: 20,
-    alignItems: 'center',
-    width: '100%',
-  },
-  subtitleContainer: {
-    marginTop: 8,
-    alignItems: 'center',
-  },
-  subtitleItalic: {
-    fontFamily: 'Inter-Italic', // Assuming Inter-Italic exists, else CormorantGaramond-Italic
-    marginTop: 0,
-  },
-  listContent: {
-    paddingBottom: 20,
+  // Heading M: Cormorant Regular 28/32, #f2e1b0, glow shadow, center-aligned
+  title: {
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize['2xl']),  // 28px
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(32),
+    color:            palette.gold.DEFAULT,
+    textAlign:        'center',                  // FIX: was missing
+    textShadowColor:  'rgba(240,212,168,0.3)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 10,
+    width:            '100%',
   },
 
-  // VIEW MODE TOGGLE
-  viewModeToggle: {
-    flexDirection: 'row',
+  // Body S Regular: Inter Regular 16/24, white, center-aligned
+  // Figma 211:1225: font-weight/regular (not Light)
+  subtitle: {
+    fontFamily: fontFamily.body,                 // FIX: was bodyLight
+    fontSize:   moderateScale(fontSize.s),       // 16px
+    fontWeight: fontWeight.regular,              // FIX: was '300'
+    lineHeight: moderateScale(24),
+    color:      palette.neutral.white,
+    textAlign:  'center',                        // FIX: was missing
+    width:      '100%',
+  },
+
+  // ── Echo Inbox row ─────────────────────────────────────────────────────────
+  // Figma 1441:1943 — border-bottom 0.5px Border/Subtle, gap:16, items-center
+  inboxRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 16,
-    paddingHorizontal: 16,
-    borderBottomWidth: 0.5,
-    borderBottomColor: palette.navy.light,
-    gap: 12,
-  },
-  toggleButton: {
-    paddingVertical: 8,
-    paddingHorizontal: 20,
-    borderRadius: 20,
-    borderWidth: 0.5,
-    borderColor: palette.navy.light,
-    minWidth: 120,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  toggleButtonActive: {
-    borderColor: GOLD,
-    backgroundColor: 'rgba(242, 226, 177, 0.1)',
-  },
-  toggleText: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 18,
-    color: palette.navy.light,
-  },
-  toggleTextActive: {
-    color: GOLD,
-  },
-  inboxToggleContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
+    gap:            scale(spacing.m),                   // 16px
+    paddingVertical: verticalScale(spacing.xxs),        // 4px (Spacing/XXS)
+    borderBottomWidth: borderWidth.thin,                // 0.5px
+    borderBottomColor: palette.navy.light,              // Border/Subtle #a3b3cc
+    alignSelf:      'center',
   },
 
-  // INBOX HEADER (OLD - NOW REPLACED BY TOGGLE)
-  inboxHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 16,
-    borderBottomWidth: 0.5,
-    borderBottomColor: palette.navy.light,
-    width: '100%',
-    marginBottom: 0,
-  },
-  inboxIconContainer: {
-    width: 24,
-    height: 24,
-    marginRight: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  inboxTitle: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 28,
-    color: GOLD,
-    textAlign: 'center',
+  mailIcon: {
+    width:     scale(24),
+    height:    scale(24),
+    tintColor: palette.gold.DEFAULT,
   },
 
-  // ECHO INBOX HEADING
-  echoInboxRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+  // Heading M: Cormorant Regular 28/32, #f2e1b0
+  inboxText: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize['2xl']),         // 28px
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(32),
+    color:      palette.gold.DEFAULT,
+  },
+
+  // ── Library card ──────────────────────────────────────────────────────────
+  // Figma 211:1468 — gradient bg, border 0.25px #a3b3cc, radius 16, padding 16
+  // overflow:hidden clips the LinearGradient; glow is on this same view
+  // (shadow doesn't clip because we're not hiding shadow separately)
+  // Base card — no flex; wraps content in empty state
+  cardGlow: {
+    width:        '100%',
+    borderRadius: radius.m,
+    borderWidth:  borderWidth.hairline,
+    borderColor:  palette.navy.light,
+    padding:      scale(spacing.m),
+    overflow:     'hidden',
+  },
+  // Applied on top of cardGlow when echoes exist — lets the list fill space
+  cardGlowFlex: {
+    flex:      1,
+    minHeight: scale(200),
+  },
+
+  // ── Tabs ────────────────────────────────────────────────────────────────────
+  // Figma 1065:1750 — gap:32, items-center, justify-center
+  tabs: {
+    flexDirection:  'row',
     justifyContent: 'center',
-    gap: 8,
-    marginBottom: 16,
-    paddingVertical: 8,
-    paddingHorizontal: 20,
-    alignSelf: 'center',
-    borderBottomWidth: 0.5,
-    borderBottomColor: palette.gold.DEFAULT,
-  },
-  echoInboxIcon: {
-    width: 24,
-    height: 24,
-    tintColor: GOLD,
-  },
-  echoInboxText: {
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-    fontSize: 28,
-    fontWeight: '400',
-    color: palette.gold.DEFAULT,
-    textAlign: 'center',
-    lineHeight: 36.4,
+    alignItems:     'center',
+    gap:            scale(32),
+    marginBottom:   verticalScale(spacing.s),           // visual separation from rows
   },
 
-  // CARD / LIST
-  card: {
-    width: '100%',
-    borderRadius: 16,
-    // paddingHorizontal: spacing.m, // Moved padding to children if needed
-    // paddingTop: 0,
-    // paddingBottom: spacing.m,
-    alignSelf: 'center',
-    ...shadows.LIGHT,
-    // backgroundColor: 'rgba(12,17,31,0.65)', // Gradient used instead
-    borderWidth: 0.5,
-    borderColor: 'rgba(96, 115, 159, 1)', // border-inverse-1
-    flex: 1, // Take available space
-    marginBottom: 20,
-    overflow: 'hidden',
+  tab: {
+    paddingVertical: 2,
   },
 
-  // TABS
-  tableHeader: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    paddingVertical: 12,
-    gap: 32,
-    // borderBottomWidth: 1, // Removed border
-  },
-  headerTab: {
-    paddingBottom: 4,
-  },
-  headerText: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 24,
-    textAlign: 'center',
-  },
-  activeHeader: {
-    color: palette.gold.subtlest,
-    borderBottomWidth: 1.5,
-    borderBottomColor: palette.gold.subtlest,
-    paddingBottom: 2,
-  },
-  inactiveHeader: {
-    color: palette.navy.light,
+  // Active tab: bottom border Border/Subtle
+  tabActive: {
+    borderBottomWidth: 1,
+    borderBottomColor: palette.navy.light,              // #a3b3cc per Figma 1065:1751
   },
 
-  // LIST ROWS
+  // Heading XS Bold: Cormorant Medium 20/24
+  tabText: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize.l),              // 20px (font/size/L)
+    fontWeight: '500',                                  // Figma: font-medium
+    lineHeight: moderateScale(24),                      // font/size/XL
+    textAlign:  'center',
+  },
+
+  tabTextActive: {
+    color: palette.gold.subtlest,                       // #fdfdf9 (Text/Paragraph-2)
+  },
+
+  tabTextInactive: {
+    color: palette.navy.light,                          // #a3b3cc (Text/Inverse-Paragraph-2)
+  },
+
+  // ── List rows ───────────────────────────────────────────────────────────────
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'space-between',
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    borderBottomWidth: 0.25,
-    borderBottomColor: palette.gold.active, // border-brand-active
+    paddingVertical: verticalScale(spacing.m),          // 16px (Spacing/M)
   },
+
+  // Figma: border-bottom 0.25px Border/Subtle between rows (not on last)
+  rowBorder: {
+    borderBottomWidth: borderWidth.hairline,             // 0.25px
+    borderBottomColor: palette.navy.light,               // #a3b3cc
+  },
+
   rowLeft: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
+    alignItems:    'center',
+    gap:           scale(12),
+    flex:          1,
+    maxWidth:      scale(200),
+  },
+
+  // ── Avatar ─────────────────────────────────────────────────────────────────
+  // Figma 4190:3633 — 40×40, border 1px #f2e1b0, glow 0 0 10 3px rgba(240,212,168,0.3)
+  avatarGlow: {
+    width:         scale(40),
+    height:        scale(40),
+    borderRadius:  scale(20),
+    // Figma glow: 0 0 10px 3px rgba(240,212,168,0.3)
+    boxShadow:     '0px 0px 10px 3px rgba(240, 212, 168, 0.3)',
+    shadowColor:   palette.gold.glow,
+    shadowOffset:  { width: 0, height: 0 },
+    shadowOpacity: 0.3,
+    shadowRadius:  10,
+    elevation:     6,
+  },
+
+  avatarRing: {
+    width:           '100%',
+    height:          '100%',
+    borderRadius:    scale(20),
+    borderWidth:     1,                                  // Figma: 1px border/brand
+    borderColor:     palette.gold.DEFAULT,               // #f2e1b0
+    backgroundColor: 'rgba(197,158,95,0.05)',
+    overflow:        'hidden',
+    alignItems:      'center',
+    justifyContent:  'center',
+  },
+
+  // Avatar image: 149.82% height, offset top -6.74%
+  avatarImg: {
+    position: 'absolute',
+    width:    '100%',
+    height:   '150%',
+    top:      '-7%',
+    left:     0,
+  },
+
+  avatarFallback: {
+    width:  scale(20),
+    height: scale(20),
+  },
+
+  rowText: {
     flex: 1,
   },
-  avatarGroup: {
-    // Container for avatar
-  },
-  avatarContainer: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: 'rgba(197, 158, 95, 0.05)',
-    borderWidth: 0.5,
-    borderColor: palette.gold.DEFAULT,
-    justifyContent: 'center',
-    alignItems: 'center',
-    // Shadow...
-  },
-  avatarImage: {
-    width: 20,
-    height: 20,
-    // tintColor: GOLD,
-  },
-  rowTextWrap: {
-    marginLeft: 0,
-    flex: 1,
-  },
+
+  // Heading XS: Cormorant Regular 20/24, white
   rowTitle: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 20,
-    color: palette.neutral.white,
-    lineHeight: 26,
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize.l),               // 20px
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(24),
+    color:      palette.neutral.white,
   },
+
+  // Body XS Light Italic: Inter Light Italic 14/1.5, white
   rowSub: {
-    fontFamily: 'Inter-LightItalic', // Assuming font
-    fontSize: 14,
-    color: palette.neutral.white, // Italic text color
-    opacity: 0.8,
-  },
-  recipientText: {
-    fontFamily: 'Inter-Light',
-    fontSize: 16,
-    color: GOLD,
-    marginRight: 8,
-  },
-  arrowIcon: {
-    color: GOLD,
-    fontSize: 14,
-    fontFamily: 'Inter-Regular',
+    fontFamily: fontFamily.bodyItalic,
+    fontStyle:  'italic',
+    fontSize:   moderateScale(fontSize.xs),              // 14px
+    fontWeight: '300',
+    lineHeight: moderateScale(fontSize.xs * 1.5),
+    color:      palette.neutral.white,
+    opacity:    0.85,
   },
 
-  // BUTTONS
-  buttonContainer: {
-    width: '100%',
-    gap: 12,
-    marginBottom: 20,
-  },
-  buttonTouch: {
-    alignSelf: 'center',
-    width: 280,
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: palette.navy.light,
-    overflow: 'hidden',
-  },
-  buttonGradient: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    minHeight: 48,
-  },
-  createButton: {},
-  secondaryButton: {},
-  buttonText: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 24,
-    color: GOLD,
-    textAlign: 'center',
-    textShadowColor: textShadow.warmGlow.color,
-    textShadowOffset: textShadow.warmGlow.offset,
-    textShadowRadius: textShadow.warmGlow.radius,
+  rowRight: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           scale(8),
   },
 
-  // ... keep loading/error styles
-  loadingContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 60,
+  // Inter Light 16/24, Text/Paragraph-1 #f2e1b0
+  rowLabel: {
+    fontFamily: fontFamily.bodyLight,
+    fontSize:   moderateScale(fontSize.s),               // 16px
+    fontWeight: '300',
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
+    textAlign:  'center',
   },
-  errorContainer: {
-    flex: 1,
+
+  // ── Buttons ─────────────────────────────────────────────────────────────────
+  // Figma 791:3866 — flex-col gap:12, width 271px
+  btnGroup: {
     alignItems: 'center',
+    gap:        verticalScale(spacing.s),                // 12px
+  },
+
+  btn: {
+    width: scale(271),
+  },
+
+  // ── State views ─────────────────────────────────────────────────────────────
+  // Figma 211:1233 — empty state card inside the list area
+  // border 0.5px #60739f (border-inverse-1 = navy.medium), gradient, radius 16
+  // padding 20v/16h (Spacing/L and Spacing/M), gap 32, items-center, text-center
+  emptyCard: {
+    width:           '100%',
+    borderRadius:    radius.m,
+    borderWidth:     borderWidth.thin,
+    borderColor:     palette.navy.medium,                  // #60739f
+    paddingVertical: verticalScale(20),
+    paddingHorizontal: scale(spacing.m),
+    gap:             verticalScale(32),
+    alignItems:      'center',
+  },
+
+  // Cormorant Regular 28px, #e5d6b0 (gold.warm), lineHeight 1.3
+  emptyCardTitle: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(28),
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(28 * 1.3),
+    color:      palette.gold.warm,
+    textAlign:  'center',
+    width:      '100%',
+    textTransform: 'uppercase',
+  },
+
+  // Inter Light 18px, #fdfdf9, lineHeight 1.5
+  emptyCardBody: {
+    fontFamily: fontFamily.bodyLight,
+    fontSize:   moderateScale(18),
+    fontWeight: '300',
+    lineHeight: moderateScale(18 * 1.5),
+    color:      palette.gold.subtlest,
+    textAlign:  'center',
+    width:      '100%',
+  },
+
+  stateBox: {
+    alignItems:     'center',
     justifyContent: 'center',
-    paddingVertical: 40,
+    paddingVertical: verticalScale(40),
   },
   errorText: {
-    color: palette.status.errorHover,
-    fontSize: 14,
-    textAlign: 'center',
+    color:       palette.status.errorHover,
+    fontSize:    moderateScale(14),
+    textAlign:   'center',
     marginBottom: 12,
   },
   retryBtn: {
-    paddingHorizontal: 20,
-    paddingVertical: 8,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: GOLD,
+    paddingHorizontal: scale(20),
+    paddingVertical:   verticalScale(8),
+    borderRadius:      radius.s,
+    borderWidth:       1,
+    borderColor:       palette.gold.DEFAULT,
   },
   retryText: {
-    color: GOLD,
-    fontSize: 14,
-  },
-  emptyContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: 60,
+    color:    palette.gold.DEFAULT,
+    fontSize: moderateScale(14),
   },
   emptyText: {
-    color: SUBTEXT,
-    fontSize: 16,
-    textAlign: 'center',
-    marginBottom: 8,
+    color:       palette.gold.subtlest,
+    fontSize:    moderateScale(16),
+    textAlign:   'center',
+    marginBottom: verticalScale(8),
   },
   emptySubtext: {
-    color: SUBTEXT,
-    fontSize: 14,
+    color:     palette.gold.subtlest,
+    fontSize:  moderateScale(14),
     textAlign: 'center',
-    opacity: 0.7,
+    opacity:   0.7,
   },
-  title: {
-    fontFamily: 'CormorantGaramond-Regular',
-    fontSize: 28,
-    color: GOLD,
-    textAlign: 'center',
-    textShadowColor: palette.gold.glow,
-    textShadowRadius: 16,
-    letterSpacing: 2,
-  },
-  subtitle: {
-    fontFamily: 'Inter-Light', // Assuming Inter-Light
-    fontSize: 16,
-    color: palette.neutral.white,
-    textAlign: 'center',
-    lineHeight: 24,
-  },
-  // Removed old styles: iconButton, menuIcon, inlineLogoHeader, iconSpacer, inboxRow, inboxIconBox, etc.
 });

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -28,6 +28,13 @@ export interface EchoResponse {
     email: string;
     motif?: string;
   };
+  /** Present on inbox echoes — the user who created and sent the echo. */
+  sender?: {
+    user_id: string;
+    name: string;
+    email: string;
+    motif?: string;
+  };
   scheduled_at?: string; // ISO date string
 }
 

--- a/MirrorCollectiveApp/src/types/navigation.ts
+++ b/MirrorCollectiveApp/src/types/navigation.ts
@@ -58,6 +58,7 @@ export type RootStackParamList = {
   // Echo Vault Screens
   MirrorEchoVaultHome: undefined;
   MirrorEchoVaultLibrary: undefined;
+  EchoInboxScreen: undefined;
   NewEchoVault: undefined;
   NewEchoScreen: undefined;
   NewEchoCompose: {


### PR DESCRIPTION
…Inbox

Button component
- SecondaryButton: implement Figma 125:436 exactly — Translucent White Gradient (0.03→0.2) background, NO text shadow (primary has warm-glow shadow, secondary does not). Updated snapshots.

AppVideoScreen
- Replace raw TouchableOpacity + 15 manual style lines with <Button variant="primary" size="L" title="NEXT" />

QuizQuestionsScreen
- Image grid gap fixed: 30→40 (Figma 203:2425 value)

EchoVaultHomeScreen — complete Figma 767:2513 match
- Title changed MIRROR ECHO → ECHO VAULT
- Hero image: restored imageWrapper/imageSquare styles (were stripped), correct aspect-ratio 1:1, @assets alias
- Copy text: updated to Figma "Your space. / Your memories. / Your story."
- Buttons: VIEW VAULT=primary active, START ECHO=secondary
- Info modal: outer shadow wrapper + LinearGradient + new text ("ECHO VAULT")
- Subtitle, body, quote text all updated to Figma 347:1239 exact copy

EchoVaultLibraryScreen — pixel-matched to Figma 211:1449
- Rewrote from scratch with design system tokens (fontFamily, scale, etc.)
- Empty state: single bordered card (no double border), no tabs
- Filled state: tabs RECIPIENT|CATEGORY, rows with avatar glow, lock icon
- Buttons conditional: "CREATE ECHO" only when empty, both when filled
- Spacing: paddingTop 30, gap 24 between sections (Figma exact)
- All raw font strings replaced with fontFamily/fontSize/fontWeight tokens

EchoInboxScreen — new screen (Figma 1436:1830)
- LogoHeader + back arrow | ECHO INBOX | spacer title row
- Tabs: SENDER (default) | CATEGORY
- Rows: title + italic date | label + lock (no avatars per Figma)
- getRightLabel() switches between sender.name and category per tab
- Registered in correct navigator (main, alongside other Echo screens)
- Navigation type EchoInboxScreen added to RootStackParamList
- EchoResponse.sender?: { user_id, name, email, motif } added to type
- Echo Inbox button in EchoVaultLibraryScreen wired to navigate here

Cleanup: 317 orphan hash-named SVG/PNG MCP exports deleted from src/assets/pledge/ (none had code references)