### PR TITLE
fix(echoes): release after edit no longer gated on PATCH response status

### DIFF
--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoComposeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoComposeScreen.tsx
@@ -320,12 +320,12 @@ const NewEchoComposeScreen: React.FC<Props> = ({ navigation, route }) => {
         if (!updateResponse.success) throw new Error('Failed to update echo.');
 
         // If the resulting state matches the auto-release rule
-        // (recipient + no lock date) and the echo is still in DRAFT, fire
-        // the release endpoint to mirror what create_echo would have done.
-        // We swallow ValidationError from /release — that signals the echo
-        // was already RELEASED or otherwise ineligible, which is fine here.
-        const shouldRelease = !!recipientId && !lockDate &&
-          updateResponse.data?.status === 'DRAFT';
+        // (recipient + no lock date), fire the release endpoint to mirror
+        // what create_echo would have done. The edit icon is hidden for
+        // non-DRAFT echoes so by the time we get here the echo was DRAFT;
+        // releaseEcho's preconditions on the backend handle any edge case,
+        // and the try/catch swallows ValidationError if it slips through.
+        const shouldRelease = !!recipientId && !lockDate;
         if (shouldRelease) {
           try {
             await echoApiService.releaseEcho(editEchoId);


### PR DESCRIPTION
The release-after-save branch in NewEchoComposeScreen depended on updateResponse.data?.status === 'DRAFT' to decide whether to fire the release endpoint. The PATCH response doesn't return status, so the check was always false and the release call never ran — echoes saved with a recipient and no lock date stayed in DRAFT instead of transitioning to RELEASED. The visible symptom was: open a saved echo, clear the lock date, save → echo unchanged, edit icon still visible.

The guard was over-defensive. By the time the user reaches the save button the echo was DRAFT (the edit icon is hidden for non-DRAFT echoes; the backend rejects PATCH on non-DRAFT anyway). The release call has a try/catch that swallows ValidationError for any edge case, so we don't need a pre-check.

Pairs with a backend fix that also widens the PATCH response to the full echo projection — both reach the same end state from different sides.