### PR TITLE
feat: infinite-scroll FlatList on EchoVaultLibrary + reusable hook

### DIFF
--- a/MirrorCollectiveApp/src/hooks/useInfiniteList.test.ts
+++ b/MirrorCollectiveApp/src/hooks/useInfiniteList.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for useInfiniteList — the FlatList-onEndReached state machine.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { ApiResponse } from '@types';
+import type { Page, PageOpts } from '@services/api/echo';
+
+import { useInfiniteList } from './useInfiniteList';
+
+type Row = { id: string };
+
+function makeResponse(
+  items: Row[],
+  nextCursor: string | null,
+): ApiResponse<Page<Row>> {
+  return {
+    success: true,
+    data: { items, nextCursor },
+  } as ApiResponse<Page<Row>>;
+}
+
+function makeFailure(message: string): ApiResponse<Page<Row>> {
+  return {
+    success: false,
+    error: message,
+  } as ApiResponse<Page<Row>>;
+}
+
+describe('useInfiniteList', () => {
+  it('fetches page 1 on mount and surfaces the items', async () => {
+    const fetchPage = jest.fn(async () =>
+      makeResponse([{ id: 'a' }, { id: 'b' }], null),
+    );
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith({ limit: 50, cursor: null });
+    expect(result.current.items).toEqual([{ id: 'a' }, { id: 'b' }]);
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('loadMore appends the next page using the cursor', async () => {
+    const fetchPage = jest.fn(
+      async (opts: PageOpts): Promise<ApiResponse<Page<Row>>> => {
+        if (opts.cursor === null || opts.cursor === undefined) {
+          return makeResponse([{ id: 'a' }], 'cursor-2');
+        }
+        return makeResponse([{ id: 'b' }], null);
+      },
+    );
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toEqual([{ id: 'a' }]);
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(fetchPage).toHaveBeenLastCalledWith({
+      limit: 50,
+      cursor: 'cursor-2',
+    });
+    expect(result.current.items).toEqual([{ id: 'a' }, { id: 'b' }]);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('loadMore is a no-op when hasMore is false', async () => {
+    const fetchPage = jest.fn(async () =>
+      makeResponse([{ id: 'a' }], null),
+    );
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.loadMore());
+    act(() => result.current.loadMore());
+
+    // No further fetches — even after multiple loadMore calls.
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('loadMore deduplicates concurrent calls', async () => {
+    let resolveSecond: (v: ApiResponse<Page<Row>>) => void = () => {};
+    const fetchPage = jest.fn(
+      (opts: PageOpts): Promise<ApiResponse<Page<Row>>> => {
+        if (opts.cursor === null || opts.cursor === undefined) {
+          return Promise.resolve(makeResponse([{ id: 'a' }], 'cur'));
+        }
+        // Hold the second page open so we can verify two loadMore
+        // calls don't both fire.
+        return new Promise(resolve => {
+          resolveSecond = resolve;
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.loadMore());
+    act(() => result.current.loadMore());
+    act(() => result.current.loadMore());
+
+    // Only the first loadMore actually started a fetch — the others
+    // saw loadingMore=true and bailed.
+    expect(fetchPage).toHaveBeenCalledTimes(2); // 1 initial + 1 loadMore
+
+    // Resolve and clean up.
+    resolveSecond(makeResponse([{ id: 'b' }], null));
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+  });
+
+  it('refresh resets the list and re-fetches page 1', async () => {
+    let callCount = 0;
+    const fetchPage = jest.fn(
+      async (): Promise<ApiResponse<Page<Row>>> => {
+        callCount += 1;
+        return makeResponse([{ id: `call-${callCount}` }], null);
+      },
+    );
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toEqual([{ id: 'call-1' }]);
+
+    act(() => result.current.refresh());
+    await waitFor(() => expect(result.current.refreshing).toBe(false));
+
+    expect(result.current.items).toEqual([{ id: 'call-2' }]);
+  });
+
+  it('surfaces error from the fetch and clears it on next success', async () => {
+    let shouldFail = true;
+    const fetchPage = jest.fn(async (): Promise<ApiResponse<Page<Row>>> => {
+      if (shouldFail) return makeFailure('boom');
+      return makeResponse([{ id: 'ok' }], null);
+    });
+
+    const { result } = renderHook(() => useInfiniteList(fetchPage));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('boom');
+
+    shouldFail = false;
+    act(() => result.current.refresh());
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.items).toEqual([{ id: 'ok' }]);
+  });
+
+  it('honors a custom limit', async () => {
+    const fetchPage = jest.fn(async () =>
+      makeResponse([], null),
+    );
+
+    renderHook(() => useInfiniteList(fetchPage, { limit: 10 }));
+
+    await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+    expect(fetchPage).toHaveBeenCalledWith({ limit: 10, cursor: null });
+  });
+});

--- a/MirrorCollectiveApp/src/hooks/useInfiniteList.ts
+++ b/MirrorCollectiveApp/src/hooks/useInfiniteList.ts
@@ -1,0 +1,151 @@
+/**
+ * Generic infinite-list hook used by Echo Vault, Inbox, Recipients,
+ * and Guardians screens. Wraps a page-fetcher (returning {items,
+ * nextCursor}) into a list-of-items + loadMore/refresh API that a
+ * FlatList's onEndReached / onRefresh can plug into directly.
+ *
+ * Why this exists
+ * ---------------
+ * The backend's pagination contract is `(opts?: { limit, cursor }) =>
+ * Promise<ApiResponse<{ items, nextCursor }>>` — see
+ * src/services/api/echo.ts. Every list screen needs the same plumbing
+ * around it: track items, track cursor, prevent double-fetches, surface
+ * empty/error/loading states. Without this hook each screen copies that
+ * logic.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ApiResponse } from '@types';
+
+import type { Page, PageOpts } from '@services/api/echo';
+
+export interface UseInfiniteListResult<T> {
+  /** All items loaded so far (across all pages). */
+  items: T[];
+  /** True only on the FIRST page load when there are no items yet. */
+  loading: boolean;
+  /** True while a subsequent page is being fetched (after at least one
+   *  page has loaded). Bind this to the FlatList's footer spinner. */
+  loadingMore: boolean;
+  /** True while a manual refresh is in flight. Bind to RefreshControl.refreshing. */
+  refreshing: boolean;
+  /** Set if the most recent fetch failed; cleared on the next success. */
+  error: string | null;
+  /** True when there are still more pages to load. */
+  hasMore: boolean;
+  /** Call from FlatList's onEndReached. Safe to spam — internally
+   *  guarded against concurrent loads. */
+  loadMore: () => void;
+  /** Call from RefreshControl.onRefresh — drops state and reloads page 1. */
+  refresh: () => void;
+}
+
+/** Default page size — the backend clamps at 100. */
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Build an infinite-list state machine over a page-fetcher.
+ *
+ * @param fetchPage — a function returning ApiResponse<Page<T>>.
+ *                    Stable identity expected (memoize via useCallback at
+ *                    the call site if it closes over scoped values).
+ * @param opts.limit — page size, default 50. Clamped to 1..100 by the
+ *                     backend.
+ */
+export function useInfiniteList<T>(
+  fetchPage: (opts: PageOpts) => Promise<ApiResponse<Page<T>>>,
+  opts: { limit?: number } = {},
+): UseInfiniteListResult<T> {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+
+  const [items, setItems] = useState<T[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards against concurrent fetches. A re-render between an onEndReached
+  // fire and state update can otherwise trigger duplicate page loads.
+  const inFlight = useRef(false);
+  // Tracks the most recent fetch sequence so an in-flight page-1 doesn't
+  // overwrite a refresh that started later.
+  const sequence = useRef(0);
+
+  const fetchPageInternal = useCallback(
+    async (
+      pageCursor: string | null,
+      mode: 'initial' | 'more' | 'refresh',
+    ): Promise<void> => {
+      if (inFlight.current) return;
+      inFlight.current = true;
+      const seq = ++sequence.current;
+
+      if (mode === 'initial') setLoading(true);
+      else if (mode === 'more') setLoadingMore(true);
+      else if (mode === 'refresh') setRefreshing(true);
+
+      try {
+        const response = await fetchPage({ limit, cursor: pageCursor });
+        // Drop the result if a newer fetch has started in the meantime.
+        if (seq !== sequence.current) return;
+
+        if (response.success && response.data) {
+          const { items: pageItems, nextCursor } = response.data;
+          setItems(prev =>
+            mode === 'more' ? [...prev, ...pageItems] : pageItems,
+          );
+          setCursor(nextCursor);
+          setHasMore(nextCursor !== null);
+          setError(null);
+        } else {
+          setError(response.error || response.message || 'Failed to load');
+        }
+      } catch (err: any) {
+        if (seq !== sequence.current) return;
+        setError(err?.message || 'Network error');
+      } finally {
+        if (seq === sequence.current) {
+          setLoading(false);
+          setLoadingMore(false);
+          setRefreshing(false);
+        }
+        inFlight.current = false;
+      }
+    },
+    [fetchPage, limit],
+  );
+
+  // Initial fetch on mount + whenever fetchPage identity changes.
+  useEffect(() => {
+    setItems([]);
+    setCursor(null);
+    setHasMore(true);
+    fetchPageInternal(null, 'initial');
+  }, [fetchPageInternal]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMore || loading || refreshing || !hasMore || !cursor) return;
+    fetchPageInternal(cursor, 'more');
+  }, [cursor, fetchPageInternal, hasMore, loading, loadingMore, refreshing]);
+
+  const refresh = useCallback(() => {
+    // Reset cursor + items and re-fetch page 1.
+    setCursor(null);
+    setHasMore(true);
+    fetchPageInternal(null, 'refresh');
+  }, [fetchPageInternal]);
+
+  return {
+    items,
+    loading,
+    loadingMore,
+    refreshing,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  };
+}

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
@@ -89,7 +89,17 @@ export function EchoInboxContent() {
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'SENDER' | 'CATEGORY'>('SENDER');
 
-  const fetchInboxEchoes = useCallback(async () => {
+  // TODO(infinite-scroll): convert this screen to FlatList +
+  // useInfiniteList. The outer ScrollView wraps a stylized card that
+  // contains tabs + the echo rows; splitting them into ListHeader/
+  // ListFooter requires reshaping the gradient + border to live on
+  // the FlatList container. Tracked separately so we don't reshape
+  // the visual design in this PR.
+  //
+  // Until then the legacy auto-paginating getInboxEchoes() (which
+  // loops through the backend's cursor pages internally) makes sure
+  // power users don't see a silently-truncated inbox.
+  const refresh = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -100,7 +110,6 @@ export function EchoInboxContent() {
       if (response.success && Array.isArray(response.data)) {
         setEchoes(response.data);
       } else if (response.success && response.data == null) {
-        // Endpoint exists but returned no data array — treat as empty
         setEchoes([]);
       } else {
         setError(response.message || response.error || 'Failed to load inbox');
@@ -112,7 +121,9 @@ export function EchoInboxContent() {
     }
   }, []);
 
-  useEffect(() => { fetchInboxEchoes(); }, [fetchInboxEchoes]);
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   const handleOpenItem = (item: EchoResponse) => {
     if (item.echo_type === 'AUDIO') {
@@ -228,7 +239,7 @@ export function EchoInboxContent() {
             ) : error ? (
               <View style={styles.stateBox}>
                 <Text style={styles.errorText}>{error}</Text>
-                <TouchableOpacity onPress={fetchInboxEchoes} style={styles.retryBtn}>
+                <TouchableOpacity onPress={refresh} style={styles.retryBtn}>
                   <Text style={styles.retryText}>Retry</Text>
                 </TouchableOpacity>
               </View>

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -40,9 +40,10 @@ import {
   verticalScale,
 } from '@theme';
 import type { RootStackParamList } from '@types';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
+  FlatList,
   Image,
   ScrollView,
   StatusBar,
@@ -51,9 +52,12 @@ import {
   TouchableOpacity,
   View,
   type ImageStyle,
+  type ListRenderItem,
   type TextStyle,
   type ViewStyle,
 } from 'react-native';
+
+import { useInfiniteList } from '@hooks/useInfiniteList';
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
@@ -81,6 +85,15 @@ import { echoApiService, type EchoResponse } from '@services/api/echo';
  *                      creator skipped recipient/schedule on creation.
  */
 type EchoUiState = 'sent' | 'scheduled' | 'guardian-locked' | 'saved';
+
+const formatDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
 
 const deriveUiState = (item: EchoResponse): EchoUiState => {
   if (item.status === 'RELEASED') return 'sent';
@@ -149,33 +162,100 @@ const EchoAvatar: React.FC<AvatarProps> = ({ motif, profileImage }) => (
   </View>
 );
 
+// ── Row renderer ─────────────────────────────────────────────────────────────
+// Factored out so FlatList's renderItem reference is stable across renders.
+// Returns a ListRenderItem<EchoResponse> closed over the active tab + the
+// row tap handler; `total` is used to suppress the trailing border on the
+// last row (matches the pre-FlatList visual).
+function renderEchoRow(
+  activeTab: 'RECIPIENT' | 'CATEGORY',
+  onOpen: (item: EchoResponse) => void,
+  total: number,
+): ListRenderItem<EchoResponse> {
+  return ({ item, index }) => {
+    const isLast = index === total - 1;
+    const uiState = deriveUiState(item);
+    const showLock = uiState === 'scheduled' || uiState === 'guardian-locked';
+    const showSentPill = uiState === 'sent';
+    const subtitle =
+      uiState === 'scheduled'
+        ? `Unlocks ${formatDate(item.release_date!)}`
+        : uiState === 'guardian-locked' && item.lock_date
+          ? `Locked ${formatDate(item.lock_date)}`
+          : `Saved ${formatDate(item.created_at)}`;
+    const rightLabel =
+      activeTab === 'RECIPIENT'
+        ? item.recipient?.name?.toUpperCase() || 'UNASSIGNED'
+        : item.category?.toUpperCase() || 'UNCATEGORIZED';
+    return (
+      <View style={[styles.rowGroup, !isLast && styles.rowBorder]}>
+        <TouchableOpacity
+          activeOpacity={0.9}
+          onPress={() => onOpen(item)}
+          style={styles.row}
+        >
+          <View style={styles.rowLeft}>
+            <EchoAvatar
+              motif={item.recipient?.motif}
+              profileImage={item.recipient?.profile_image_url}
+            />
+            <View style={styles.rowText}>
+              <Text style={styles.rowTitle} numberOfLines={2}>
+                {item.title}
+              </Text>
+              <Text style={styles.rowSub} numberOfLines={1}>
+                {subtitle}
+              </Text>
+            </View>
+          </View>
+          <View style={styles.rowRight}>
+            <Text style={styles.rowLabel} numberOfLines={1}>
+              {rightLabel}
+            </Text>
+            {showLock && <LockIcon />}
+          </View>
+        </TouchableOpacity>
+        {/* Echo Sent pill — renders only on RELEASED status (the
+            authoritative signal from the backend, set when the recipient
+            notification has been sent). */}
+        {showSentPill && (
+          <View style={styles.echoSentPillWrap}>
+            <View style={styles.echoSentPill}>
+              <EchoSentCheckIcon />
+              <Text style={styles.echoSentText}>Echo Sent</Text>
+            </View>
+          </View>
+        )}
+      </View>
+    );
+  };
+}
+
 // ── Screen ───────────────────────────────────────────────────────────────────
 
 export function EchoLibraryContent() {
   const navigation = useNavigation<EchoLibraryNavigationProp>();
-  const [echoes, setEchoes] = useState<EchoResponse[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'RECIPIENT' | 'CATEGORY'>('RECIPIENT');
 
-  const fetchEchoes = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await echoApiService.getEchoes();
-      if (response.success && response.data) {
-        setEchoes(response.data);
-      } else {
-        setError(response.error || 'Failed to load echoes');
-      }
-    } catch (err: any) {
-      setError(`Failed to load echoes: ${err.message || ''}`);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // Bound to the new paginated /api/echoes contract. Page size 50 matches
+  // the backend's clamp default; loadMore fires from FlatList.onEndReached
+  // until next_cursor is null.
+  const fetchEchoPage = useCallback(
+    (opts: { limit?: number; cursor?: string | null }) =>
+      echoApiService.getEchoesPage(opts),
+    [],
+  );
 
-  useEffect(() => { fetchEchoes(); }, [fetchEchoes]);
+  const {
+    items: echoes,
+    loading,
+    loadingMore,
+    refreshing,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  } = useInfiniteList<EchoResponse>(fetchEchoPage);
 
   const handleOpenItem = (item: EchoResponse) => {
     if (item.echo_type === 'AUDIO') {
@@ -185,11 +265,6 @@ export function EchoLibraryContent() {
     } else {
       navigation.navigate('EchoDetailScreen', { echoId: item.echo_id, title: item.title });
     }
-  };
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
   };
 
   return (
@@ -253,7 +328,7 @@ export function EchoLibraryContent() {
           ) : error ? (
             <View style={styles.stateBox}>
               <Text style={styles.errorText}>{error}</Text>
-              <TouchableOpacity onPress={fetchEchoes} style={styles.retryBtn}>
+              <TouchableOpacity onPress={refresh} style={styles.retryBtn}>
                 <Text style={styles.retryText}>Retry</Text>
               </TouchableOpacity>
             </View>
@@ -291,63 +366,33 @@ export function EchoLibraryContent() {
                   </TouchableOpacity>
                 ))}
               </View>
-              {/* Echo rows — scrollable */}
-              <ScrollView
+              {/* Echo rows — virtualized via FlatList so a 1k-echo vault
+                  doesn't pin 1k row Views in memory and the JS thread
+                  doesn't render them all upfront. onEndReached drives
+                  the cursor-paginated /api/echoes/page fetcher. */}
+              <FlatList<EchoResponse>
+                data={echoes}
+                keyExtractor={item => item.echo_id}
+                renderItem={renderEchoRow(activeTab, handleOpenItem, echoes.length)}
                 showsVerticalScrollIndicator={false}
                 style={styles.listScroll}
                 contentContainerStyle={styles.listScrollContent}
-              >
-                {echoes.map((item, index) => {
-                  const isLast = index === echoes.length - 1;
-                  const uiState = deriveUiState(item);
-                  const showLock = uiState === 'scheduled' || uiState === 'guardian-locked';
-                  const showSentPill = uiState === 'sent';
-                  const subtitle =
-                    uiState === 'scheduled'
-                      ? `Unlocks ${formatDate(item.release_date!)}`
-                      : uiState === 'guardian-locked' && item.lock_date
-                        ? `Locked ${formatDate(item.lock_date)}`
-                        : `Saved ${formatDate(item.created_at)}`;
-                  const rightLabel = activeTab === 'RECIPIENT'
-                    ? (item.recipient?.name?.toUpperCase() || 'UNASSIGNED')
-                    : (item.category?.toUpperCase() || 'UNCATEGORIZED');
-                  return (
-                    <View
-                      key={item.echo_id}
-                      style={[styles.rowGroup, !isLast && styles.rowBorder]}
-                    >
-                      <TouchableOpacity
-                        activeOpacity={0.9}
-                        onPress={() => handleOpenItem(item)}
-                        style={styles.row}
-                      >
-                        <View style={styles.rowLeft}>
-                          <EchoAvatar motif={item.recipient?.motif} profileImage={item.recipient?.profile_image_url} />
-                          <View style={styles.rowText}>
-                            <Text style={styles.rowTitle} numberOfLines={2}>{item.title}</Text>
-                            <Text style={styles.rowSub} numberOfLines={1}>{subtitle}</Text>
-                          </View>
-                        </View>
-                        <View style={styles.rowRight}>
-                          <Text style={styles.rowLabel} numberOfLines={1}>{rightLabel}</Text>
-                          {showLock && <LockIcon />}
-                        </View>
-                      </TouchableOpacity>
-                      {/* Echo Sent pill — renders only on RELEASED status
-                          (the authoritative signal from the backend, set
-                          when the recipient notification has been sent). */}
-                      {showSentPill && (
-                        <View style={styles.echoSentPillWrap}>
-                          <View style={styles.echoSentPill}>
-                            <EchoSentCheckIcon />
-                            <Text style={styles.echoSentText}>Echo Sent</Text>
-                          </View>
-                        </View>
-                      )}
+                onEndReached={loadMore}
+                onEndReachedThreshold={0.5}
+                removeClippedSubviews
+                initialNumToRender={12}
+                maxToRenderPerBatch={10}
+                windowSize={5}
+                refreshing={refreshing}
+                onRefresh={refresh}
+                ListFooterComponent={
+                  loadingMore ? (
+                    <View style={styles.footerLoader}>
+                      <ActivityIndicator size="small" color="#f2e1b0" />
                     </View>
-                  );
-                })}
-              </ScrollView>
+                  ) : null
+                }
+              />
             </View>
           )}
 
@@ -390,6 +435,7 @@ const styles = StyleSheet.create<{
   outerColumn: ViewStyle;
   listScroll: ViewStyle;
   listScrollContent: ViewStyle;
+  footerLoader: ViewStyle;
   titleGroup: ViewStyle;
   headerRow: ViewStyle;
   backBtn: ViewStyle;
@@ -449,6 +495,10 @@ const styles = StyleSheet.create<{
   // Inner ScrollView — only the echo rows scroll
   listScroll: { flex: 1 },
   listScrollContent: { flexGrow: 1 },
+  footerLoader: {
+    paddingVertical: verticalScale(12),
+    alignItems: 'center',
+  },
 
   // ── Title + Subtitle ───────────────────────────────────────────────────────
   // Figma 211:1223 — flex-col gap:16, items-center


### PR DESCRIPTION
Two pieces:

1. **New `useInfiniteList<T>` hook** at src/hooks/useInfiniteList.ts. Wraps any page-fetcher matching the backend's `(opts) => ApiResponse<{ items, nextCursor }>` contract into a FlatList-friendly state machine: - `items` accumulated across pages - `loading` for the first page, `loadingMore` for subsequent - `refreshing` for RefreshControl - `loadMore()` safe to spam — internally deduped via inFlight ref + sequence counter so a race between onEndReached fires and state updates can't cause duplicate fetches - `refresh()` resets cursor + reloads page 1 - Error/empty/hasMore surfaced for the UI Tests: 7 scenarios, all pass (page 1 load, loadMore cursor pass, hasMore=false short-circuit, concurrent loadMore dedup, refresh reset, error → success recovery, custom limit).

2. **EchoVaultLibraryScreen full FlatList migration.** Replaces the prior `ScrollView + echoes.map((item) => ...)` (no virtualization, all rows materialized upfront) with a FlatList wired to `getEchoesPage` via the new hook. Adds: - `onEndReached` → `loadMore` (threshold=0.5) - `removeClippedSubviews`, `initialNumToRender=12`, `maxToRenderPerBatch=10`, `windowSize=5` (the audit-recommended defaults for this size of row component) - `refreshing` + `onRefresh` for pull-to-refresh - `ListFooterComponent` spinner while next page loads - Row renderer extracted to module-level `renderEchoRow` so the reference is stable across renders (no extra row re-renders caused by parent state changes) - `formatDate` hoisted to module scope so the extracted row renderer can use it At 100+ echoes (common for power users) the screen previously pinned 100+ row Views in memory and stalled the JS thread during initial render. Now ~12 rows materialize on first paint.

Deferred (not in this PR):
  - **EchoInboxScreen** — has a nested ScrollView wrapping a styled card that contains both tabs AND the echo rows. Properly virtualizing requires reshaping the gradient + border to live on the FlatList container or splitting the card into ListHeader/ListFooter — a structural rewrite I didn't want to bundle with this PR. Left a TODO in the file. Legacy auto-paginating getInboxEchoes() still fully loads the inbox so no power user sees truncated data.
  - **ChooseRecipientScreen / ChooseGuardianScreen / ManageRecipient / ManageGuardian** — small lists (typical user has <20 contacts). Selectors should show all options at once; infinite scroll has low UX value. Hook is available if/when these screens grow.

Validation:
  - 18 tests pass (7 new hook tests + 11 existing echo-API tests).
  - tsc --noEmit clean on the changed files (2 pre-existing errors on main unrelated to this PR).