### PR TITLE
fix(echoes): edit save returns to vault library, not stack root

### DIFF
--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoComposeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoComposeScreen.tsx
@@ -337,7 +337,13 @@ const NewEchoComposeScreen: React.FC<Props> = ({ navigation, route }) => {
         Alert.alert(
           'Success',
           shouldRelease ? 'Echo sent!' : 'Echo updated!',
-          [{ text: 'OK', onPress: () => navigation.popToTop() }],
+          [{
+            text: 'OK',
+            // Match the create flow: drop the user back into the vault
+            // library so they can see the row update in context, rather
+            // than popping all the way to the stack root (TalkToMirror).
+            onPress: () => navigation.navigate('MirrorEchoVaultLibrary' as any),
+          }],
         );
         return;
       }


### PR DESCRIPTION
navigation.popToTop() was popping all the way to TalkToMirror (the first route in the stack) after a successful edit, which made the user lose context — they expected to land back where they started the edit, the Echo Vault library.

Switch to navigation.navigate('MirrorEchoVaultLibrary'), matching what the create-flow branch (line 344) already does. Both create and edit now end at the same screen.