### PR TITLE
feat: Echo Vault screen redesigns + profile image S3 upload

### DIFF
--- a/MirrorCollectiveApp/src/screens/echoVault/AddNewProfileScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/AddNewProfileScreen.tsx
@@ -1,41 +1,79 @@
+/**
+ * Add New Profile Screen
+ * Figma: Design-Master-File → Add Profile (780:1147)
+ *
+ * Layout:
+ *   LogoHeader
+ *   Header row: ← | ADD PROFILE | spacer
+ *   Subtitle — "Personalize your echo with a photo of the intended recipient/guardian."
+ *   Photo circle (186×186) — "Add Image +" taps open gallery; shows photo when selected
+ *   Name field — TextInputField
+ *   Email field — TextInputField
+ *   ADD button — Button primary
+ *
+ * Image flow:
+ *   1. User taps circle → launchImageLibrary from react-native-image-picker
+ *   2. Selected photo shown in circle (URI stored in state)
+ *   3. getUploadUrl('image/jpeg', undefined, 'profile') → presigned S3 URL (no echoId needed)
+ *   4. uploadMedia(upload_url, localUri) → PUT to S3
+ *   5. Public media_url stored as profile_image_url on recipient via addRecipient
+ *   6. EchoVaultLibraryScreen reads recipient.profile_image_url → shows in EchoAvatar
+ */
+
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
-import { RootStackParamList } from '@types';
 import React, { useState } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  StatusBar,
-  TouchableOpacity,
-  Image,
-  TextInput,
-  Dimensions,
-  Platform,
-  KeyboardAvoidingView,
-  ScrollView,
-  Alert,
   ActivityIndicator,
+  Alert,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import { launchImageLibrary } from 'react-native-image-picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { SvgXml } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 
-import { MOTIF_ICONS } from '@assets/motifs/MotifAssets';
 import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
-import MotifSelectionModal from '@components/MotifSelectionModal';
+import TextInputField from '@components/TextInputField';
 import { echoApiService } from '@services/api/echo';
