### PR TITLE
fix: attach JWT to RR telemetry; correct /auth/logout path to /api/au…

### DIFF
--- a/MirrorCollectiveApp/src/features/reflection-room/__tests__/telemetry.test.ts
+++ b/MirrorCollectiveApp/src/features/reflection-room/__tests__/telemetry.test.ts
@@ -3,11 +3,24 @@
  *  - firePracticeExpand POSTs the right shape to /api/telemetry/event.
  *  - Failures don't throw (fire-and-forget).
  *  - Body is IDs/enums only (no PII / free text).
+ *  - Authorization header carries the user's JWT (post-Cognito-authorizer
+ *    fix — without this, RR telemetry events 401 silently).
+ *  - No fetch fires when there's no session.
  */
 
 import { firePracticeExpand, fireTelemetry } from '../api/telemetry';
 
+jest.mock('@services/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('mock-jwt-token'),
+  },
+}));
+
 const originalFetch = global.fetch;
+
+// Pull in the mocked tokenManager so individual tests can override the
+// getValidToken return for the "no session" / "expired session" paths.
+import { tokenManager } from '@services/tokenManager';
 
 afterAll(() => {
   (global as any).fetch = originalFetch;
@@ -19,6 +32,7 @@ describe('Reflection Room telemetry', () => {
   beforeEach(() => {
     fetchMock = jest.fn().mockResolvedValue({ ok: true });
     (global as any).fetch = fetchMock;
+    (tokenManager.getValidToken as jest.Mock).mockResolvedValue('mock-jwt-token');
   });
 
   it('firePracticeExpand POSTs the expected JSON body', async () => {
@@ -38,6 +52,29 @@ describe('Reflection Room telemetry', () => {
     });
   });
 
+  it('includes the JWT bearer token in the Authorization header', async () => {
+    await fireTelemetry({
+      event: 'practice_expand',
+      body: { loop_id: 'pressure', surface: 'echo_signature' },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer mock-jwt-token');
+  });
+
+  it('skips the request entirely when there is no session', async () => {
+    (tokenManager.getValidToken as jest.Mock).mockResolvedValueOnce(null);
+
+    await fireTelemetry({
+      event: 'echo_map_refresh',
+      body: {},
+    });
+
+    // No session = no fetch. Better to drop silently than to fire a
+    // request we know the API Gateway authorizer will 401.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('fireTelemetry never throws — even when fetch rejects', async () => {
     fetchMock.mockRejectedValueOnce(new Error('network down'));
     // Should resolve, not reject.
@@ -46,6 +83,15 @@ describe('Reflection Room telemetry', () => {
         event: 'practice_expand',
         body: { loop_id: 'overwhelm', surface: 'mirror_moment' },
       }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fireTelemetry never throws — even when tokenManager rejects', async () => {
+    (tokenManager.getValidToken as jest.Mock).mockRejectedValueOnce(
+      new Error('keychain unavailable'),
+    );
+    await expect(
+      fireTelemetry({ event: 'echo_map_refresh', body: {} }),
     ).resolves.toBeUndefined();
   });
 

--- a/MirrorCollectiveApp/src/features/reflection-room/api/telemetry.ts
+++ b/MirrorCollectiveApp/src/features/reflection-room/api/telemetry.ts
@@ -20,6 +20,7 @@
  */
 
 import { API_CONFIG } from '@constants/config';
+import { tokenManager } from '@services/tokenManager';
 
 import type { LoopId, PracticeSurface } from '../types/ids';
 
@@ -30,19 +31,33 @@ export type RRTelemetryEvent =
 
 /**
  * POSTs a telemetry event to the backend's `/telemetry/event` endpoint.
- * Authentication uses the same JWT pattern as other RR endpoints
- * (handled by the caller — typically the screen passes a fetch wrapper).
  *
- * For V1 we use plain fetch so a transport hiccup doesn't surface as
- * a thrown ReflectionRoomApiError to the UI.
+ * Authentication: Reflection Room is post-signup, so a JWT exists by
+ * the time any of these events fire. The API Gateway authorizer rejects
+ * unauthenticated requests with 401, so we must include the bearer
+ * token. We fetch it via tokenManager (same path the rest of the API
+ * client uses) — if no token is present we skip the call entirely
+ * rather than firing an event we know will 401.
+ *
+ * Fire-and-forget by design — any thrown error (network, 4xx, 5xx) is
+ * swallowed so the UI flow never breaks because telemetry hiccuped.
  */
 export async function fireTelemetry(payload: RRTelemetryEvent): Promise<void> {
   try {
+    const token = await tokenManager.getValidToken();
+    if (!token) {
+      // No session = no user to attribute the event to. Drop silently
+      // (vs. firing an anonymous request that the authorizer will 401).
+      return;
+    }
     await fetch(
       `${API_CONFIG.HOST}${API_CONFIG.ENDPOINTS.REFLECTION_ROOM.TELEMETRY_EVENT}`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(payload),
       },
     );

--- a/MirrorCollectiveApp/src/services/api/auth.test.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.test.ts
@@ -48,11 +48,53 @@ describe('AuthApiService', () => {
   describe('isAuthenticated', () => {
     it('delegates to tokenManager', async () => {
       (tokenManager.isAuthenticated as jest.Mock).mockResolvedValueOnce(true);
-      
+
       const result = await authService.isAuthenticated();
-      
+
       expect(result).toBe(true);
       expect(tokenManager.isAuthenticated).toHaveBeenCalled();
+    });
+  });
+
+  describe('signOut', () => {
+    it('POSTs to /api/auth/logout (not the legacy /auth/logout path)', async () => {
+      (tokenManager.getValidToken as jest.Mock).mockResolvedValueOnce(
+        'mock-jwt-token',
+      );
+
+      await authService.signOut();
+
+      // Verify the URL includes the /api prefix that matches the backend
+      // router mount (app.include_router(api_router, prefix="/api")).
+      // The prior /auth/logout was a 404 — tokens cleared client-side but
+      // Cognito session never invalidated server-side.
+      expect(global.fetch).toHaveBeenCalled();
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(String(url)).toContain('/api/auth/logout');
+      // Regression guard for the previous bare /auth/logout path —
+      // strip the base URL first, then check the remainder starts
+      // with /api/.
+      const path = String(url).replace(/^https?:\/\/[^/]+/, '');
+      expect(path.startsWith('/api/auth/logout')).toBe(true);
+      expect(init.method).toBe('POST');
+    });
+
+    it('clears tokens even when the server call fails', async () => {
+      (tokenManager.getValidToken as jest.Mock).mockResolvedValueOnce(
+        'mock-jwt-token',
+      );
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'boom' }),
+      });
+
+      await authService.signOut();
+
+      // Client-side cleanup must run regardless of server outcome — a
+      // user tapping "Log out" should ALWAYS see the auth stack again,
+      // even if the network is down.
+      expect(tokenManager.clearTokens).toHaveBeenCalled();
     });
   });
 });

--- a/MirrorCollectiveApp/src/services/api/auth.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.ts
@@ -115,8 +115,14 @@ export class AuthApiService extends BaseApiService {
   }
 
   async signOut(): Promise<ApiResponse> {
+    // Backend route is mounted under `/api` (see app/handler.py
+    // include_router(api_router, prefix="/api")), so the full path is
+    // `/api/auth/logout`. The previous `/auth/logout` produced a 404 on
+    // the gateway — tokens were still cleared client-side so the user
+    // saw a successful sign-out, but the Cognito session was never
+    // server-side invalidated.
     const response = await this.makeRequest<any>(
-      '/auth/logout',
+      '/api/auth/logout',
       'POST',
       {},
       true,


### PR DESCRIPTION
…th/logout

Two small auth-plumbing bugs surfaced by the cross-PR pre-auth-endpoint sweep on the backend authorizer.

1. **fireTelemetry was firing without an Authorization header.** The in-file docstring claimed "Authentication uses the same JWT pattern as other RR endpoints," but the code never added the header. With the Cognito JWT authorizer on the HTTP API, every Reflection Room telemetry beacon was being rejected with 401 — and since ``fireTelemetry`` catches all errors silently (fire-and-forget), no user-visible failure: just complete silent loss of the practice_expand / nudge_opened / echo_map_refresh events the team depends on for product observability.

   Fix: pull the bearer token via ``tokenManager.getValidToken()`` (same pattern the rest of the API client uses) and add the header. If no session exists we drop the request entirely rather than firing one we know will 401.

2. **auth.signOut was POSTing to /auth/logout.** Backend router is mounted under /api (app/handler.py: include_router(api_router, prefix="/api")), so the real path is /api/auth/logout. The legacy path returned 404. Tokens were still cleared client-side so the user saw a successful sign-out, but the Cognito session was never server-side invalidated — refresh tokens stayed valid for their full 30-day window even after the user "logged out".

Tests added:
  - fireTelemetry: Authorization header carries the JWT; no fetch fires when tokenManager returns null; fireTelemetry never throws even when tokenManager rejects.
  - signOut: URL is /api/auth/logout (regression guard against the bare /auth/logout); clearTokens runs even on 5xx.

12 tests pass across the two touched files (7 telemetry + 5 auth). The 1 unrelated test failure in ReflectionRoomQuizEntryScreen is pre-existing on main, not caused by this PR.