### PR TITLE
fix: restore session on cold start, extend inactivity to 24h

### DIFF
--- a/MirrorCollectiveApp/src/context/SessionContext.tsx
+++ b/MirrorCollectiveApp/src/context/SessionContext.tsx
@@ -11,6 +11,7 @@ import React, {
 import { authApiService } from '@services/api';
 import { authEvents } from '@services/authEvents';
 import PushNotificationService from '@services/PushNotificationService';
+import { tokenManager } from '@services/tokenManager';
 
 // Types
 interface SessionState {
@@ -112,20 +113,21 @@ export const SessionProvider = ({ children }: SessionProviderProps) => {
 
         safeDispatch({ type: 'SET_LOADING', payload: true });
 
-        // Clear tokens on app start as per original logic
+        // Restore session from persisted tokens. tokenManager.isAuthenticated()
+        // will silently refresh an expired access token using the refresh token,
+        // so the user-perceived session lasts as long as Cognito's refresh
+        // token (default 30 days) instead of getting cleared on every cold start.
+        let restored = false;
         try {
-          await authApiService.clearTokens();
-          if (__DEV__) {
-            console.log('Cleared authentication tokens on app initialization');
-          }
+          restored = await tokenManager.isAuthenticated();
         } catch (error) {
           if (__DEV__) {
-            console.warn('Failed to clear tokens during initialization:', error);
+            console.warn('Session restore check failed:', error);
           }
         }
 
         if (!isMountedRef.current || !isInitializing) return;
-        safeDispatch({ type: 'LOGOUT_SUCCESS' });
+        safeDispatch({ type: restored ? 'LOGIN_SUCCESS' : 'LOGOUT_SUCCESS' });
       } catch (error) {
         console.error('Auth initialization error:', error);
         if (isMountedRef.current && isInitializing) {

--- a/MirrorCollectiveApp/src/hooks/useInactivityTimer.ts
+++ b/MirrorCollectiveApp/src/hooks/useInactivityTimer.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 
-const INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const INACTIVITY_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 interface UseInactivityTimerProps {
   isEnabled: boolean;
@@ -9,10 +9,10 @@ interface UseInactivityTimerProps {
 }
 
 /**
- * Tracks user inactivity and fires `onTimeout` after 5 minutes.
+ * Tracks user inactivity and fires `onTimeout` after 24 hours.
  * Covers two scenarios:
- *   1. No touch activity for 5 continuous minutes while app is in foreground.
- *   2. App returns to foreground after being backgrounded for 5+ minutes.
+ *   1. No touch activity for 24 continuous hours while app is in foreground.
+ *   2. App returns to foreground after being backgrounded for 24h+.
  *
  * Returns `resetTimer` — call this on every user touch to keep the session alive.
  */


### PR DESCRIPTION
The session was being wiped on every app launch because SessionContext unconditionally called clearTokens() during initializeAuth, defeating the persistent token storage. Cold-start now calls tokenManager.isAuthenticated(), which silently refreshes an expired access token using the refresh token (Cognito default 30-day refresh window) and only logs the user out when no valid session can be restored.

Also bumps the inactivity timer from 5 minutes to 24 hours as a soft safety net, since the user-perceived session is now driven by the silent refresh path rather than the timer.

No backend changes: Cognito access tokens stay at 1h, refresh tokens at 30d, and the existing refresh flow in tokenManager + api/base.ts handles the rest.