### PR TITLE
feat(api): client-side 429 retry-with-backoff in BaseApiService

### DIFF
--- a/MirrorCollectiveApp/src/services/api/base.test.ts
+++ b/MirrorCollectiveApp/src/services/api/base.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for BaseApiService — focused on the 429 retry-with-backoff path.
+ *
+ * Other request behavior (auth header, JSON parse, graceful 5xx handling)
+ * is exercised through the per-service test files (auth.test, echo.test,
+ * subscriptionApi etc.).
+ */
+
+import { BaseApiService } from './base';
+
+// --- Mocks ---------------------------------------------------------------
+
+jest.mock('@services/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('mock-token'),
+  },
+}));
+
+jest.mock('@services/authEvents', () => ({
+  authEvents: { emitSessionExpired: jest.fn() },
+}));
+
+// Graceful-handling shim — return false so the 429 actually throws and
+// our retry loop gets a chance to fire (instead of being absorbed into a
+// graceful envelope).
+jest.mock('./errorHandler', () => ({
+  ApiErrorHandler: {
+    handleApiResponse: jest.fn(r => r),
+    handleSystemError: jest.fn(() => ({ success: false, error: 'sys' })),
+    shouldHandleGracefully: jest.fn(() => false),
+  },
+}));
+
+jest.mock('@constants/config', () => ({
+  API_CONFIG: { HOST: 'https://api.example.test', TIMEOUT: 5000 },
+}));
+
+global.fetch = jest.fn();
+
+// --- Subclass exposing the protected makeRequest --------------------------
+
+class TestApiService extends BaseApiService {
+  call<T = any>(
+    endpoint: string,
+    method: 'GET' | 'POST' = 'GET',
+    body?: any,
+  ): Promise<any> {
+    return this.makeRequest<T>(endpoint, method, body, false);
+  }
+}
+
+const svc = new TestApiService();
+
+// Tiny helper that returns a Headers-like object for our fake responses.
+function makeResponse(opts: {
+  status?: number;
+  ok?: boolean;
+  body?: any;
+  retryAfter?: string;
+}): any {
+  const status = opts.status ?? 200;
+  const headers = new Map<string, string>();
+  if (opts.retryAfter !== undefined) {
+    headers.set('retry-after', opts.retryAfter);
+  }
+  return {
+    ok: opts.ok ?? (status >= 200 && status < 300),
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    json: async () => opts.body ?? {},
+  };
+}
+
+// --- Tests ----------------------------------------------------------------
+
+describe('BaseApiService — 429 retry-with-backoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Make Math.random deterministic so the jitter math doesn't flake CI.
+    jest.spyOn(Math, 'random').mockReturnValue(0); // → minimum jittered delay
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes through a 200 response without retrying', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeResponse({ status: 200, body: { success: true, data: [] } }),
+    );
+
+    const result = await svc.call('/api/whatever');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('retries on 429 then succeeds on the second attempt', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        makeResponse({ status: 429, body: { error: 'Slow down' } }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse({ status: 200, body: { success: true } }),
+      );
+
+    const result = await svc.call('/api/x');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+
+  it('honors numeric Retry-After header for the wait time', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        makeResponse({
+          status: 429,
+          body: { error: 'Slow down' },
+          retryAfter: '1', // 1 second
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse({ status: 200, body: { success: true } }),
+      );
+
+    const start = Date.now();
+    await svc.call('/api/x');
+    const elapsed = Date.now() - start;
+
+    // Should be at least ~1000ms (the Retry-After) and not absurdly more.
+    expect(elapsed).toBeGreaterThanOrEqual(950);
+    expect(elapsed).toBeLessThan(2500);
+  });
+
+  it('gives up after MAX_429_RETRIES and rethrows the last 429', async () => {
+    // Always 429 — 1 initial + 3 retries = 4 fetch calls expected.
+    (global.fetch as jest.Mock).mockResolvedValue(
+      makeResponse({ status: 429, body: { error: 'Throttled' } }),
+    );
+
+    await expect(svc.call('/api/x')).rejects.toMatchObject({ status: 429 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('does NOT retry non-429 errors', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeResponse({ status: 500, body: { error: 'boom' } }),
+    );
+
+    await expect(svc.call('/api/x')).rejects.toMatchObject({ status: 500 });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('also retries 429 on POST (server tells us "not processed")', async () => {
+    // 429 means "we didn't process your request" → safe to retry even
+    // for mutating methods.
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        makeResponse({ status: 429, body: { error: 'slow' } }),
+      )
+      .mockResolvedValueOnce(
+        makeResponse({ status: 200, body: { success: true } }),
+      );
+
+    const result = await svc.call('/api/x', 'POST', { foo: 'bar' });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/base.ts
+++ b/MirrorCollectiveApp/src/services/api/base.ts
@@ -6,6 +6,51 @@ import { tokenManager } from '@services/tokenManager';
 
 import { ApiErrorHandler } from './errorHandler';
 
+// ---------------------------------------------------------------------------
+// 429 retry-with-backoff
+// ---------------------------------------------------------------------------
+// API Gateway now throttles at 1000 RPS sustained / 5000 burst (see backend
+// `infra/replace-in-memory-rate-limiter-with-apigw-throttling`). Without
+// client-side retry, transient throttling surfaces as opaque red toasts.
+// We retry 429s up to MAX_429_RETRIES times with exponential-backoff +
+// jitter. If the server sends a `Retry-After` header (seconds or HTTP date),
+// we honor it as the base delay instead of computing one.
+const MAX_429_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 8000;
+
+/** Sleep with cancellation support. */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Compute the wait time before retry N (0-indexed). Honors a `Retry-After`
+ *  header if the server set one; otherwise uses exponential backoff with
+ *  full jitter. Capped at RETRY_MAX_DELAY_MS to bound user-visible latency. */
+function computeRetryDelayMs(
+  attempt: number,
+  retryAfterHeader: string | null,
+): number {
+  if (retryAfterHeader) {
+    // Two valid formats per RFC 7231: integer seconds, or an HTTP date.
+    const asSeconds = Number(retryAfterHeader);
+    if (Number.isFinite(asSeconds) && asSeconds >= 0) {
+      return Math.min(asSeconds * 1000, RETRY_MAX_DELAY_MS);
+    }
+    const asDateMs = Date.parse(retryAfterHeader);
+    if (!Number.isNaN(asDateMs)) {
+      const deltaMs = asDateMs - Date.now();
+      if (deltaMs > 0) {
+        return Math.min(deltaMs, RETRY_MAX_DELAY_MS);
+      }
+    }
+  }
+  // Exponential backoff with full jitter: random in [0, base * 2^attempt].
+  const exponential = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+  const jittered = Math.random() * exponential;
+  return Math.min(jittered, RETRY_MAX_DELAY_MS);
+}
+
 export class BaseApiService {
   public readonly baseUrl: string;
   private readonly timeout: number;
@@ -16,6 +61,50 @@ export class BaseApiService {
   }
 
   protected async makeRequest<T = any>(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' = 'GET',
+    data?: any,
+    requiresAuth: boolean = false,
+    extraHeaders?: Record<string, string>,
+  ): Promise<ApiResponse<T>> {
+    let lastError: any;
+    for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
+      try {
+        return await this._attemptRequest<T>(
+          endpoint,
+          method,
+          data,
+          requiresAuth,
+          extraHeaders,
+        );
+      } catch (error: any) {
+        lastError = error;
+        // Retry only on 429. Any other error (network, 4xx, 5xx) is
+        // surfaced immediately — the caller's existing error handling
+        // applies. We don't retry POST/PUT/DELETE for non-429 because
+        // the server may have already processed the request.
+        if (
+          error?.status === 429 &&
+          attempt < MAX_429_RETRIES
+        ) {
+          const retryAfter = error?.retryAfter ?? null;
+          const delayMs = computeRetryDelayMs(attempt, retryAfter);
+          console.warn(
+            `[API] 429 on ${method} ${endpoint}; ` +
+              `retry ${attempt + 1}/${MAX_429_RETRIES} in ${Math.round(delayMs)}ms`,
+          );
+          await sleep(delayMs);
+          continue;
+        }
+        throw error;
+      }
+    }
+    // Exhausted retries — rethrow the last 429 so callers can present a
+    // "still being rate-limited" message.
+    throw lastError;
+  }
+
+  private async _attemptRequest<T = any>(
     endpoint: string,
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' = 'GET',
     data?: any,
@@ -80,7 +169,15 @@ export class BaseApiService {
         }
         // Extract error message from response data
         const errorMessage = responseData?.error || responseData?.message || `Server error: ${response.status}`;
-        throw this.createApiError(errorMessage, response.status);
+        const err = this.createApiError(errorMessage, response.status);
+        // Attach Retry-After (if present) so the outer retry loop can
+        // honor it. Only meaningful for 429, but always attaching is
+        // cheap and avoids a branch.
+        const retryAfter = response.headers.get('retry-after');
+        if (retryAfter) {
+          (err as any).retryAfter = retryAfter;
+        }
+        throw err;
       }
 
       return { ...responseData, statusCode: response.status };


### PR DESCRIPTION
API Gateway now throttles at 1000 RPS sustained / 5000 burst (set by backend infra/replace-in-memory-rate-limiter-with-apigw-throttling). Without client-side retry, transient throttling surfaces as opaque red error toasts on the user. This PR adds:

- A retry loop around makeRequest that fires only on HTTP 429 (any other 4xx/5xx propagates immediately to existing handlers).
- Max 3 retries (4 attempts total).
- Honors the server's `Retry-After` header (numeric seconds OR HTTP date format per RFC 7231). Capped at 8 s so the user doesn't wait forever on an aggressive value.
- Falls back to exponential backoff with full jitter when the server doesn't send the header — base 500 ms, doubles per attempt, capped at 8 s.
- Retries 429 on POST/PUT/DELETE too. 429 specifically means "we did not process your request" — safe to retry even for mutating methods. Server-side idempotency is a separate concern (covered by the backend Wave 2 idempotency-keys PR, not yet shipped).

Implementation pattern: outer `makeRequest` wraps the original logic (now extracted to `_attemptRequest`) in a for-loop. On 429 → sleep then continue; on any other error → throw immediately.

Tests (6 new, all pass):
- 200 passes through with no retry
- 429 → 200 succeeds after one retry
- Numeric Retry-After header honored (elapsed >= 1000ms when header = "1")
- Exhausted retries throws the last 429 (verified 4 fetch calls)
- 500 does NOT retry (only 429 does)
- 429 on POST also retries

All 19 API test suites still green.