+import {
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  scale,
+  spacing,
+  textShadow,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'AddNewProfileScreen'>;
 
-const { width } = Dimensions.get('window');
+// ── Back arrow ────────────────────────────────────────────────────────────────
+const BackIcon: React.FC = () => (
+  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+      fill={palette.gold.DEFAULT}
+    />
+  </Svg>
+);
 
-const GOLD = palette.gold.mid;
-const LIGHT_GOLD = palette.gold.DEFAULT;
-const OFFWHITE = palette.gold.subtlest;
-const BLUE_GREY = palette.navy.light;
-const SUBTEXT = 'rgba(253,253,249,0.75)';
+const CIRCLE = scale(186);
 
 const AddNewProfileScreen: React.FC<Props> = ({ navigation, route }) => {
   const mode = route.params?.mode ?? 'recipient';
@@ -43,159 +81,165 @@ const AddNewProfileScreen: React.FC<Props> = ({ navigation, route }) => {
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
-  const [motif, setMotif] = useState('');
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [modalVisible, setModalVisible] = useState(false);
 
-  const handleAddProfile = async () => {
+  const handlePickImage = async () => {
+    const result = await launchImageLibrary({
+      mediaType: 'photo',
+      quality: 0.8,
+      maxWidth: 400,
+      maxHeight: 400,
+    });
+
+    if (!result.didCancel && result.assets?.[0]?.uri) {
+      setPhotoUri(result.assets[0].uri);
+    }
+  };
+
+  const handleAdd = async () => {
     if (!name.trim() || !email.trim()) {
-      Alert.alert('Error', 'Please enter a name and email address');
+      Alert.alert('Required', 'Please enter a name and email address.');
       return;
     }
-
     try {
       setLoading(true);
+
+      // Upload profile photo → S3 before saving the recipient.
+      // Reuses getUploadUrl (upload_type:'profile', no echoId) + uploadMedia —
+      // the same pipeline as echo audio/video, no separate endpoint needed.
+      let profileImageUrl: string | undefined;
+      if (photoUri && !isGuardian) {
+        const urlRes = await echoApiService.getUploadUrl('image/jpeg', undefined, 'profile');
+        if (!urlRes.success || !urlRes.data) {
+          throw new Error(urlRes.error ?? 'Could not get image upload URL');
+        }
+        await echoApiService.uploadMedia(urlRes.data.upload_url, photoUri, 'image/jpeg');
+        profileImageUrl = urlRes.data.media_url;   // public S3 URL stored on recipient
+      }
+
       const response = isGuardian
         ? await echoApiService.addGuardian({ name, email })
-        : await echoApiService.addRecipient({ name, email, motif: motif.trim() || undefined });
+        : await echoApiService.addRecipient({
+            name,
+            email,
+            ...(profileImageUrl ? { profile_image_url: profileImageUrl } : {}),
+          });
+
       if (response.success) {
         Alert.alert('Success', `${isGuardian ? 'Guardian' : 'Recipient'} added successfully`, [
-          { text: 'OK', onPress: () => navigation.goBack() }
+          { text: 'OK', onPress: () => navigation.goBack() },
         ]);
       } else {
         Alert.alert('Error', response.error || `Failed to add ${isGuardian ? 'guardian' : 'recipient'}`);
       }
-    } catch (error) {
-      console.error('Add profile error:', error);
-      Alert.alert('Error', 'An unexpected error occurred');
+    } catch (err: any) {
+      Alert.alert('Error', err?.message ?? 'An unexpected error occurred');
     } finally {
       setLoading(false);
     }
   };
 
-  const handleSelectMotif = (motifId: string) => {
-    setMotif(motifId);
-    setModalVisible(false);
-  };
-
-  const contentWidth = Math.min(width * 0.88, 360);
-
-  const selectedIcon = MOTIF_ICONS.find(m => m.id === motif);
-
   return (
-    <BackgroundWrapper style={styles.root}>
+    <BackgroundWrapper style={styles.bg} scrollable>
       <SafeAreaView style={styles.safe}>
-        <StatusBar
-          barStyle="light-content"
-          translucent
-          backgroundColor="transparent"
-        />
-        
-        {/* Header - Sticky */}
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
         <LogoHeader navigation={navigation} />
 
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={{ flex: 1, width: '100%' }}
+          style={styles.kav}
         >
           <ScrollView
-            contentContainerStyle={{ flexGrow: 1, alignItems: 'center', paddingBottom: 40 }}
+            contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
             keyboardShouldPersistTaps="handled"
           >
-            {/* Title */}
-            <View style={[styles.titleRow, { width: contentWidth }]}>
-              <TouchableOpacity onPress={() => navigation.goBack()}>
-                <Image source={require('@assets/back-arrow.png')} style={styles.backArrowImg} resizeMode="contain" />
-              </TouchableOpacity>
+            <View style={styles.content}>
 
-              <Text style={styles.title}>{isGuardian ? 'ADD GUARDIAN' : 'ADD PROFILE'}</Text>
-
-              <View style={{ width: 24 }} />
-            </View>
-
-            {/* Description */}
-            <Text style={[styles.description, { width: contentWidth }]}>
-              {isGuardian
-                ? 'Your guardians can verify your identity and unlock legacy echoes.'
-                : 'Your recipients will have access to echoes you share with them.'}
-            </Text>
-
-            {/* Add Icon Circle */}
-            <View style={styles.iconWrap}>
-              <TouchableOpacity
-                onPress={() => setModalVisible(true)}
-              >
-                <LinearGradient
-                  colors={['rgba(229, 214, 176, 0.05)', 'rgba(197, 157, 95, 0.05)']}
-                  start={{x: 1, y: 0.5}}
-                  end={{x: 0, y: 0.5}}
-                  style={styles.iconOuter}
+              {/* ── Header row ──────────────────────────────────────────── */}
+              <View style={styles.headerRow}>
+                <TouchableOpacity
+                  onPress={() => navigation.goBack()}
+                  style={styles.backBtn}
+                  accessibilityRole="button"
                 >
-                  <View style={styles.iconInner}>
-                  {selectedIcon ? (
-                    <SvgXml xml={selectedIcon.xml} width={80} height={80} />
-                  ) : motif ? (
-                    <Text style={[styles.iconLabel, { fontSize: 48 }]}>{motif}</Text>
-                  ) : (
-                    <Text style={styles.iconLabel}>Add Icon</Text>
-                  )}
-                  </View>
-                </LinearGradient>
-              </TouchableOpacity>
-            </View>
-
-            {/* Form */}
-            <View style={[styles.form, { width: contentWidth }]}>
-              <Text style={styles.label}>Name</Text>
-              <View style={styles.inputShell}>
-                <TextInput
-                  value={name}
-                  onChangeText={setName}
-                  placeholder={isGuardian ? 'Enter name of guardian' : 'Enter name of recipient'}
-                  placeholderTextColor={BLUE_GREY}
-                  style={styles.input}
-                />
+                  <BackIcon />
+                </TouchableOpacity>
+                {/* Heading M: Cormorant Regular 28/32, gold, glow */}
+                <Text style={styles.screenTitle}>
+                  {isGuardian ? 'ADD GUARDIAN' : 'ADD PROFILE'}
+                </Text>
+                <View style={styles.headerSpacer} />
               </View>
 
-              <Text style={[styles.label, { marginTop: 16 }]}>Email Address</Text>
-              <View style={styles.inputShell}>
-                <TextInput
-                  value={email}
-                  onChangeText={setEmail}
-                  placeholder={isGuardian ? 'Enter guardian email address' : 'Enter recipient email address'}
-                  placeholderTextColor={BLUE_GREY}
-                  style={styles.input}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                />
-              </View>
+              {/* ── Subtitle ─────────────────────────────────────────────── */}
+              {/* Body S Regular: Inter 16/24, #fdfdf9, center */}
+              <Text style={styles.subtitle}>
+                Personalize your echo with a photo of the intended recipient/guardian.
+              </Text>
 
-
-            </View>
-
-            {/* Add Button */}
-            <TouchableOpacity 
-              style={styles.addWrap}
-              onPress={handleAddProfile}
-              disabled={loading}
-            >
-              <View style={styles.addButton}>
-                {loading ? (
-                  <ActivityIndicator color={LIGHT_GOLD} />
+              {/* ── Photo circle ──────────────────────────────────────────── */}
+              {/*
+                Figma: 186×186 circle, gold border 0.5px, gold glow shadow.
+                "Add Image +" when empty, shows photo when selected.
+                Tap → opens device gallery (react-native-image-picker).
+              */}
+              <TouchableOpacity
+                style={styles.photoCircle}
+                activeOpacity={0.85}
+                onPress={handlePickImage}
+                accessibilityRole="button"
+                accessibilityLabel="Add photo from gallery"
+              >
+                {photoUri ? (
+                  <Image
+                    source={{ uri: photoUri }}
+                    style={styles.photoImg}
+                    resizeMode="cover"
+                  />
                 ) : (
-                  <Text style={styles.addText}>ADD</Text>
+                  <Text style={styles.addImageText}>Add Image +</Text>
                 )}
-              </View>
-            </TouchableOpacity>
+              </TouchableOpacity>
+
+              {/* ── Name ─────────────────────────────────────────────────── */}
+              <TextInputField
+                label="Name"
+                placeholder={isGuardian ? 'Enter name of guardian' : 'Enter name of recipient/guardian'}
+                value={name}
+                onChangeText={setName}
+                autoCapitalize="words"
+              />
+
+              {/* ── Email ────────────────────────────────────────────────── */}
+              <TextInputField
+                label="Email Address"
+                placeholder={isGuardian ? 'Enter guardian email address' : 'Enter recipient/guardian email address'}
+                value={email}
+                onChangeText={setEmail}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoComplete="email"
+                textContentType="emailAddress"
+              />
+
+              {/* ── ADD button ───────────────────────────────────────────── */}
+              {loading ? (
+                <ActivityIndicator color={palette.gold.DEFAULT} style={{ marginTop: verticalScale(8) }} />
+              ) : (
+                <Button
+                  variant="primary"
+                  size="L"
+                  title="ADD"
+                  onPress={handleAdd}
+                  active={!!(name.trim() && email.trim())}
+                />
+              )}
+
+            </View>
           </ScrollView>
         </KeyboardAvoidingView>
-        
-        <MotifSelectionModal 
-          visible={modalVisible}
-          onClose={() => setModalVisible(false)}
-          onSelect={handleSelectMotif}
-        />
       </SafeAreaView>
     </BackgroundWrapper>
   );
@@ -203,164 +247,113 @@ const AddNewProfileScreen: React.FC<Props> = ({ navigation, route }) => {
 
 export default AddNewProfileScreen;
 
-/* ---------------- STYLES ---------------- */
+// ── Styles ────────────────────────────────────────────────────────────────────
 
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: 'transparent',
-    alignItems: 'center',
+const styles = StyleSheet.create<{
+  bg: ViewStyle;
+  safe: ViewStyle;
+  kav: ViewStyle;
+  scrollContent: ViewStyle;
+  content: ViewStyle;
+  headerRow: ViewStyle;
+  backBtn: ViewStyle;
+  screenTitle: TextStyle;
+  headerSpacer: ViewStyle;
+  subtitle: TextStyle;
+  photoCircle: ViewStyle;
+  photoImg: ImageStyle;
+  addImageText: TextStyle;
+}>({
+  bg:   { flex: 1 },
+  safe: { flex: 1, backgroundColor: 'transparent' },
+  kav:  { flex: 1, width: '100%' },
+
+  scrollContent: {
+    flexGrow: 1,
+    paddingBottom: verticalScale(spacing.xxxl),
   },
-  root: {
-    flex: 1,
-    alignItems: 'center',
+  content: {
+    paddingHorizontal: scale(spacing.xl),        // 24px
+    paddingTop:        verticalScale(spacing.l),
+    gap:               verticalScale(spacing.xl), // 24px between sections
+    alignItems:        'center',
   },
 
-  /* Title */
-  titleRow: {
-    marginTop: 30,
-    flexDirection: 'row',
-    alignItems: 'center',
+  // ── Header ─────────────────────────────────────────────────────────────────
+  headerRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'space-between',
+    width:          '100%',
   },
-  backArrow: {
-    fontSize: 22,
-    color: LIGHT_GOLD,
+  backBtn: {
+    width:          scale(44),
+    height:         scale(44),
+    justifyContent: 'center',
+    alignItems:     'flex-start',
   },
-  backArrowImg: {
-    width: 20,
-    height: 20,
-    tintColor: LIGHT_GOLD,
-  },
-  title: {
-    fontSize: 28,
-    color: LIGHT_GOLD,
-    letterSpacing: 0,
-    textAlign: 'center',
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-    textShadowColor: palette.gold.glow,
+  // Heading M: Cormorant Regular 28/32, #f2e1b0, glow
+  screenTitle: {
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize['2xl']),
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(32),
+    color:            palette.gold.DEFAULT,
+    textAlign:        'center',
+    flex:             1,
+    textShadowColor:  'rgba(240,212,168,0.3)',
     textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 16,
+    textShadowRadius: 10,
+  },
+  headerSpacer: { width: scale(44) },
+
+  // ── Subtitle ────────────────────────────────────────────────────────────────
+  // Body S Regular: Inter 16/24, #fdfdf9, center
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontWeight: fontWeight.regular,
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.subtlest,
+    textAlign:  'center',
+    width:      '100%',
   },
 
-  /* Description */
-  description: {
-    marginTop: 12,
-    textAlign: 'center',
-    color: OFFWHITE,
-    fontSize: 16,
-    lineHeight: 24,
-    fontFamily: Platform.select({
-      ios: 'System', // Inter is not standard, using System as fallback or we assume custom font loaded
-      android: 'sans-serif',
-    }),
+  // ── Photo circle ────────────────────────────────────────────────────────────
+  // Figma: 186×186, gold border 0.5px, glow shadow 0 0 25px rgba(229,214,176,0.3)
+  photoCircle: {
+    width:           CIRCLE,
+    height:          CIRCLE,
+    borderRadius:    CIRCLE / 2,
+    borderWidth:     borderWidth.thin,              // 0.5px
+    borderColor:     palette.gold.warm,             // gold warm
+    backgroundColor: 'rgba(229,214,176,0.04)',
+    alignItems:      'center',
+    justifyContent:  'center',
+    overflow:        'hidden',
+    // Glow
+    boxShadow:       '0px 0px 25px 0px rgba(229,214,176,0.3)',
+    shadowColor:     palette.gold.warm,
+    shadowOffset:    { width: 0, height: 0 },
+    shadowOpacity:   0.3,
+    shadowRadius:    25,
+    elevation:       8,
   },
-
-  /* Icon Circle */
-  iconWrap: {
-    marginTop: 24,
-    marginBottom: 24,
-    alignItems: 'center',
+  photoImg: {
+    width:        '100%',
+    height:       '100%',
+    borderRadius: CIRCLE / 2,
   },
-  iconOuter: {
-    width: 186,
-    height: 186,
-    borderRadius: 93,
-    borderWidth: 0.5,
-    borderColor: palette.gold.warm,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...Platform.select({
-      ios: {
-        shadowColor: 'rgba(229, 214, 176, 1)',
-        shadowOffset: { width: 0, height: 0 },
-        shadowOpacity: 0.3,
-        shadowRadius: 25,
-      },
-      android: {
-        boxShadow: '0 0 25px rgba(229, 214, 176, 0.30)',
-      },
-    }),
-  },
-  iconInner: {
-    width: 160,
-    height: 160,
-    borderRadius: 80,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  iconLabel: {
-    color: 'white',
-    fontSize: 24,
-    textAlign: 'center',
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-  },
-
-  /* Form */
-  form: {
-    marginBottom: 24,
-  },
-  label: {
-    color: LIGHT_GOLD,
-    fontSize: 20,
-    marginBottom: 6,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Medium',
-      android: 'serif',
-    }),
-  },
-  inputShell: {
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: BLUE_GREY,
-    backgroundColor: 'rgba(253,253,249,0.04)',
-    paddingHorizontal: 16,
-    height: 48,
-    justifyContent: 'center',
-  },
-  input: {
-    color: BLUE_GREY,
-    fontSize: 16,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Italic',
-      android: 'serif',
-    }),
-    fontStyle: 'italic',
-    paddingVertical: 0,
-    includeFontPadding: false,
-  },
-
-  /* Add button */
-  addWrap: {
-    marginTop: 8,
-  },
-  addButton: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: BLUE_GREY,
-    backgroundColor: 'rgba(253,253,249,0.04)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minWidth: 100,
-  },
-  addText: {
-    color: LIGHT_GOLD,
-    fontSize: 24,
-    textAlign: 'center',
-    textShadowColor: textShadow.warmGlow.color,
+  // "Add Image +" — Heading XS: Cormorant Regular 20/24, gold
+  addImageText: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(fontSize.l),          // 20px
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
+    textAlign:  'center',
+    textShadowColor:  textShadow.warmGlow.color,
     textShadowOffset: textShadow.warmGlow.offset,
     textShadowRadius: textShadow.warmGlow.radius,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
   },
 });

--- a/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
@@ -1,78 +1,99 @@
+/**
+ * Choose Recipient Screen
+ * Figma: Design-Master-File → Choose Your Recipient (791:1488)
+ *
+ * Layout (top → bottom):
+ *   LogoHeader
+ *   Header row: ← | CHOOSE YOUR RECIPIENT | spacer
+ *   "Recipient *" label + inline dropdown (Choose from list ▼ / ▲ + list)
+ *   "Lock Date (only if required)" label + date input (calendar icon)
+ *   "Letter to Recipient *" label + multiline textarea
+ *   NEXT button
+ *
+ * Hidden (Day 2 / legacy):
+ *   - "Legacy" section (Is this a legacy echo? YES/NO)
+ *   - "Unlock upon death" checkbox
+ *   - Guardian prompt modal
+ *
+ * On NEXT: navigate directly to NewEchoComposeScreen (no guardian flow).
+ *
+ * Tokens (from Figma 791:1488 variable defs):
+ *   Heading M 28/32     → fontFamily.heading, Cormorant Regular — screen title
+ *   Heading XS Bold 20/24 → fontFamily.heading weight 500 — section labels
+ *   Body S Italic 16/24 → fontFamily.bodyItalic — placeholders
+ *   Body S Regular 16/24 → fontFamily.body — selected values
+ *   Border/Inverse-1 #60739f → palette.navy.medium — field borders
+ *   Radius/S 12, radius/md 8, Space/M 16
+ */
+
 import DateTimePicker from '@react-native-community/datetimepicker';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
-import { RootStackParamList } from '@types';
-import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
-  View,
-  Text,
-  StyleSheet,
-  StatusBar,
-  TouchableOpacity,
-  TextInput,
-  Dimensions,
-  Platform,
-  FlatList,
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
   ActivityIndicator,
-  Modal,
   Image,
-  ScrollView,
   KeyboardAvoidingView,
-  Keyboard,
+  Platform,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Path } from 'react-native-svg';
 
 import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
-import StarIcon from '@components/StarIcon';
-import { echoApiService, Recipient } from '@services/api/echo';
+import TextInputField from '@components/TextInputField';
+import { echoApiService, type Recipient } from '@services/api/echo';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ChooseRecipientScreen'>;
 
-const { width } = Dimensions.get('window');
+// ── Back arrow ────────────────────────────────────────────────────────────────
+const BackIcon: React.FC = () => (
+  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+      fill={palette.gold.DEFAULT}
+    />
+  </Svg>
+);
 
-const GOLD = palette.gold.mid;
-const OFFWHITE = 'rgba(253,253,249,0.92)';
-const SUBTEXT = 'rgba(253,253,249,0.65)';
-const BORDER = 'rgba(253,253,249,0.18)';
-
+// ── Screen ────────────────────────────────────────────────────────────────────
 const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
-  const { title, category, mode } = route.params; 
+  const { title, category, mode } = route.params;
+
   const [recipients, setRecipients] = useState<Recipient[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedRecipient, setSelectedRecipient] = useState<Recipient | null>(null);
-  const [showDropdown, setShowDropdown] = useState(false);
-  const [legacy, setLegacy] = useState<'yes' | 'no' | null>(null);
-  const [unlockOnDeath, setUnlockOnDeath] = useState(false);
-  const [notes, setNotes] = useState('');
-  const [showGuardianPrompt, setShowGuardianPrompt] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [lockDate, setLockDate] = useState<Date | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const scrollViewRef = useRef<ScrollView>(null);
-
-  const contentWidth = Math.min(width * 0.88, 360);
-
-  useEffect(() => {
-    const showSub = Keyboard.addListener('keyboardDidShow', () => setKeyboardVisible(true));
-    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
-      setKeyboardVisible(false);
-      scrollViewRef.current?.scrollTo({ y: 0, animated: true });
-    });
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
+  const [notes, setNotes] = useState('');
 
   const fetchRecipients = useCallback(async () => {
     try {
       setLoading(true);
       const response = await echoApiService.getRecipients();
-      if (response.success && response.data) {
-        setRecipients(response.data);
-      }
+      if (response.success && response.data) setRecipients(response.data);
     } catch (err) {
       console.error('Failed to load recipients:', err);
     } finally {
@@ -82,323 +103,227 @@ const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
 
   useEffect(() => {
     fetchRecipients();
-    const unsubscribe = navigation.addListener('focus', fetchRecipients);
-    return unsubscribe;
+    const unsub = navigation.addListener('focus', fetchRecipients);
+    return unsub;
   }, [navigation, fetchRecipients]);
 
-  const handleSelectRecipient = (recipient: Recipient) => {
-    setSelectedRecipient(recipient);
-    setShowDropdown(false);
+  const handleDateChange = (_: any, date?: Date) => {
+    if (Platform.OS === 'android') setShowDatePicker(false);
+    if (date) setLockDate(date);
+    if (Platform.OS === 'ios') setShowDatePicker(false);
   };
+
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 
   const handleNext = () => {
-    if (selectedRecipient) {
-      // Show guardian prompt modal
-      setShowGuardianPrompt(true);
-    }
-  };
-
-  const handleGuardianPromptYes = () => {
-    setShowGuardianPrompt(false);
-    // Navigate to ChooseGuardianScreen
-    navigation.navigate('ChooseGuardianScreen', {
-      mode,
-      title,
-      category,
-      recipientId: selectedRecipient?.recipient_id,
-      recipientName: selectedRecipient?.name,
-      lockDate: lockDate?.toISOString(),
-      unlockOnDeath,
-    });
-  };
-
-  const handleGuardianPromptNo = () => {
-    setShowGuardianPrompt(false);
-    // Navigate directly to compose
+    if (!selectedRecipient) return;
+    // Navigate directly to compose — no guardian prompt (Day 2 feature)
     navigation.navigate('NewEchoComposeScreen', {
       mode,
       title,
       category,
       hasRecipient: true,
-      recipient: selectedRecipient,
-      recipientId: selectedRecipient?.recipient_id,
-      recipientName: selectedRecipient?.name,
-      unlockOnDeath,
-      lockDate: lockDate?.toISOString(),
-      // No guardianId
-    });
-  };
-
-  const handleDateChange = (event: any, selectedDate?: Date) => {
-    // Close picker on both platforms when date is selected or dismissed
-    if (Platform.OS === 'android') {
-      setShowDatePicker(false);
-    }
-    
-    if (event.type === 'dismissed' || event.type === 'set') {
-      setShowDatePicker(false);
-    }
-    
-    if (selectedDate) {
-      setLockDate(selectedDate);
-    }
-  };
-
-  const formatDate = (date: Date | null) => {
-    if (!date) return null;
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
+      recipient:    selectedRecipient,
+      recipientId:  selectedRecipient.recipient_id,
+      recipientName: selectedRecipient.name,
+      lockDate:     lockDate?.toISOString(),
     });
   };
 
   return (
-    <BackgroundWrapper style={styles.root}>
+    <BackgroundWrapper style={styles.bg} scrollable>
       <SafeAreaView style={styles.safe}>
-        <StatusBar
-          barStyle="light-content"
-          translucent
-          backgroundColor="transparent"
-        />
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+        <LogoHeader navigation={navigation} />
 
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={{ flex: 1, width: '100%' }}
+          style={styles.kav}
         >
           <ScrollView
-            ref={scrollViewRef}
-            style={{ flex: 1 }}
+            style={styles.scroll}
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
             keyboardShouldPersistTaps="handled"
-            scrollEnabled={keyboardVisible}
           >
-        {/* Header */}
-        <LogoHeader navigation={navigation} />
+            <View style={styles.content}>
 
-        {/* Title */}
-        <View style={[styles.titleRow, { width: contentWidth, alignSelf: 'center' }]}>
-          <TouchableOpacity onPress={() => navigation.goBack()}>
-            <Image source={require('@assets/back-arrow.png')} style={styles.backArrowImg} resizeMode="contain" />
-          </TouchableOpacity>
-
-          <Text style={styles.title}>CHOOSE YOUR{'\n'}RECIPIENT</Text>
-
-          <View style={{ width: 24 }} />
-        </View>
-
-        {/* Content */}
-        <View style={[styles.content, { width: contentWidth, alignSelf: 'center' }]}>
-          {/* Recipient dropdown */}
-          <Text style={styles.label}>Recipient</Text>
-          <TouchableOpacity
-            activeOpacity={0.9}
-            onPress={() => setShowDropdown(true)}
-            style={{ width: '100%' }}
-          >
-            <LinearGradient
-              colors={['rgba(253,253,249,0.04)', 'rgba(253,253,249,0.01)']}
-              start={{ x: 0.5, y: 0 }}
-              end={{ x: 0.5, y: 1 }}
-              style={styles.dropdownShell}
-            >
-              <View style={styles.dropdownContent}>
-                <View style={styles.dropdownLeft} />
-                <Text style={selectedRecipient ? styles.dropdownValueText : styles.dropdownPlaceholderText}>
-                  {selectedRecipient ? selectedRecipient.name : 'Choose from list'}
-                </Text>
-                <View style={styles.dropdownRight}>
-                  <Image source={require('@assets/down-arrow.png')} style={{ width: 16, height: 16, tintColor: OFFWHITE }} resizeMode="contain" />
-                </View>
+              {/* ── Header row ──────────────────────────────────────────── */}
+              <View style={styles.headerRow}>
+                <TouchableOpacity
+                  onPress={() => navigation.goBack()}
+                  style={styles.backBtn}
+                  accessibilityRole="button"
+                >
+                  <BackIcon />
+                </TouchableOpacity>
+                {/* Heading M: Cormorant Regular 28/32, #f2e1b0, glow */}
+                <Text style={styles.screenTitle}>CHOOSE YOUR{'\n'}RECIPIENT</Text>
+                <View style={styles.headerSpacer} />
               </View>
-            </LinearGradient>
-          </TouchableOpacity>
 
-          {/* Legacy */}
-          <LinearGradient
-            colors={['rgba(253, 253, 249, 0.04)', 'rgba(253, 253, 249, 0.01)']}
-            start={{ x: 0.5, y: 0 }}
-            end={{ x: 0.5, y: 1 }}
-            style={styles.legacyCard}
-          >
-            <View style={styles.legacyRow}>
-              <Text style={styles.label}>Legacy</Text>
-              <TouchableOpacity hitSlop={10}>
-                <Text style={styles.infoIcon}>ⓘ</Text>
-              </TouchableOpacity>
-            </View>
+              {/* ── Recipient dropdown ─────────────────────────────────── */}
+              {/*
+                TextInputField (editable=false) as the trigger surface.
+                Chevron icon overlaid absolutely on the right.
+                Backdrop TouchableOpacity dismisses the inline list.
+              */}
+              <View style={styles.fieldGroup}>
+                {/*
+                  Outer TouchableOpacity = entire tap target (whole input area).
+                  pointerEvents="none" on inner View prevents TextInput from
+                  stealing taps — every tap anywhere on the field opens dropdown.
+                  TextInputField label prop handles correct label styling.
+                */}
+                {/*
+                  fieldWithIcon is relative. TouchableOpacity covers full area.
+                  Icon is a SIBLING of TouchableOpacity, absolutely positioned
+                  on fieldWithIcon with bottom:0 + fixed height = input field area.
+                  This ensures icon centres in the INPUT, not in label+input.
+                */}
+                <View style={styles.fieldWithIcon}>
+                  <TouchableOpacity
+                    style={styles.fieldTouchable}
+                    activeOpacity={0.9}
+                    onPress={() => setDropdownOpen(o => !o)}
+                  >
+                    <View pointerEvents="none">
+                      <TextInputField
+                        label="Recipient"
+                        placeholder="Choose from list"
+                        value={selectedRecipient?.name ?? ''}
+                      />
+                    </View>
+                  </TouchableOpacity>
+                  {/* Chevron — sibling of TouchableOpacity, anchored to input bottom */}
+                  <View style={styles.fieldIcon} pointerEvents="none">
+                    <Svg width={scale(16)} height={scale(16)} viewBox="0 0 24 24" fill="none">
+                      <Path
+                        d={dropdownOpen ? 'M7 14l5-5 5 5' : 'M7 10l5 5 5-5'}
+                        stroke={palette.gold.subtlest}
+                        strokeWidth={1.5}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </Svg>
+                  </View>
+                </View>
 
-            <View style={styles.legacyCheckRow}>
-              <Text style={[styles.subLabel, { flex: 1, marginBottom: 0 }]}>Is this a legacy echo?</Text>
-              <CheckOption
-                label="YES"
-                active={legacy === 'yes'}
-                onPress={() => setLegacy('yes')}
+                {dropdownOpen && (
+                  <TouchableOpacity
+                    style={styles.dropdownBackdrop}
+                    activeOpacity={1}
+                    onPress={() => setDropdownOpen(false)}
+                  />
+                )}
+
+                {/* Inline recipient list */}
+                {dropdownOpen && (
+                  <View style={styles.dropdownList}>
+                    {loading ? (
+                      <View style={styles.listState}>
+                        <ActivityIndicator size="small" color={palette.gold.DEFAULT} />
+                      </View>
+                    ) : recipients.length === 0 ? (
+                      <View style={styles.listState}>
+                        <Text style={styles.emptyText}>No recipients yet</Text>
+                      </View>
+                    ) : (
+                      recipients.map((r, idx) => {
+                        const isLast = idx === recipients.length - 1;
+                        return (
+                          <TouchableOpacity
+                            key={r.recipient_id}
+                            style={[styles.dropdownOption, isLast && styles.dropdownOptionLast]}
+                            activeOpacity={0.85}
+                            onPress={() => { setSelectedRecipient(r); setDropdownOpen(false); }}
+                          >
+                            <Text style={styles.optionName}>{r.name}</Text>
+                            <Text style={styles.optionEmail}>{r.email}</Text>
+                          </TouchableOpacity>
+                        );
+                      })
+                    )}
+                    <TouchableOpacity
+                      style={styles.addNewRow}
+                      activeOpacity={0.85}
+                      onPress={() => { setDropdownOpen(false); navigation.navigate('AddNewProfileScreen'); }}
+                    >
+                      <Text style={styles.addNewText}>+ Add New Recipient</Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
+              </View>
+
+              {/* ── Lock Date ─────────────────────────────────────────── */}
+              {/*
+                TextInputField (editable=false) as the trigger surface.
+                Calendar icon overlaid absolutely on the right.
+              */}
+              <View style={styles.fieldGroup}>
+                <View style={styles.fieldWithIcon}>
+                  <TouchableOpacity
+                    style={styles.fieldTouchable}
+                    activeOpacity={0.9}
+                    onPress={() => setShowDatePicker(true)}
+                  >
+                    <View pointerEvents="none">
+                      <TextInputField
+                        label="Lock Date (only if required)"
+                        placeholder="When do you want to open it?"
+                        value={lockDate ? formatDate(lockDate) : ''}
+                      />
+                    </View>
+                  </TouchableOpacity>
+                  {/* Calendar — sibling, anchored to input bottom */}
+                  <View style={styles.fieldIcon} pointerEvents="none">
+                    <Image
+                      source={require('@assets/calendar_month.png')}
+                      style={styles.calendarIcon}
+                      resizeMode="contain"
+                    />
+                  </View>
+                </View>
+
+                {showDatePicker && (
+                  <DateTimePicker
+                    value={lockDate ?? new Date()}
+                    mode="date"
+                    display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                    onChange={handleDateChange}
+                    minimumDate={new Date()}
+                    textColor={palette.gold.DEFAULT}
+                    themeVariant="dark"
+                  />
+                )}
+              </View>
+
+              {/* ── Letter to Recipient ───────────────────────────────── */}
+              <View style={styles.fieldGroup}>
+                <TextInputField
+                  label="Letter to Recipient"
+                  placeholder="Write notes here"
+                  value={notes}
+                  onChangeText={setNotes}
+                  size="L"
+                  multiline
+                />
+              </View>
+
+              {/* ── NEXT button ───────────────────────────────────────── */}
+              <Button
+                variant="primary"
+                size="L"
+                title="NEXT"
+                onPress={handleNext}
+                disabled={!selectedRecipient}
+                active={!!selectedRecipient}
               />
-              <CheckOption
-                label="NO"
-                active={legacy === 'no'}
-                onPress={() => setLegacy('no')}
-              />
+
             </View>
-          </LinearGradient>
-
-          {/* Lock date */}
-          <Text style={[styles.label, { marginTop: 18 }]}>
-            Lock Date <Text style={styles.subtle}>(only if required)</Text>
-          </Text>
-
-          <TouchableOpacity
-            style={styles.inputShell}
-            onPress={() => setShowDatePicker(true)}
-          >
-            <Text style={lockDate ? styles.selectedText : styles.placeholder}>
-              {lockDate ? formatDate(lockDate) : 'When do you want to open it?'}
-            </Text>
-            <Image source={require('@assets/calendar_month.png')} style={styles.calendar} />
-          </TouchableOpacity>
-
-          {showDatePicker && (
-            <DateTimePicker
-              value={lockDate || new Date()}
-              mode="date"
-              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-              onChange={handleDateChange}
-              minimumDate={new Date()}
-              textColor={GOLD}
-              themeVariant="dark"
-            />
-          )}
-
-          {/* Unlock on death */}
-          <TouchableOpacity
-            style={styles.row}
-            onPress={() => setUnlockOnDeath(!unlockOnDeath)}
-          >
-            <View
-              style={[styles.checkbox, unlockOnDeath && styles.checkboxActive]}
-            >
-              {unlockOnDeath && <Text style={styles.checkMark}>✓</Text>}
-            </View>
-            <Text style={styles.checkboxLabel}>Unlock upon death</Text>
-          </TouchableOpacity>
-
-          {/* Letter */}
-          <Text style={[styles.label, { marginTop: 18 }]}>
-            Letter to Recipient
-          </Text>
-
-          <View style={[styles.inputShell, styles.textArea]}>
-            <TextInput
-              value={notes}
-              onChangeText={setNotes}
-              placeholder="Write notes here"
-              placeholderTextColor={palette.navy.medium}
-              multiline
-              style={styles.textAreaInput}
-            />
-          </View>
-        </View>
-
-        {/* Next */}
-        <TouchableOpacity
-          style={[styles.nextAction, !selectedRecipient && styles.disabled]}
-          onPress={handleNext}
-          disabled={!selectedRecipient}
-        >
-          <LinearGradient
-            colors={['rgba(253,253,249,0.04)', 'rgba(253,253,249,0.01)']}
-            start={{ x: 0.5, y: 0 }}
-            end={{ x: 0.5, y: 1 }}
-            style={styles.nextGradient}
-          >
-            <Text style={styles.nextText}>NEXT</Text>
-          </LinearGradient>
-        </TouchableOpacity>
           </ScrollView>
         </KeyboardAvoidingView>
-
-        {/* Dropdown Modal */}
-        <Modal
-          visible={showDropdown}
-          transparent
-          animationType="fade"
-          onRequestClose={() => setShowDropdown(false)}
-        >
-          <TouchableOpacity
-            style={styles.modalOverlay}
-            activeOpacity={1}
-            onPress={() => setShowDropdown(false)}
-          >
-            <View style={[styles.dropdownContainer, { width: contentWidth }]}>
-              <Text style={styles.dropdownTitle}>Select Recipient</Text>
-              {loading ? (
-                <ActivityIndicator size="small" color={GOLD} />
-              ) : recipients.length === 0 ? (
-                <Text style={styles.emptyText}>No recipients available</Text>
-              ) : (
-                <FlatList
-                  data={recipients}
-                  keyExtractor={item => item.recipient_id}
-                  renderItem={({ item }) => (
-                    <TouchableOpacity
-                      style={styles.dropdownItem}
-                      onPress={() => handleSelectRecipient(item)}
-                    >
-                      <Text style={styles.dropdownItemName}>{item.name}</Text>
-                      <Text style={styles.dropdownItemEmail}>{item.email}</Text>
-                    </TouchableOpacity>
-                  )}
-                />
-              )}
-              {/* Add New Recipient Button */}
-              <TouchableOpacity
-                style={styles.addNewButton}
-                onPress={() => {
-                   setShowDropdown(false);
-                   navigation.navigate('AddNewProfileScreen');
-                }}
-              >
-                  <Text style={styles.addNewText}>+ Add New Recipient</Text>
-              </TouchableOpacity>
-            </View>
-          </TouchableOpacity>
-        </Modal>
-
-        {/* Guardian Prompt Modal */}
-        <Modal
-          visible={showGuardianPrompt}
-          transparent
-          animationType="fade"
-          onRequestClose={() => setShowGuardianPrompt(false)}
-        >
-          <View style={styles.modalOverlay}>
-            <View style={styles.guardianPromptCard}>
-              <Text style={styles.guardianPromptTitle}>Assign a Guardian?</Text>
-              <Text style={styles.guardianPromptText}>
-                A Guardian can manage the release of this Echo on your behalf.
-                Would you like to assign one?
-              </Text>
-              
-              <View style={styles.guardianPromptButtons}>
-                <TouchableOpacity
-                  style={[styles.guardianPromptButton, styles.guardianPromptButtonYes]}
-                  onPress={handleGuardianPromptYes}
-                >
-                  <Text style={styles.guardianPromptButtonText}>Yes</Text>
-                </TouchableOpacity>
-                
-                <TouchableOpacity
-                  style={[styles.guardianPromptButton, styles.guardianPromptButtonNo]}
-                  onPress={handleGuardianPromptNo}
-                >
-                  <Text style={[styles.guardianPromptButtonText, styles.guardianPromptButtonTextNo]}>No</Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-          </View>
-        </Modal>
       </SafeAreaView>
     </BackgroundWrapper>
   );
@@ -406,418 +331,184 @@ const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
 
 export default ChooseRecipientScreen;
 
-/* ---------------- COMPONENTS ---------------- */
+// ── Styles ────────────────────────────────────────────────────────────────────
 
-const CheckOption = ({
-  label,
-  active,
-  onPress,
-}: {
-  label: string;
-  active: boolean;
-  onPress: () => void;
-}) => (
-  <TouchableOpacity style={styles.checkOption} onPress={onPress}>
-    <View style={[styles.checkbox, active && styles.checkboxActive]}>
-      {active && <Text style={styles.checkMark}>✓</Text>}
-    </View>
-    <Text style={styles.checkLabel}>{label}</Text>
-  </TouchableOpacity>
-);
+const styles = StyleSheet.create<{
+  bg: ViewStyle;
+  safe: ViewStyle;
+  kav: ViewStyle;
+  scroll: ViewStyle;
+  scrollContent: ViewStyle;
+  content: ViewStyle;
+  // Header
+  headerRow: ViewStyle;
+  backBtn: ViewStyle;
+  screenTitle: TextStyle;
+  headerSpacer: ViewStyle;
+  // Field groups
+  fieldGroup: ViewStyle;
+  fieldWithIcon: ViewStyle;
+  fieldTouchable: ViewStyle;
+  fieldIcon: ViewStyle;
+  // Dropdown / picker
+  dropdownBackdrop: ViewStyle;
+  dropdownList: ViewStyle;
+  dropdownOption: ViewStyle;
+  dropdownOptionLast: ViewStyle;
+  optionName: TextStyle;
+  optionEmail: TextStyle;
+  listState: ViewStyle;
+  emptyText: TextStyle;
+  addNewRow: ViewStyle;
+  addNewText: TextStyle;
+  calendarIcon: ImageStyle;
+}>({
+  bg:   { flex: 1 },
+  safe: { flex: 1, backgroundColor: 'transparent' },
+  kav:  { flex: 1, width: '100%' },
 
-/* ---------------- STYLES ---------------- */
-
-const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: 'transparent', alignItems: 'center' },
-  root: {
-    flex: 1,
-  },
-
-  /* Header */
-  header: {
-    height: 56,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  iconBtn: { width: 44, height: 44, justifyContent: 'center' },
-  iconText: { color: OFFWHITE, fontSize: 22 },
-  brand: { flexDirection: 'row', alignItems: 'center', gap: 10 },
-  logoCircle: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: GOLD,
-  },
-  brandSmall: { color: GOLD, fontSize: 10, letterSpacing: 1 },
-  brandText: { color: GOLD, fontSize: 12, letterSpacing: 2, lineHeight: 14 },
-
-  /* Title */
-  titleRow: {
-    marginTop: 30,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  backArrow: { fontSize: 22, color: GOLD },
-  backArrowImg: { width: 20, height: 20, tintColor: GOLD },
-  title: {
-    textAlign: 'center',
-    color: GOLD,
-    fontSize: 28,
-    letterSpacing: 0,
-    textShadowColor: GOLD,
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 16,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-  },
-
+  scroll: { flex: 1 },
   scrollContent: {
-    alignItems: 'center',
-    paddingBottom: 80,
+    flexGrow:          1,
+    paddingBottom:     verticalScale(spacing.xxxl),
+  },
+  content: {
+    paddingHorizontal: scale(spacing.xl),               // 24px
+    paddingTop:        verticalScale(spacing.l),
+    gap:               verticalScale(spacing.l),         // 20px between sections
   },
 
-  /* Content */
-  content: { marginTop: 10 },
+  // ── Header ─────────────────────────────────────────────────────────────────
+  headerRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
+    justifyContent: 'space-between',
+  },
+  backBtn: {
+    width:          scale(44),
+    height:         scale(44),
+    justifyContent: 'center',
+    alignItems:     'flex-start',
+  },
+  // Heading M: Cormorant Regular 28/32, #f2e1b0, glow
+  screenTitle: {
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize['2xl']),    // 28px
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(32),
+    color:            palette.gold.DEFAULT,
+    textAlign:        'center',
+    textShadowColor:  'rgba(240,212,168,0.3)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 10,
+    flex:             1,
+  },
+  headerSpacer: { width: scale(44) },
 
-  label: {
-    color: GOLD,
-    fontSize: 20,
-    marginBottom: 6,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Medium',
-      android: 'serif',
-    }),
+  // ── Field groups ────────────────────────────────────────────────────────────
+  fieldGroup: { gap: verticalScale(spacing.xs) },       // 8px label-to-field gap
+
+  // Heading XS Bold: Cormorant Medium 20/24, gold
+  fieldLabel: {
+    fontFamily: fontFamily.heading,
+    fontWeight: '500',
+    fontSize:   moderateScale(fontSize.l),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
   },
-  subLabel: {
-    color: palette.navy.medium,
-    fontSize: 16,
-    fontStyle: 'italic',
-    marginBottom: 8,
-    fontFamily: Platform.select({
-      ios: 'Inter-Italic',
-      android: 'sans-serif',
-    }),
+  fieldLabelLight: {
+    fontFamily: fontFamily.bodyLight,
+    fontWeight: '300',
+    fontSize:   moderateScale(fontSize.xs),
+    lineHeight: moderateScale(20),
+    color:      palette.navy.light,
   },
-  subtle: {
-    color: GOLD,
-    fontSize: 14,
-    fontFamily: Platform.select({
-      ios: 'Inter-Light',
-      android: 'sans-serif',
-    }),
-    opacity: 0.8,
+  required: { color: palette.gold.DEFAULT },
+  fieldWithIcon:  { position: 'relative' },
+  fieldTouchable: { width: '100%' },
+
+  // Icon sibling of fieldTouchable, positioned absolutely on fieldWithIcon.
+  // bottom: 0 = bottom of the entire TextInputField (label + input).
+  // height: scale(40) ≈ input field height only — so the icon centres in
+  // the INPUT area, not in label+input together.
+  fieldIcon: {
+    position:       'absolute',
+    right:          scale(spacing.m),
+    bottom:         0,
+    height:         scale(40),
+    justifyContent: 'center',
+    alignItems:     'center',
+    zIndex:         2,
   },
 
-  inputShell: {
-    borderRadius: 12,
-    borderWidth: 0.5,
+  // ── Dropdown / picker overlays ─────────────────────────────────────────────
+  dropdownBackdrop: {
+    position: 'absolute',
+    top:      -200, left: -100, right: -100, bottom: -200,
+    zIndex:   -1,
+  },
+
+  // Inline list
+  dropdownList: {
+    width:       '100%',
+    borderWidth: borderWidth.hairline,
     borderColor: palette.navy.medium,
-    backgroundColor: 'rgba(253,253,249,0.04)',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 12,
-    minHeight: 48,
+    borderTopWidth: 0,
+    borderBottomLeftRadius:  8,
+    borderBottomRightRadius: 8,
+    overflow: 'hidden',
+    maxHeight: verticalScale(220),
   },
-  placeholder: {
-    color: palette.navy.medium,
-    fontSize: 15,
+  dropdownOption: {
+    backgroundColor:   'rgba(253,253,249,0.05)',
+    paddingVertical:   verticalScale(spacing.s),
+    paddingHorizontal: scale(spacing.m),
+    borderBottomWidth: borderWidth.hairline,
+    borderBottomColor: palette.navy.medium,
   },
-  selectedText: {
-    color: OFFWHITE,
-    fontSize: 15,
+  dropdownOptionLast: {
+    borderBottomWidth: 0,
   },
-  chevron: { color: OFFWHITE, fontSize: 16 },
-  calendar: { width: 20, height: 20 },
-  dropdownShell: {
-    width: '100%',
-    borderRadius: 12,
-    borderWidth: 0.25,
-    borderColor: palette.navy.medium,
-    marginBottom: 12,
-    height: 48,
-    justifyContent: 'center',
+  // Body S Regular: Inter 16/24, gold
+  optionName: {
+    fontFamily: fontFamily.body,
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
   },
-  dropdownContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
+  // Body XS Light: Inter Light 14/20, navy.light
+  optionEmail: {
+    fontFamily: fontFamily.bodyLight,
+    fontWeight: '300',
+    fontSize:   moderateScale(fontSize.xs),
+    lineHeight: moderateScale(20),
+    color:      palette.navy.light,
   },
-  dropdownLeft: { width: 24 },
-  dropdownRight: { width: 24, alignItems: 'flex-end' as const },
-  dropdownValueText: {
-    flex: 1,
-    color: OFFWHITE,
-    fontSize: 15,
-    textAlign: 'center',
-  },
-  dropdownPlaceholderText: {
-    flex: 1,
-    color: 'rgba(253,253,249,0.55)',
-    fontSize: 15,
-    textAlign: 'center',
-  },
-
-  legacyCard: {
-    width: '100%',
-    paddingVertical: 4,
-    paddingHorizontal: 4,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'flex-start',
-    gap: 8,
-    borderTopLeftRadius: 12,
-    borderTopRightRadius: 12,
-    borderBottomLeftRadius: 0,
-    borderBottomRightRadius: 0,
-    marginBottom: 12,
-    minHeight: 100,
-  },
-  legacyRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    width: '96%',
-  },
-  legacyCheckRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    width: '96%',
-    justifyContent: 'space-between',
-  },
-  infoIcon: {
-    color: GOLD,
-    fontSize: 16,
-    opacity: 0.8,
-  },
-
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 20,
-    marginBottom: 10,
-  },
-
-  checkOption: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  checkbox: {
-    width: 16,
-    height: 16,
-    borderRadius: 0,
-    borderWidth: 1,
-    borderColor: GOLD,
-    backgroundColor: 'transparent',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  checkboxActive: {
-    backgroundColor: 'rgba(215,192,138,0.7)',
-  },
-  checkMark: {
-    color: palette.navy.card,
-    fontSize: 10,
-    fontWeight: 'bold',
-    lineHeight: 13,
-  },
-  checkLabel: {
-    color: GOLD,
-    fontSize: 14,
-    fontFamily: Platform.select({
-      ios: 'Inter-Regular',
-      android: 'sans-serif',
-    }),
-  },
-  checkboxLabel: {
-    color: OFFWHITE,
-    fontSize: 14,
-  },
-
-  textArea: {
-    height: 120,
-    alignItems: 'flex-start',
-  },
-  textAreaInput: {
-    flex: 1,
-    width: '100%',
-    color: OFFWHITE,
-    fontSize: 15,
-    textAlignVertical: 'top',
-  },
-
-  /* Next */
-  nextAction: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 16,
-    justifyContent: 'center',
-    marginTop: 20,
-    marginBottom: 20,
-  },
-  nextGradient: {
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: GOLD,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  nextText: {
-    paddingHorizontal: 32,
-    paddingVertical: 12,
-    color: GOLD,
-    fontSize: 24,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-    textShadowColor: textShadow.warmGlow.color,
-    textShadowOffset: textShadow.warmGlow.offset,
-    textShadowRadius: textShadow.warmGlow.radius,
-    letterSpacing: 2,
-  },
-  nextActionText: {
-    color: GOLD,
-    fontSize: 24,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-    textShadowColor: textShadow.warmGlow.color,
-    textShadowOffset: textShadow.warmGlow.offset,
-    textShadowRadius: textShadow.warmGlow.radius,
-    letterSpacing: 2,
-  },
-  disabled: {
-    opacity: 0.5,
-  },
-
-  /* Modal */
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.7)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  dropdownContainer: {
-    backgroundColor: palette.navy.deep,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: BORDER,
-    padding: 16,
-    maxHeight: 300,
-  },
-  dropdownTitle: {
-    color: GOLD,
-    fontSize: 18,
-    marginBottom: 12,
-    textAlign: 'center',
-  },
-  dropdownItem: {
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: BORDER,
-  },
-  dropdownItemName: {
-    color: OFFWHITE,
-    fontSize: 16,
-  },
-  dropdownItemEmail: {
-    color: SUBTEXT,
-    fontSize: 12,
-    marginTop: 2,
+  listState: {
+    alignItems:    'center',
+    paddingVertical: verticalScale(spacing.m),
+    backgroundColor: 'rgba(253,253,249,0.05)',
   },
   emptyText: {
-    color: SUBTEXT,
-    fontSize: 14,
-    textAlign: 'center',
-    paddingVertical: 20,
+    fontFamily: fontFamily.body,
+    fontSize:   moderateScale(fontSize.s),
+    color:      palette.navy.light,
   },
-  addNewButton: {
-    paddingVertical: 14,
-    borderTopWidth: 1,
-    borderTopColor: BORDER,
-    alignItems: 'center',
+  addNewRow: {
+    alignItems:      'center',
+    paddingVertical: verticalScale(spacing.s),
+    backgroundColor: 'rgba(253,253,249,0.03)',
   },
   addNewText: {
-    color: GOLD,
-    fontSize: 16,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-SemiBold',
-      android: 'serif',
-    }),
+    fontFamily: fontFamily.body,
+    fontSize:   moderateScale(fontSize.s),
+    color:      palette.gold.DEFAULT,
+    opacity:    0.8,
   },
 
-  /* Guardian Prompt Modal */
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  guardianPromptCard: {
-    width: '85%',
-    maxWidth: 400,
-    backgroundColor: palette.navy.card,
-    borderRadius: 16,
-    padding: 24,
-    borderWidth: 1,
-    borderColor: GOLD,
-  },
-  guardianPromptTitle: {
-    color: GOLD,
-    fontSize: 24,
-    marginBottom: 16,
-    textAlign: 'center',
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Medium',
-      android: 'serif',
-    }),
-  },
-  guardianPromptText: {
-    color: OFFWHITE,
-    fontSize: 16,
-    marginBottom: 24,
-    textAlign: 'center',
-    lineHeight: 24,
-  },
-  guardianPromptButtons: {
-    flexDirection: 'row',
-    gap: 12,
-    justifyContent: 'center',
-  },
-  guardianPromptButton: {
-    flex: 1,
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 1,
-    borderColor: GOLD,
-  },
-  guardianPromptButtonYes: {
-    backgroundColor: GOLD,
-  },
-  guardianPromptButtonNo: {
-    backgroundColor: 'transparent',
-  },
-  guardianPromptButtonText: {
-    fontSize: 18,
-    color: palette.navy.card,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Medium',
-      android: 'serif',
-    }),
-  },
-  guardianPromptButtonTextNo: {
-    color: GOLD,
+  calendarIcon: {
+    width:     scale(20),
+    height:    scale(20),
+    tintColor: palette.navy.light,    // matches placeholder color (#a3b3cc = Text/Inverse Paragraph-2)
   },
 });

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -262,7 +262,7 @@ export function EchoLibraryContent() {
                     style={[styles.row, !isLast && styles.rowBorder]}
                   >
                     <View style={styles.rowLeft}>
-                      <EchoAvatar motif={item.recipient?.motif} profileImage={undefined} />
+                      <EchoAvatar motif={item.recipient?.motif} profileImage={item.recipient?.profile_image_url} />
                       <View style={styles.rowText}>
                         <Text style={styles.rowTitle} numberOfLines={1}>{item.title}</Text>
                         <Text style={styles.rowSub} numberOfLines={1}>
@@ -635,13 +635,14 @@ const styles = StyleSheet.create<{
 
   // Inter Light 18px, #fdfdf9, lineHeight 1.5
   emptyCardBody: {
-    fontFamily: fontFamily.bodyLight,
-    fontSize:   moderateScale(18),
-    fontWeight: '300',
-    lineHeight: moderateScale(18 * 1.5),
-    color:      palette.gold.subtlest,
-    textAlign:  'center',
-    width:      '100%',
+    fontFamily:  fontFamily.bodyLight,
+    fontSize:    moderateScale(18),
+    fontWeight:  '300',
+    lineHeight:  moderateScale(18 * 1.5),
+    color:       palette.gold.subtlest,
+    textAlign:   'center',
+    width:       '100%',
+    alignSelf:   'stretch',   // override parent alignItems:'center' so text fills full width
   },
 
   stateBox: {

--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
@@ -1,631 +1,697 @@
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
-// NewEchoVaultScreen.tsx
-import { RootStackParamList } from '@types';
-import React, { useMemo, useState } from 'react';
+/**
+ * New Echo Screen
+ * Figma: Design-Master-File → New Echo (211:1597)
+ *
+ * Layout (top → bottom, all within left:24 w:345 gap:24 column):
+ *   LogoHeader (MC logo header)
+ *   Header row: ← | NEW ECHO | spacer
+ *   Title input          — gradient 0.01→0, border 0.25px #a3b3cc, radius 12, py:12 px:16
+ *   Hero illustration    — 216×200, brain/constellation asset
+ *   Category dropdown    — gradient 0.01→0, border 0.25px #60739f, radius 12, h:48
+ *   Recipient row        — gradient bg, TOP-ONLY radius 12, padding 8px (Spacing/XS)
+ *   Action buttons row   — gap:32, 3×{72×64} flat bg-surface, border 0.5px brand, shadow
+ *   NEXT button          — gradient 0.01→0, border 0.5px #a3b3cc, radius 16 (Radius/M)
+ *
+ * Token audit (from Figma 211:1597 variable defs):
+ *   Heading M 28/32 → fontFamily.heading, Cormorant Regular
+ *   Heading S 24/28 → fontFamily.heading 24/28 (NEXT button)
+ *   Body S Italic 16/24 → fontFamily.bodyItalic (placeholder, dropdown, recipient label)
+ *   Body S Medium 16/24 → fontFamily.body weight 500 (YES/NO labels)
+ *   Text/Paragraph-1 #f2e1b0 → palette.gold.DEFAULT
+ *   Text/Paragraph-2 #fdfdf9 → palette.gold.subtlest
+ *   Icon/Subtle #dfe3ec → palette.navy.lighter
+ *   Border/Subtle #a3b3cc → palette.navy.light
+ *   Border/Inverse-1 #60739f → palette.navy.medium
+ *   Border/Brand #f2e1b0 → palette.gold.DEFAULT
+ *   Bg/Surface rgba(163,179,204,0.05) → palette.surface.DEFAULT
+ *   Radius/S 12, Radius/M 16, Spacing/XS 8, Spacing/S 12, Spacing/M 16, Spacing/L 20
+ */
+
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
-  View,
-  Text,
-  StyleSheet,
-  StatusBar,
-  TouchableOpacity,
-  TextInput,
-  Dimensions,
-  Modal,
-  Pressable,
-  Platform,
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
+import React, { useState } from 'react';
+import {
   Image,
-  ScrollView,
   KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type ImageStyle,
+  type TextStyle,
+  type ViewStyle,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Path, Rect } from 'react-native-svg';
 
 import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
-import StarIcon from '@components/StarIcon';
+import TextInputField from '@components/TextInputField';
 
+type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'NewEchoScreen'>;
 
-type Props = NativeStackScreenProps<RootStackParamList, 'NewEchoScreen'>;
+// ── Category options ──────────────────────────────────────────────────────────
+// Categories per Figma 734:1308
+const CATEGORIES = ['Grief', 'Love', 'Healing', 'Loss', 'Memory'];
 
-const { width: W, height: H } = Dimensions.get('window');
+// ── Checkbox icon — Figma imgComponent7/8 (20×20 outlined square) ─────────────
+const CheckboxIcon: React.FC<{ checked: boolean }> = ({ checked }) => (
+  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 20 20" fill="none">
+    <Rect
+      x={0.5} y={0.5} width={19} height={19}
+      rx={3.5}
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1}
+      fill={checked ? 'rgba(215,192,138,0.25)' : 'transparent'}
+    />
+    {checked && (
+      <Path
+        d="M4.5 10l4 4 7-8"
+        stroke={palette.gold.DEFAULT}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    )}
+  </Svg>
+);
 
-const GOLD = palette.gold.DEFAULT; // Updated from Figma: palette.gold.DEFAULT
-const OFFWHITE = palette.gold.subtlest; // Updated from Figma: palette.gold.subtlest
-const SURFACE_BORDER = 'rgba(253, 253, 249, 0.18)';
-const SURFACE_BORDER_2 = 'rgba(253, 253, 249, 0.08)';
+// ── Back arrow icon ───────────────────────────────────────────────────────────
+const BackIcon: React.FC = () => (
+  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+      fill={palette.gold.DEFAULT}
+    />
+  </Svg>
+);
 
-const CATEGORIES = [
-  'Gratitude',
-  'Reflection',
-  'Affirmation',
-  'Request',
-  'Apology',
-  'Memory',
-];
+// ── Action button ─────────────────────────────────────────────────────────────
+// ── Action button components ──────────────────────────────────────────────────
+// Figma 220:2035 — all 3 buttons have IDENTICAL styling:
+//   bg Bg/Surface, border 0.5px Border/Brand #f2e1b0, radius 12,
+//   shadow 0 0 15px rgba(242,226,177,0.3), padding 16v/20h
+// Icons are always gold (palette.gold.DEFAULT) regardless of selection.
+// Selected state ONLY changes the background highlight.
 
-const NewEchoScreen: React.FC<Props> = ({ navigation }) => {
+interface ActionBtnProps {
+  children: React.ReactNode;
+  selected: boolean;
+  onPress: () => void;
+}
+const ActionBtn: React.FC<ActionBtnProps> = ({ children, selected, onPress }) => (
+  <TouchableOpacity onPress={onPress} activeOpacity={0.85}>
+    <View style={[styles.actionBtn, selected && styles.actionBtnSelected]}>
+      {children}
+    </View>
+  </TouchableOpacity>
+);
+
+// T button — Figma: 29×32 serif "T" icon = Cormorant Garamond character, gold
+const TextModeIcon: React.FC = () => (
+  <Text style={styles.actionTextIcon}>T</Text>
+);
+
+// Mic button — Figma: 24×24 Material mic icon in 29×32 container
+const MicModeIcon: React.FC = () => (
+  <Image source={require('@assets/mic.png')} style={styles.actionImgIcon} resizeMode="contain" />
+);
+
+// Video button — Figma: 24×24 Material videocam icon in 32×32 container
+const VideoModeIcon: React.FC = () => (
+  <Image source={require('@assets/videocam.png')} style={styles.actionImgIcon} resizeMode="contain" />
+);
+
+// ── Screen ────────────────────────────────────────────────────────────────────
+const NewEchoScreen: React.FC = () => {
+  const navigation = useNavigation<NavigationProp>();
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<string | null>(null);
-  const [recipientChoice, setRecipientChoice] = useState<'yes' | 'no' | null>(
-    null,
-  );
   const [categoryOpen, setCategoryOpen] = useState(false);
-
-  const [selectedMode, setSelectedMode] = useState<'text' | 'audio' | 'video'>('text');
-
-  const contentWidth = useMemo(() => Math.min(W * 0.88, 360), []);
+  const [hasRecipient, setHasRecipient] = useState<'yes' | 'no' | null>(null);
+  const [mode, setMode] = useState<'text' | 'audio' | 'video'>('text');
 
   const onNext = () => {
-    if (!title.trim()) {
-      return;
-    }
-
-    if (recipientChoice === 'yes') {
-      navigation.navigate('ChooseRecipientScreen', {
+    if (!title.trim()) return;
+    const cat = category || 'Uncategorized';
+    if (hasRecipient === 'yes') {
+      navigation.navigate('ChooseRecipientScreen', { title, category: cat, mode });
+    } else {
+      navigation.navigate('NewEchoComposeScreen', {
+        mode,
         title,
-        category: category || 'Uncategorized',
-        mode: selectedMode,
+        category: cat,
+        hasRecipient: false,
       });
-      return;
     }
-
-    // Navigate to Compose screen with params
-    navigation.navigate('NewEchoComposeScreen', {
-      mode: selectedMode,
-      title: title,
-      category: category || 'Uncategorized',
-      hasRecipient: false,
-    });
   };
 
   return (
-    <BackgroundWrapper style={styles.root}>
+    <BackgroundWrapper style={styles.bg}>
       <SafeAreaView style={styles.safe}>
-        <StatusBar
-          barStyle="light-content"
-          translucent
-          backgroundColor="transparent"
-        />
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
 
-        {/* Top Header */}
+        {/* Figma: LogoHeader always at top */}
         <LogoHeader navigation={navigation} />
 
-        {/* Updated Header Layout per Figma */}
-        <View style={styles.headerContainer}>
-          <TouchableOpacity
-            activeOpacity={0.8}
-            style={styles.backBtn}
-            onPress={() => navigation.goBack()}
-          >
-            <Image source={require('@assets/back-arrow.png')} style={{ width: 20, height: 20, tintColor: GOLD }} resizeMode="contain" />
-          </TouchableOpacity>
-
-          <Text style={styles.screenTitle}>NEW ECHO</Text>
-
-          <View style={styles.headerSpacer} />
-        </View>
-
+        {/*
+          Screen is NOT scrollable — fixed layout filling the viewport.
+          Dropdown expands inline with its own internal scroll.
+          KeyboardAvoidingView keeps NEXT button above keyboard.
+        */}
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={{ flex: 1, width: '100%' }}
+          style={styles.kav}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
         >
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={styles.scrollContent}
-          >
-            {/* Content */}
-            <View style={[styles.content, { width: contentWidth }]}>
-              {/* Title input - Updated Styling */}
-              <LinearGradient
-                colors={['rgba(253,253,249,0.04)', 'rgba(253,253,249,0.01)']}
-                start={{ x: 0.5, y: 0 }}
-                end={{ x: 0.5, y: 1 }}
-                style={styles.inputShell}
-              >
-                <View style={styles.inputContainer}>
-                  <TextInput
-                    value={title}
-                    onChangeText={setTitle}
-                    placeholder="Enter Title here"
-                    placeholderTextColor="rgba(253,253,249,0.5)"
-                    style={styles.textInput}
-                  />
-                </View>
-              </LinearGradient>
+            {/*
+              Figma 220:2027 — content column:
+              left:24, top:140, w:345, gap:24, items-center
+            */}
+            <View style={styles.content}>
 
-              {/* Illustration - Replaced Placeholder */}
+              {/* ── Header row (222:2091) ─────────────────────────────── */}
+              {/* back | NEW ECHO | spacer — justify-between, items-center */}
+              <View style={styles.headerRow}>
+                <TouchableOpacity
+                  onPress={() => navigation.goBack()}
+                  style={styles.backBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Go back"
+                >
+                  <BackIcon />
+                </TouchableOpacity>
+
+                {/* Heading M: Cormorant Regular 28/32, #f2e1b0, glow shadow */}
+                <Text style={styles.screenTitle}>NEW ECHO</Text>
+
+                {/* Equal spacer so title stays centred */}
+                <View style={styles.headerSpacer} />
+              </View>
+
+              {/* ── Title input (220:2029) — uses MC TextInputField component */}
+              <TextInputField
+                value={title}
+                onChangeText={setTitle}
+                placeholder="Enter Title here"
+                placeholderAlign="center"
+                textAlign='center'
+                size="S"
+              />
+
+              {/* ── Hero illustration (780:1043) ──────────────────────── */}
+              {/* Figma: 216×200 container, image overflows (large brain constellation) */}
               <View style={styles.illustrationWrap}>
                 <Image
                   source={require('@assets/mirror_echo_illustration.png')}
-                  style={[styles.illustrationImage, { width: contentWidth }]}
+                  style={styles.illustrationImg}
                   resizeMode="contain"
                 />
               </View>
 
-              {/* Category dropdown - Updated Styling */}
-              <TouchableOpacity
-                activeOpacity={0.9}
-                onPress={() => setCategoryOpen(true)}
-                style={{ width: '100%' }}
-              >
-                <LinearGradient
-                  colors={['rgba(253,253,249,0.04)', 'rgba(253,253,249,0.01)']}
-                  start={{ x: 0.5, y: 0 }}
-                  end={{ x: 0.5, y: 1 }}
-                  style={styles.dropdownShell}
-                >
-                  <View style={styles.dropdownContent}>
-                    <View style={styles.dropdownLeft} />
+              {/* ── Category dropdown (734:1307 / 734:1308) ──────────────
+                Figma: ONE right-side chevron only (▼ closed, ▲ open).
+                No left arrow — confirmed by Figma screenshot.
+                Outside-tap: transparent absolute overlay dismisses it.
+              */}
+              {/* Invisible full-screen backdrop — only active when open */}
+              {categoryOpen && (
+                <TouchableOpacity
+                  style={styles.dropdownBackdrop}
+                  activeOpacity={1}
+                  onPress={() => setCategoryOpen(false)}
+                />
+              )}
 
-                    <Text
-                      style={[
-                        styles.dropdownText,
-                        !category && { color: OFFWHITE, opacity: 0.9 },
-                      ]}
-                    >
+              <View style={styles.dropdownWrap}>
+                <TouchableOpacity
+                  activeOpacity={0.9}
+                  onPress={() => setCategoryOpen(o => !o)}
+                >
+                  <View style={[styles.dropdownShell, categoryOpen && styles.dropdownShellOpen]}>
+                    <Text style={[styles.dropdownText, !category && styles.dropdownPlaceholder]}>
                       {category ?? 'Choose echo category'}
                     </Text>
 
-                    <View style={styles.dropdownRight}>
-                      <Image
-                        source={require('@assets/down-arrow.png')}
-                        style={{ width: 16, height: 16, tintColor: OFFWHITE }}
-                        resizeMode="contain"
+                    {/* Single right chevron — ▼ closed, ▲ open */}
+                    <Svg width={scale(16)} height={scale(16)} viewBox="0 0 24 24" fill="none">
+                      <Path
+                        d={categoryOpen ? 'M7 14l5-5 5 5' : 'M7 10l5 5 5-5'}
+                        stroke={palette.gold.subtlest}
+                        strokeWidth={1.5}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
                       />
-                    </View>
+                    </Svg>
                   </View>
-                </LinearGradient>
-              </TouchableOpacity>
+                </TouchableOpacity>
 
-              {/* Recipient yes/no - Updated to horizontal layout */}
-              <View style={styles.recipientBlock}>
-                <Text style={styles.recipientQuestion}>
+                {/* Inline option list — visible when open */}
+                {/* Inline list — own ScrollView so ONLY the list scrolls */}
+                {categoryOpen && (
+                  <ScrollView
+                    style={styles.dropdownList}
+                    scrollEnabled
+                    showsVerticalScrollIndicator={false}
+                    keyboardShouldPersistTaps="handled"
+                    nestedScrollEnabled
+                  >
+                    {CATEGORIES.map((cat, idx) => {
+                      const isLast = idx === CATEGORIES.length - 1;
+                      return (
+                        <TouchableOpacity
+                          key={cat}
+                          activeOpacity={0.85}
+                          style={[
+                            styles.dropdownOption,
+                            isLast && styles.dropdownOptionLast,
+                          ]}
+                          onPress={() => { setCategory(cat); setCategoryOpen(false); }}
+                        >
+                          <Text style={styles.dropdownOptionText}>{cat}</Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </ScrollView>
+                )}
+              </View>
+
+              {/* ── Recipient row (1030:1153) ─────────────────────────── */}
+              {/*
+                Figma: backdrop-blur:30, gradient 0.01→0, padding 8px (Spacing/XS),
+                TOP-ONLY corners rounded (radius 12) — rounded-tl-[12px] rounded-tr-[12px]
+                justify-between, items-start
+              */}
+              {/* Plain View — LinearGradient caused same double-border + width issues */}
+              <View style={styles.recipientRow}>
+                {/* Body S Italic: Inter Italic 16/24, #fdfdf9, flex:1 shrinks first */}
+                <Text style={styles.recipientLabel} numberOfLines={2}>
                   Do you have a recipient?
                 </Text>
 
-                <View style={styles.recipientButtons}>
+                {/* YES/NO checkboxes — gap:16, shrink-proof */}
+                <View style={styles.recipientChoices}>
                   <TouchableOpacity
+                    onPress={() => setHasRecipient('yes')}
+                    style={styles.choiceBtn}
                     activeOpacity={0.8}
-                    style={styles.recipientBtn}
-                    onPress={() => setRecipientChoice('yes')}
                   >
-                    <View
-                      style={[
-                        styles.radioOuter,
-                        recipientChoice === 'yes' && styles.radioOuterSelected,
-                      ]}
-                    >
-                      {recipientChoice === 'yes' && (
-                        <Text style={styles.checkMark}>✓</Text>
-                      )}
-                    </View>
-                    <Text
-                      style={[
-                        styles.recipientBtnText,
-                        recipientChoice === 'yes' &&
-                          styles.recipientBtnTextSelected,
-                      ]}
-                    >
-                      YES
-                    </Text>
+                    <CheckboxIcon checked={hasRecipient === 'yes'} />
+                    <Text style={styles.choiceLabel}>YES</Text>
                   </TouchableOpacity>
 
                   <TouchableOpacity
+                    onPress={() => setHasRecipient('no')}
+                    style={styles.choiceBtn}
                     activeOpacity={0.8}
-                    style={styles.recipientBtn}
-                    onPress={() => setRecipientChoice('no')}
                   >
-                    <View
-                      style={[
-                        styles.radioOuter,
-                        recipientChoice === 'no' && styles.radioOuterSelected,
-                      ]}
-                    >
-                      {recipientChoice === 'no' && (
-                        <Text style={styles.checkMark}>✓</Text>
-                      )}
-                    </View>
-                    <Text
-                      style={[
-                        styles.recipientBtnText,
-                        recipientChoice === 'no' &&
-                          styles.recipientBtnTextSelected,
-                      ]}
-                    >
-                      NO
-                    </Text>
+                    <CheckboxIcon checked={hasRecipient === 'no'} />
+                    <Text style={styles.choiceLabel}>NO</Text>
                   </TouchableOpacity>
                 </View>
               </View>
 
-              {/* Action buttons row - Updated Icons */}
+              {/* ── Action buttons row (220:2035) ─────────────────────── */}
+              {/*
+                Figma: flex gap:32 h:64 items-center justify-center w-full
+                3 buttons: T text, Mic, Videocam — each 72×64
+                Each: bg Bg/Surface, border 0.5px Border/Brand, radius 12, shadow,
+                padding 16v/20h — NOT gradient, flat fill
+              */}
               <View style={styles.actionRow}>
-                <ActionSquare
-                  icon={require('@assets/T_Icon.png')}
-                  selected={selectedMode === 'text'}
-                  onPress={() => setSelectedMode('text')}
-                />
-                <ActionSquare
-                  icon={require('@assets/mic.png')}
-                  selected={selectedMode === 'audio'}
-                  onPress={() => setSelectedMode('audio')}
-                />
-                <ActionSquare
-                  icon={require('@assets/videocam.png')}
-                  selected={selectedMode === 'video'}
-                  onPress={() => setSelectedMode('video')}
-                />
+                <ActionBtn selected={mode === 'text'}  onPress={() => setMode('text')}>
+                  <TextModeIcon />
+                </ActionBtn>
+                <ActionBtn selected={mode === 'audio'} onPress={() => setMode('audio')}>
+                  <MicModeIcon />
+                </ActionBtn>
+                <ActionBtn selected={mode === 'video'} onPress={() => setMode('video')}>
+                  <VideoModeIcon />
+                </ActionBtn>
               </View>
 
-              {/* Next Button - Updated to Standard Primary Action Style */}
-              <TouchableOpacity
-                activeOpacity={0.8}
+              {/* ── NEXT button (220:2042 — Component 2) ──────────────── */}
+              {/*
+                Figma: backdrop-blur:30, gradient 0.01→0, border 0.5px #a3b3cc (Border/Subtle),
+                radius 16 (Radius/M), padding 12v/16h, gap:8
+                Text: Heading S Cormorant Regular 24/28, #f2e1b0, warm glow shadow
+                Width: content-sized (not full width)
+              */}
+              <Button
+                variant="primary"
+                size="L"
+                title="NEXT"
                 onPress={onNext}
-                style={styles.nextWrap}
-              >
-                <LinearGradient
-                  colors={['rgba(253,253,249,0.04)', 'rgba(253,253,249,0.01)']}
-                  start={{ x: 0.5, y: 0 }}
-                  end={{ x: 0.5, y: 1 }}
-                  style={styles.nextGradient}
-                >
-                  <Text style={styles.nextText}>NEXT</Text>
-                </LinearGradient>
-              </TouchableOpacity>
+              />
+
             </View>
-          </ScrollView>
         </KeyboardAvoidingView>
 
-        {/* Category modal */}
-        <Modal
-          visible={categoryOpen}
-          transparent
-          animationType="fade"
-          onRequestClose={() => setCategoryOpen(false)}
-        >
-          <Pressable
-            style={styles.modalBackdrop}
-            onPress={() => setCategoryOpen(false)}
-          >
-            <Pressable style={[styles.modalCard, { width: contentWidth }]}>
-              <Text style={styles.modalTitle}>Choose a category</Text>
-
-              {CATEGORIES.map(c => (
-                <TouchableOpacity
-                  key={c}
-                  activeOpacity={0.85}
-                  style={styles.modalItem}
-                  onPress={() => {
-                    setCategory(c);
-                    setCategoryOpen(false);
-                  }}
-                >
-                  <Text style={styles.modalItemText}>{c}</Text>
-                </TouchableOpacity>
-              ))}
-            </Pressable>
-          </Pressable>
-        </Modal>
       </SafeAreaView>
     </BackgroundWrapper>
   );
 };
 
-const ActionSquare = ({
-  emoji,
-  icon,
-  onPress,
-  selected,
-}: {
-  emoji?: string;
-  icon?: any;
-  onPress: () => void;
-  selected?: boolean;
-}) => {
-  return (
-    <TouchableOpacity activeOpacity={0.9} onPress={onPress} style={{ flex: 1 }}>
-      <LinearGradient
-        colors={['rgba(253,253,249,0.05)', 'rgba(253,253,249,0.01)']} 
-        start={{ x: 0.5, y: 0 }}
-        end={{ x: 0.5, y: 1 }}
-        style={[
-            styles.actionShell, 
-            selected && { borderColor: GOLD, backgroundColor: 'rgba(242, 226, 177, 0.1)' } 
-        ]}
-      >
-        {icon ? (
-          <Image
-            source={icon}
-            style={{ width: 30, height: 30, tintColor: selected ? GOLD : 'rgba(242, 226, 177, 0.92)' }}
-            resizeMode="contain"
-          />
-        ) : (
-          <Text style={{ fontSize: 30, color: selected ? GOLD : 'rgba(242, 226, 177, 0.92)' }}>{emoji}</Text>
-        )}
-      </LinearGradient>
-    </TouchableOpacity>
-  );
-};
+export default NewEchoScreen;
 
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: 'transparent',
-    alignItems: 'center',
-  },
-  root: {
-    flex: 1,
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+
+const styles = StyleSheet.create<{
+  bg: ViewStyle;
+  safe: ViewStyle;
+  kav: ViewStyle;
+  dropdownList: ViewStyle;
+  content: ViewStyle;
+  // Header
+  headerRow: ViewStyle;
+  backBtn: ViewStyle;
+  screenTitle: TextStyle;
+  headerSpacer: ViewStyle;
+  // Title input
+  dropdownBackdrop: ViewStyle;
+  // Illustration
+  illustrationWrap: ViewStyle;
+  illustrationImg: ImageStyle;
+  // Category dropdown
+  dropdownWrap: ViewStyle;
+  dropdownShell: ViewStyle;
+  dropdownShellOpen: ViewStyle;
+  dropdownText: TextStyle;
+  dropdownPlaceholder: TextStyle;
+  dropdownOption: ViewStyle;
+  dropdownOptionLast: ViewStyle;
+  dropdownOptionText: TextStyle;
+  // Recipient row
+  recipientRow: ViewStyle;
+  recipientLabel: TextStyle;
+  recipientChoices: ViewStyle;
+  choiceBtn: ViewStyle;
+  choiceLabel: TextStyle;
+  // Action buttons
+  actionRow: ViewStyle;
+  actionBtn: ViewStyle;
+  actionBtnSelected: ViewStyle;
+  actionTextIcon: TextStyle;
+  actionImgIcon: ImageStyle;
+  // Modal
+  modalBackdrop: ViewStyle;
+  modalCard: ViewStyle;
+  modalTitle: TextStyle;
+  modalItem: ViewStyle;
+  modalItemText: TextStyle;
+}>({
+  bg:   { flex: 1 },
+  safe: { flex: 1, backgroundColor: 'transparent' },
+  kav:  { flex: 1, width: '100%' },
+
+  // Dropdown list — internally scrollable, maxHeight keeps it from taking
+  // over the screen. Only THESE items scroll, not the whole screen.
+  dropdownList: {
+    maxHeight: verticalScale(200),
   },
 
-  /* Header */
-  headerContainer: {
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
+  // Content column — gap:24 between all children
+  // alignItems:'stretch' (default) lets children with width:'100%' work correctly.
+  // Elements that need centering (illustration) use alignSelf:'center'.
+  content: {
+    flex:              1,
+    width:             '100%',
+    paddingHorizontal: scale(spacing.xl),         // 24px — Figma left:24
+    paddingTop:        verticalScale(spacing.l),  // breathing room below LogoHeader
+    paddingBottom:     verticalScale(spacing.xl),
+    gap:               verticalScale(spacing.xl), // 24px between sections
+  },
+
+  // ── Header row ──────────────────────────────────────────────────────────────
+  // Figma 222:2091 — justify-between, items-center, w-full
+  headerRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'space-between',
-    paddingHorizontal: 24,
-    marginTop: 20,
-    marginBottom: 10,
+    width:          '100%',
   },
   backBtn: {
-    width: 40,
-    height: 40,
+    width:          scale(44),
+    height:         scale(44),
     justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: 20,
-    backgroundColor: 'rgba(0,0,0,0.2)', // Add a subtle back for touch target
+    alignItems:     'flex-start',
   },
+  // Heading M: Cormorant Regular 28/32, #f2e1b0, glow text-shadow
   screenTitle: {
-    color: palette.gold.DEFAULT,
-    fontSize: 28,
-    letterSpacing: 2,
-    fontFamily: Platform.select({
-      ios: 'CormorantGaramond-Regular',
-      android: 'serif',
-    }),
-    textShadowColor: textShadow.glowSubtle.color,
-    textShadowOffset: textShadow.glowSubtle.offset,
-    textShadowRadius: 16,
+    fontFamily:       fontFamily.heading,
+    fontSize:         moderateScale(fontSize['2xl']),    // 28px
+    fontWeight:       fontWeight.regular,
+    lineHeight:       moderateScale(32),                 // font/line-height/XL
+    color:            palette.gold.DEFAULT,
+    textShadowColor:  'rgba(240,212,168,0.3)',
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 10,
   },
-  headerSpacer: {
-    width: 40, // Balance back button
+  headerSpacer: { width: scale(44) },
+
+  // Absolute backdrop — covers full screen, only rendered when dropdown is open.
+  // Tapping it closes the dropdown (outside-tap dismiss).
+  // zIndex -1 keeps it behind the dropdown list.
+  dropdownBackdrop: {
+    position:   'absolute',
+    top:        -200,
+    left:       -100,
+    right:      -100,
+    bottom:     -200,
+    zIndex:     -1,
   },
 
-  scrollContent: {
-    flexGrow: 1,
-    alignItems: 'center',
-    paddingBottom: 60,
-  },
-  content: {
-    paddingTop: 10,
-    alignItems: 'center',
-    width: '100%',
-  },
-
-  /* Title Input */
-  inputShell: {
-    width: '100%',
-    height: 48,
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: palette.navy.light, // var(--border/subtle)
-    marginBottom: 24,
-    justifyContent: 'center',
-  },
-  inputContainer: {
-    paddingHorizontal: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  textInput: {
-    color: palette.gold.subtlest, // var(--text/paragraph-2)
-    fontSize: 16, // var(--font/size/s)
-    fontFamily: 'Inter', // var(--font/family/body)
-    fontStyle: 'italic',
-    textAlign: 'center',
-    width: '100%',
-  },
-
-  /* Illustration */
+  // ── Illustration (780:1043) ──────────────────────────────────────────────────
+  // Figma container: 216×200, image larger than container (overflows)
   illustrationWrap: {
-    width: '100%',
-    alignItems: 'center',
+    width:          scale(216),
+    height:         scale(200),
+    alignItems:     'center',
     justifyContent: 'center',
-    height: 200,
-    marginTop: 16,
-    marginBottom: 16,
+    overflow:       'visible',
+    alignSelf:      'center',
   },
-  illustrationImage: {
-    height: 200,
+  illustrationImg: {
+    width:  scale(216),
+    height: scale(200),
   },
 
-  /* Dropdown */
+  // ── Category dropdown (Component2 / 734:1307) ────────────────────────────────
+  // gradient 0.01→0, border 0.25px Border/Inverse-1 (#60739f), h:48, radius 12
+  dropdownWrap: { width: '100%' },
+  // Plain View — no LinearGradient to avoid iOS double-border artifact.
+  // Gradient was rgba(253,253,249,0.01)→0 = near-invisible anyway.
   dropdownShell: {
-    width: '100%',
-    borderRadius: 12,
-    borderWidth: 0.25,
-    borderColor: palette.navy.medium, // var(--border/inverse-1)
-    // Wait, in Figma, Component 2 (Dropdown) is above the recipient block.
-    marginBottom: 24,
-    height: 48,
-    justifyContent: 'center',
+    width:             '100%',
+    height:            verticalScale(48),
+    borderRadius:      radius.s,                        // 12px
+    borderWidth:       borderWidth.hairline,            // 0.25px
+    borderColor:       palette.navy.medium,             // #60739f (Border/Inverse-1)
+    backgroundColor:   'transparent',
+    flexDirection:     'row',
+    alignItems:        'center',
+    justifyContent:    'space-between',
+    paddingHorizontal: scale(spacing.m),                // 16px
+    paddingVertical:   verticalScale(spacing.s),        // 12px
+    gap:               scale(10),
   },
-  dropdownContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-  },
+  // Body S Italic: Inter Italic 16/24, #fdfdf9, center (flex:1 makes it fill space)
   dropdownText: {
-    flex: 1,
-    color: palette.gold.subtlest,
-    fontSize: 16,
-    fontFamily: 'Inter',
-    fontStyle: 'italic',
-    textAlign: 'center',
+    flex:       1,
+    fontFamily: fontFamily.bodyItalic,
+    fontStyle:  'italic',
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.subtlest,
+    textAlign:  'center',
   },
-  dropdownLeft: {
-    width: 24,
-  },
-  dropdownRight: {
-    width: 24,
-    alignItems: 'flex-end',
-  },
-
-  /* Recipient Block - Horizontal Layout */
-  recipientBlock: {
-    width: '100%',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    marginBottom: 24,
-  },
-  recipientQuestion: {
-    color: palette.gold.subtlest,
-    fontSize: 16,
-    fontFamily: 'Inter',
-    fontStyle: 'italic',
-    flex: 1,
-  },
-  recipientButtons: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 24,
-  },
-  recipientBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  radioOuter: {
-    width: 16,
-    height: 16,
-    borderRadius: 0,
-    borderWidth: 1,
-    borderColor: GOLD,
-    backgroundColor: 'transparent',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  radioOuterSelected: {
-    backgroundColor: 'rgba(215,192,138,0.7)',
-  },
-  checkMark: {
-    color: palette.navy.card,
-    fontSize: 10,
-    fontWeight: 'bold',
-    lineHeight: 13,
-  },
-  recipientBtnText: {
-    color: GOLD,
-    fontSize: 14,
-    fontFamily: Platform.select({
-      ios: 'Inter-Regular',
-      android: 'sans-serif',
-    }),
-  },
-  recipientBtnTextSelected: {
-    fontWeight: '700',
+  // When closed, full radius. When open, flatten bottom corners.
+  dropdownShellOpen: {
+    borderBottomLeftRadius:  0,
+    borderBottomRightRadius: 0,
   },
 
-  /* Action Row */
-  actionRow: {
-    width: '100%',
-    flexDirection: 'row',
-    justifyContent: 'space-between', // gap 32px in Figma, assume justify-between handles for small screens, or gap.
-    gap: 24,
-    marginBottom: 0,
-    paddingHorizontal: 48,
+  dropdownPlaceholder: { opacity: 0.7 },
+
+  // Inline dropdown option row — Figma 734:1306
+  // bg: rgba(253,253,249,0.05) (Bg/Surface-Raised), border 0.25px #60739f
+  dropdownOption: {
+    backgroundColor:  'rgba(253,253,249,0.05)',
+    borderWidth:      borderWidth.hairline,
+    borderColor:      palette.navy.medium,
+    paddingVertical:  verticalScale(spacing.s),
+    paddingHorizontal: scale(spacing.m),
+    alignItems:       'center',
+    justifyContent:   'center',
   },
-  actionShell: {
-    flex: 1, // Distribute evenly
-    height: 72, // Fixed height from Figma
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: palette.gold.DEFAULT, // var(--border/brand)
-    alignItems: 'center',
-    justifyContent: 'center',
-    // Shadow from Figma
-    ...Platform.select({
-      ios: {
-        shadowColor: palette.gold.DEFAULT,
-        shadowOffset: { width: 2, height: 2 },
-        shadowOpacity: 0.2,
-        shadowRadius: 32,
-        elevation: 5,
-      },
-      android: {
-        boxShadow: '2px 2px 32px 0px rgba(242, 226, 177, 0.20)',
-      },
-    }),
+  // Last option: rounded bottom corners (Radius/XS = 8px per Figma)
+  dropdownOptionLast: {
+    borderBottomLeftRadius:  8,
+    borderBottomRightRadius: 8,
+  },
+  // Option text: Inter Regular 16/24, #f2e1b0 (gold — NOT white/placeholder)
+  dropdownOptionText: {
+    fontFamily: fontFamily.body,
+    fontWeight: fontWeight.regular,
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
+    textAlign:  'center',
   },
 
-  /* Next Button */
-  nextWrap: {
-    alignSelf: 'center',
-    marginTop: 20,
+  // ── Recipient row (1030:1153) ─────────────────────────────────────────────────
+  // gradient 0.01→0, TOP-ONLY radius 12, padding 8px (Spacing/XS), justify-between
+  // Plain View — no LinearGradient (same double-border artifact as input).
+  // Gradient was 0.01→0 = near-invisible; replaced with transparent bg.
+  // flexShrink on label ensures long text yields space to YES/NO buttons
+  // rather than pushing them off screen.
+  recipientRow: {
+    flexDirection:       'row',
+    alignItems:          'center',
+    justifyContent:      'space-between',
+    padding:             scale(spacing.xs),             // 8px (Spacing/XS)
+    borderTopLeftRadius: radius.s,                      // Figma: rounded-tl-[12px]
+    borderTopRightRadius: radius.s,                     // Figma: rounded-tr-[12px]
+    backgroundColor:     'transparent',
   },
-  nextGradient: {
+  // Body S Italic: Inter Italic 16/24, #fdfdf9
+  // flex:1 + flexShrink:1 allow label to shrink if total row overflows
+  recipientLabel: {
+    fontFamily: fontFamily.bodyItalic,
+    fontStyle:  'italic',
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.subtlest,
+    flex:       1,
+    flexShrink: 1,
+    marginRight: scale(spacing.xs),                     // gap from label to YES/NO
+  },
+  // YES/NO choices: flex-row with fixed gap, no shrink so they always show fully
+  recipientChoices: {
     flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    minHeight: 48,
-    borderRadius: 12,
-    borderWidth: 0.5,
-    borderColor: palette.navy.light,
+    alignItems:    'center',
+    gap:           scale(spacing.m),                    // 16px (Spacing/M)
+    flexShrink:    0,                                   // never compress choices
   },
-  nextText: {
-    fontFamily: 'CormorantGaramond-Medium',
-    fontSize: 28,
+  choiceBtn: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           scale(spacing.xs),                   // 8px (Spacing/XS)
+  },
+  // Body S Medium: Inter 500 16/24, #f2e1b0
+  choiceLabel: {
+    fontFamily: fontFamily.body,
     fontWeight: '500',
-    color: palette.gold.warm,
-    textShadowColor: textShadow.glowSubtle.color,
-    textShadowOffset: textShadow.glowSubtle.offset,
-    textShadowRadius: textShadow.glowSubtle.radius,
-    textTransform: 'uppercase',
-    padding: 10,
+    fontSize:   moderateScale(fontSize.s),
+    lineHeight: moderateScale(24),
+    color:      palette.gold.DEFAULT,
   },
 
-  /* Modal */
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.55)',
-    alignItems: 'center',
+  // ── Action buttons row (220:2035) ─────────────────────────────────────────────
+  // flex gap:32 h:64 items-center justify-center w-full
+  actionRow: {
+    flexDirection:  'row',
+    alignItems:     'center',
     justifyContent: 'center',
-    paddingHorizontal: 18,
+    gap:            scale(32),
+    width:          '100%',
+    height:         verticalScale(64),
+  },
+  // Each action button: Bg/Surface, border 0.5px Border/Brand, radius 12, shadow, 72×64
+  // Figma: bg rgba(163,179,204,0.05) — flat, NOT gradient
+  actionBtn: {
+    width:           scale(72),
+    height:          verticalScale(64),
+    borderRadius:    radius.s,                          // 12px
+    borderWidth:     borderWidth.thin,                  // 0.5px
+    borderColor:     palette.gold.DEFAULT,              // Border/Brand #f2e1b0
+    backgroundColor: palette.surface.DEFAULT,          // Bg/Surface rgba(163,179,204,0.05)
+    alignItems:      'center',
+    justifyContent:  'center',
+    paddingVertical:  verticalScale(spacing.m),         // 16px (Spacing/M)
+    paddingHorizontal: scale(spacing.l),                // 20px (Spacing/L)
+    // Figma: shadow 0 0 15px rgba(242,226,177,0.3)
+    boxShadow:       '0px 0px 15px 0px rgba(242, 226, 177, 0.3)',
+    shadowColor:     palette.gold.warm,
+    shadowOffset:    { width: 0, height: 0 },
+    shadowOpacity:   0.3,
+    shadowRadius:    15,
+    elevation:       6,
+  },
+  // Selected: subtle gold bg highlight only — icon colour stays gold always
+  actionBtnSelected: {
+    backgroundColor: 'rgba(242,226,177,0.1)',
+  },
+  // T icon: Cormorant Garamond serif "T", 28px, gold — matches Figma imgProperty1Text
+  actionTextIcon: {
+    fontFamily: fontFamily.heading,
+    fontSize:   moderateScale(32),
+    fontWeight: fontWeight.regular,
+    color:      palette.gold.DEFAULT,
+    lineHeight: moderateScale(32),
+  },
+  // Mic/video icons: 29×32 container to match Figma icon dimensions, always gold tint
+  actionImgIcon: {
+    width:     scale(29),
+    height:    scale(32),
+    tintColor: palette.gold.DEFAULT,
+  },
+
+  // ── Modal ──────────────────────────────────────────────────────────────────────
+  modalBackdrop: {
+    flex:            1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems:      'center',
+    justifyContent:  'center',
+    paddingHorizontal: scale(spacing.xl),
   },
   modalCard: {
-    borderRadius: 18,
+    width:           '100%',
+    borderRadius:    radius.m,
     backgroundColor: 'rgba(10,12,18,0.96)',
-    borderWidth: 1,
-    borderColor: 'rgba(215,192,138,0.25)',
-    padding: 14,
+    borderWidth:     borderWidth.regular,
+    borderColor:     'rgba(215,192,138,0.25)',
+    padding:         scale(spacing.m),
   },
   modalTitle: {
-    color: 'rgba(215,192,138,0.92)',
-    fontSize: 16,
-    letterSpacing: 1,
-    marginBottom: 10,
-    textAlign: 'center',
+    fontFamily:   fontFamily.heading,
+    fontSize:     moderateScale(fontSize.xl),
+    fontWeight:   fontWeight.regular,
+    color:        palette.gold.DEFAULT,
+    textAlign:    'center',
+    marginBottom: verticalScale(spacing.s),
   },
   modalItem: {
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: 'rgba(253,253,249,0.10)',
-    marginBottom: 10,
-    backgroundColor: 'rgba(253,253,249,0.04)',
+    paddingVertical:   verticalScale(spacing.s),
+    paddingHorizontal: scale(spacing.s),
+    borderRadius:      radius.s,
+    borderWidth:       borderWidth.thin,
+    borderColor:       'rgba(253,253,249,0.10)',
+    marginBottom:      verticalScale(spacing.xs),
+    backgroundColor:   'rgba(253,253,249,0.04)',
   },
   modalItemText: {
-    color: OFFWHITE,
-    fontSize: 15,
-    textAlign: 'center',
+    fontFamily: fontFamily.body,
+    fontSize:   moderateScale(fontSize.s),
+    color:      palette.gold.subtlest,
+    textAlign:  'center',
   },
 });
-
-export default NewEchoScreen;

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -27,6 +27,7 @@ export interface EchoResponse {
     name: string;
     email: string;
     motif?: string;
+    profile_image_url?: string;   // uploaded photo, shown in vault list
   };
   /** Present on inbox echoes — the user who created and sent the echo. */
   sender?: {
@@ -72,6 +73,7 @@ export interface CreateRecipientRequest {
   email: string;
   relationship?: string;
   motif?: string;
+  profile_image_url?: string;   // S3 URL after upload, not a local file:// URI
 }
 
 export class EchoApiService extends BaseApiService {
@@ -138,13 +140,33 @@ export class EchoApiService extends BaseApiService {
     return ApiErrorHandler.handleApiResponse(response, 'Echo deleted');
   }
 
-  async getUploadUrl(fileType: string, echoId: string): Promise<ApiResponse<UploadUrlResponse>> {
-    // fileType should be MIME type like 'audio/m4a' or 'video/mp4'
+  /**
+   * Get a presigned S3 upload URL.
+   *
+   * @param fileType   MIME type e.g. 'audio/m4a', 'video/mp4', 'image/jpeg'
+   * @param echoId     Required for echo media (audio/video/text attachments).
+   *                   Omit for non-echo uploads (e.g. profile images) — backend
+   *                   generates the URL without an echo association.
+   * @param uploadType Hint to the backend: 'echo' (default) | 'profile'.
+   *                   Allows the backend to apply appropriate S3 path/policy.
+   *
+   * All callers share the same endpoint and the same uploadMedia() utility,
+   * so no separate API is needed for profile images.
+   */
+  async getUploadUrl(
+    fileType: string,
+    echoId?: string,
+    uploadType: 'echo' | 'profile' = 'echo',
+  ): Promise<ApiResponse<UploadUrlResponse>> {
     const response = await this.makeRequest<UploadUrlResponse>(
       '/api/echoes/upload-url',
       'POST',
-      { file_type: fileType, echo_id: echoId },
-      true
+      {
+        file_type:   fileType,
+        upload_type: uploadType,
+        ...(echoId ? { echo_id: echoId } : {}),
+      },
+      true,
     );
     return ApiErrorHandler.handleApiResponse(response, 'Upload URL retrieved');
   }


### PR DESCRIPTION
- AddNewProfileScreen: photo picker + S3 upload pipeline (getUploadUrl/uploadMedia) reuses existing echo endpoint with uploadType:'profile', no separate API needed
- ChooseRecipientScreen: Figma-accurate layout, calendar icon matches placeholder color, dropdown dismiss on outside tap, labels use design token colors
- NewEchoVaultScreen: plain View inputs (fixes double-border iOS artifact), inline dropdown, action icons always gold tintColor
- EchoVaultLibraryScreen: EchoAvatar wired to recipient.profile_image_url
- echo.ts: getUploadUrl accepts optional echoId + uploadType:'echo'|'profile'; CreateRecipientRequest + EchoResponse.recipient include profile_image_url