### PR TITLE
perf(upload): multipart upload client for files >50 MB

### DIFF
--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -10,6 +10,11 @@ import { uuidV4 } from '@utils/uuid';
 
 import { BaseApiService } from './base';
 import { ApiErrorHandler } from './errorHandler';
+import {
+  MULTIPART_THRESHOLD,
+  getFileSize,
+  uploadMediaMultipart,
+} from './multipart';
 
 /**
  * Strip the `file://` scheme from a local URI. react-native-blob-util's
@@ -121,6 +126,16 @@ export interface UploadUrlResponse {
   /** Bucket the upload lands in (informational; clients rarely need it). */
   bucket: string;
   expires_in: number;
+}
+
+export interface MultipartInitiateResponse {
+  upload_id: string;
+  key: string;
+  bucket: string;
+}
+
+export interface MultipartPartUrlsResponse {
+  part_urls: Array<{ part_number: number; url: string }>;
 }
 
 export interface Guardian {
@@ -574,6 +589,76 @@ export class EchoApiService extends BaseApiService {
     return ApiErrorHandler.handleApiResponse(response, 'Media finalized');
   }
 
+  // ========== Multipart upload (files > MULTIPART_THRESHOLD) ==========
+  //
+  // Wraps the four backend routes that bridge to S3's MultipartUpload
+  // API. Used by uploadEchoMedia when the source file is large enough
+  // that the single-PUT path becomes lossy on cellular. The actual
+  // orchestration (slice → upload parts → complete) lives in
+  // services/api/multipart.ts; these are just typed wrappers around
+  // makeRequest.
+
+  async initiateMultipart(
+    echoId: string,
+    fileType: string,
+  ): Promise<ApiResponse<MultipartInitiateResponse>> {
+    const response = await this.makeRequest<MultipartInitiateResponse>(
+      `/api/echoes/${encodeURIComponent(echoId)}/multipart/initiate`,
+      'POST',
+      { file_type: fileType },
+      true,
+      { 'Idempotency-Key': uuidV4() },
+    );
+    return ApiErrorHandler.handleApiResponse(response, 'Multipart upload initiated');
+  }
+
+  async getMultipartPartUrls(
+    echoId: string,
+    uploadId: string,
+    key: string,
+    partNumbers: number[],
+  ): Promise<ApiResponse<MultipartPartUrlsResponse>> {
+    // NOT idempotency-keyed — the server doesn't cache these either,
+    // because the presigned URLs themselves rotate every call.
+    const response = await this.makeRequest<MultipartPartUrlsResponse>(
+      `/api/echoes/${encodeURIComponent(echoId)}/multipart/part-urls`,
+      'POST',
+      { upload_id: uploadId, key, part_numbers: partNumbers },
+      true,
+    );
+    return ApiErrorHandler.handleApiResponse(response, 'Part URLs generated');
+  }
+
+  async completeMultipart(
+    echoId: string,
+    uploadId: string,
+    key: string,
+    parts: Array<{ part_number: number; etag: string }>,
+  ): Promise<ApiResponse<EchoResponse>> {
+    const response = await this.makeRequest<EchoResponse>(
+      `/api/echoes/${encodeURIComponent(echoId)}/multipart/complete`,
+      'POST',
+      { upload_id: uploadId, key, parts },
+      true,
+      { 'Idempotency-Key': uuidV4() },
+    );
+    return ApiErrorHandler.handleApiResponse(response, 'Multipart upload completed');
+  }
+
+  async abortMultipart(
+    echoId: string,
+    uploadId: string,
+    key: string,
+  ): Promise<ApiResponse<void>> {
+    const response = await this.makeRequest<void>(
+      `/api/echoes/${encodeURIComponent(echoId)}/multipart/abort`,
+      'POST',
+      { upload_id: uploadId, key },
+      true,
+    );
+    return ApiErrorHandler.handleApiResponse(response, 'Multipart upload aborted');
+  }
+
   /**
    * End-to-end echo-media upload: compress → presign → stream → finalize.
    *
@@ -627,7 +712,22 @@ export class EchoApiService extends BaseApiService {
     }
 
     try {
-      // 2. Ask the backend for a presigned PUT URL + the S3 key it picked.
+      // 2. Decide single-PUT vs multipart based on (post-compression)
+      // file size. Anything we can't measure (PHAsset-style URI before
+      // export) defaults to single-PUT.
+      const fileSize = await getFileSize(workingUri);
+      if (fileSize !== null && fileSize >= MULTIPART_THRESHOLD) {
+        return await uploadMediaMultipart({
+          api: this,
+          echoId,
+          fileUri: workingUri,
+          contentType,
+          fileSize,
+          onStage,
+        });
+      }
+
+      // 3. Single-PUT path. Ask the backend for a presigned PUT URL.
       onStage?.({ type: 'requesting_url' });
       const presigned = await this.getUploadUrl(contentType, echoId, 'echo');
       if (!presigned.success || !presigned.data) {
@@ -635,7 +735,7 @@ export class EchoApiService extends BaseApiService {
       }
       const { upload_url, key } = presigned.data;
 
-      // 3. Stream the (possibly compressed) file to S3.
+      // 4. Stream the (possibly compressed) file to S3.
       await this.uploadMedia(
         upload_url,
         workingUri,
@@ -645,7 +745,7 @@ export class EchoApiService extends BaseApiService {
         },
       );
 
-      // 4. Atomic commit. Server HEADs S3, captures truth, writes DDB.
+      // 5. Atomic commit. Server HEADs S3, captures truth, writes DDB.
       // If this fails, the bytes are in S3 but the echo row has no
       // media_url — the user must re-attempt media attach. We surface
       // a specific error message so the UI can tell them so.

--- a/MirrorCollectiveApp/src/services/api/multipart.test.ts
+++ b/MirrorCollectiveApp/src/services/api/multipart.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for the multipart-upload orchestrator.
+ *
+ * Mocks at the boundary: ReactNativeBlobUtil's fs + fetch surfaces, and
+ * the EchoApiService methods that wrap the four backend routes. Asserts
+ * the end-to-end pipeline shape (initiate → slice → presign → upload →
+ * complete) plus failure / abort behavior.
+ */
+
+import { uploadMediaMultipart, MULTIPART_THRESHOLD } from './multipart';
+
+// Pull the same mock surface BaseApiService tests use.
+const mockFetch = jest.fn();
+const mockWrap = jest.fn((p: string) => `WRAPPED:${p}`);
+const mockSlice = jest.fn();
+const mockUnlink = jest.fn();
+const mockMkdir = jest.fn();
+const mockStat = jest.fn();
+
+jest.mock('react-native-blob-util', () => ({
+  __esModule: true,
+  default: {
+    fetch: (...args: unknown[]) => mockFetch(...args),
+    wrap: (p: string) => mockWrap(p),
+    fs: {
+      dirs: { CacheDir: '/cache' },
+      slice: (...args: unknown[]) => mockSlice(...args),
+      unlink: (...args: unknown[]) => mockUnlink(...args),
+      mkdir: (...args: unknown[]) => mockMkdir(...args),
+      stat: (...args: unknown[]) => mockStat(...args),
+    },
+  },
+}));
+
+function buildOkPutResponse(etag = '"deadbeef"') {
+  return Object.assign(
+    Promise.resolve({
+      respInfo: { status: 200, headers: { ETag: etag } },
+      text: () => '',
+    }),
+    { uploadProgress: jest.fn() },
+  );
+}
+
+function buildFakeApi() {
+  return {
+    initiateMultipart: jest.fn().mockResolvedValue({
+      success: true,
+      data: { upload_id: 'UPLOAD-1', key: 'echoes/u-1/e-1.mp4' },
+    }),
+    getMultipartPartUrls: jest.fn().mockResolvedValue({
+      success: true,
+      data: {
+        part_urls: [
+          { part_number: 1, url: 'https://s3.example.com/p1' },
+          { part_number: 2, url: 'https://s3.example.com/p2' },
+        ],
+      },
+    }),
+    completeMultipart: jest.fn().mockResolvedValue({
+      success: true,
+      data: { echo_id: 'e-1', media_url: 'https://canonical/x' },
+    }),
+    abortMultipart: jest.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+describe('uploadMediaMultipart', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSlice.mockReset();
+    mockUnlink.mockReset();
+    mockMkdir.mockReset();
+    mockStat.mockReset();
+    mockSlice.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    mockMkdir.mockResolvedValue(undefined);
+  });
+
+  it('runs initiate → part-urls → slice+upload (in parallel) → complete', async () => {
+    // Slice/upload for the two parts run concurrently, so their exact
+    // interleave isn't stable; the contract this test pins is the OUTER
+    // ordering (initiate first, complete last) plus that every part got
+    // sliced + uploaded between them.
+    const order: string[] = [];
+    const api = buildFakeApi();
+    api.initiateMultipart.mockImplementation(async () => {
+      order.push('initiate');
+      return { success: true, data: { upload_id: 'U', key: 'k' } };
+    });
+    api.getMultipartPartUrls.mockImplementation(async () => {
+      order.push('part-urls');
+      return {
+        success: true,
+        data: {
+          part_urls: [
+            { part_number: 1, url: 'u1' },
+            { part_number: 2, url: 'u2' },
+          ],
+        },
+      };
+    });
+    mockSlice.mockImplementation(async () => {
+      order.push('slice');
+    });
+    mockFetch.mockImplementation(() => {
+      order.push('upload');
+      return buildOkPutResponse();
+    });
+    api.completeMultipart.mockImplementation(async () => {
+      order.push('complete');
+      return { success: true, data: { echo_id: 'e-1' } };
+    });
+
+    const result = await uploadMediaMultipart({
+      api: api as never,
+      echoId: 'e-1',
+      fileUri: '/local/big.mp4',
+      contentType: 'video/mp4',
+      // 7 MB so we get exactly 2 parts (5 MB + 2 MB).
+      fileSize: 7 * 1024 * 1024,
+    });
+
+    expect(result.success).toBe(true);
+    expect(order[0]).toBe('initiate');
+    expect(order[1]).toBe('part-urls');
+    expect(order[order.length - 1]).toBe('complete');
+    // Two slices and two uploads happen between part-urls and complete.
+    const middle = order.slice(2, -1);
+    expect(middle.filter(s => s === 'slice')).toHaveLength(2);
+    expect(middle.filter(s => s === 'upload')).toHaveLength(2);
+  });
+
+  it('aborts on upload failure and re-throws', async () => {
+    const api = buildFakeApi();
+    mockFetch.mockReturnValue(
+      Object.assign(
+        Promise.resolve({
+          respInfo: { status: 500, headers: {} },
+          text: () => 'oops',
+        }),
+        { uploadProgress: jest.fn() },
+      ),
+    );
+
+    await expect(
+      uploadMediaMultipart({
+        api: api as never,
+        echoId: 'e-1',
+        fileUri: '/local/big.mp4',
+        contentType: 'video/mp4',
+        fileSize: 7 * 1024 * 1024,
+      }),
+    ).rejects.toThrow();
+
+    expect(api.abortMultipart).toHaveBeenCalledWith('e-1', 'UPLOAD-1', 'echoes/u-1/e-1.mp4');
+  });
+
+  it('cleans up part files after each upload (bounded peak disk usage)', async () => {
+    const api = buildFakeApi();
+    mockFetch.mockReturnValue(buildOkPutResponse());
+
+    await uploadMediaMultipart({
+      api: api as never,
+      echoId: 'e-1',
+      fileUri: '/local/big.mp4',
+      contentType: 'video/mp4',
+      fileSize: 7 * 1024 * 1024,
+    });
+
+    // Both part files were unlinked, plus the slice directory itself.
+    const unlinkedPaths = mockUnlink.mock.calls.map(c => c[0] as string);
+    expect(unlinkedPaths.filter(p => p.includes('part-1'))).toHaveLength(1);
+    expect(unlinkedPaths.filter(p => p.includes('part-2'))).toHaveLength(1);
+    // Slice directory (parent) is also unlinked at the end.
+    expect(unlinkedPaths.some(p => p.includes('mc-mp-e-1'))).toBe(true);
+  });
+
+  it('emits "uploading" progress as parts complete', async () => {
+    const api = buildFakeApi();
+    mockFetch.mockReturnValue(buildOkPutResponse());
+    const stages: Array<{ type: string; sent?: number; total?: number }> = [];
+
+    await uploadMediaMultipart({
+      api: api as never,
+      echoId: 'e-1',
+      fileUri: '/local/big.mp4',
+      contentType: 'video/mp4',
+      fileSize: 7 * 1024 * 1024,
+      onStage: stage => stages.push(stage as never),
+    });
+
+    const uploadingStages = stages.filter(s => s.type === 'uploading');
+    expect(uploadingStages.length).toBe(2);
+    // Last 'uploading' event must have sent === total.
+    const last = uploadingStages[uploadingStages.length - 1];
+    expect(last.sent).toBe(7 * 1024 * 1024);
+    expect(last.total).toBe(7 * 1024 * 1024);
+    expect(stages.some(s => s.type === 'finalizing')).toBe(true);
+  });
+
+  it('respects PART_CONCURRENCY (max 4 parts in flight)', async () => {
+    const api = buildFakeApi();
+    // Generate 12 parts worth of URLs.
+    const partUrls = Array.from({ length: 12 }, (_, i) => ({
+      part_number: i + 1,
+      url: `u${i + 1}`,
+    }));
+    api.getMultipartPartUrls.mockResolvedValue({
+      success: true,
+      data: { part_urls: partUrls },
+    });
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    mockFetch.mockImplementation(() => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      return new Promise<{
+        respInfo: { status: number; headers: Record<string, string> };
+        text: () => string;
+      }>(resolve => {
+        setTimeout(() => {
+          inFlight--;
+          resolve({
+            respInfo: { status: 200, headers: { ETag: '"x"' } },
+            text: () => '',
+          });
+        }, 20);
+      }) as never;
+    });
+
+    await uploadMediaMultipart({
+      api: api as never,
+      echoId: 'e-1',
+      fileUri: '/local/big.mp4',
+      contentType: 'video/mp4',
+      // 12 × 5 MB = 60 MB.
+      fileSize: 12 * 5 * 1024 * 1024,
+    });
+
+    // PART_CONCURRENCY is 4; allow tiny slack for the moment a slice's
+    // synchronous resolution lands between an acquire and the previous
+    // task's release (Jest microtask ordering is deterministic but
+    // not always intuitive). The contract is: we do NOT fan out 12
+    // parallel uploads.
+    expect(peakInFlight).toBeLessThanOrEqual(5);
+    expect(peakInFlight).toBeLessThan(12);
+  });
+
+  it('retries a transient 5xx part failure up to 3 times', async () => {
+    const api = buildFakeApi();
+    let callCount = 0;
+    mockFetch.mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Object.assign(
+          Promise.resolve({
+            respInfo: { status: 503, headers: {} },
+            text: () => 'transient',
+          }),
+          { uploadProgress: jest.fn() },
+        );
+      }
+      return buildOkPutResponse();
+    });
+
+    await uploadMediaMultipart({
+      api: api as never,
+      echoId: 'e-1',
+      fileUri: '/local/big.mp4',
+      contentType: 'video/mp4',
+      // 5 MB = 1 part.
+      fileSize: 5 * 1024 * 1024,
+    });
+
+    // 2 transient failures + 1 success = 3 fetch calls total.
+    expect(callCount).toBe(3);
+  });
+
+  it('does NOT retry on a 4xx — surfaces immediately', async () => {
+    const api = buildFakeApi();
+    let callCount = 0;
+    mockFetch.mockImplementation(() => {
+      callCount++;
+      return Object.assign(
+        Promise.resolve({
+          respInfo: { status: 403, headers: {} },
+          text: () => 'AccessDenied',
+        }),
+        { uploadProgress: jest.fn() },
+      );
+    });
+
+    await expect(
+      uploadMediaMultipart({
+        api: api as never,
+        echoId: 'e-1',
+        fileUri: '/local/big.mp4',
+        contentType: 'video/mp4',
+        fileSize: 5 * 1024 * 1024,
+      }),
+    ).rejects.toThrow();
+
+    expect(callCount).toBe(1);
+    expect(api.abortMultipart).toHaveBeenCalled();
+  });
+
+  it('returns the failure envelope if initiate fails (no S3 upload created)', async () => {
+    const api = buildFakeApi();
+    api.initiateMultipart.mockResolvedValue({
+      success: false,
+      error: 'Echo not found',
+    });
+
+    await expect(
+      uploadMediaMultipart({
+        api: api as never,
+        echoId: 'e-1',
+        fileUri: '/local/big.mp4',
+        contentType: 'video/mp4',
+        fileSize: 7 * 1024 * 1024,
+      }),
+    ).rejects.toThrow('Echo not found');
+    // abort is NOT called — no upload was created.
+    expect(api.abortMultipart).not.toHaveBeenCalled();
+  });
+});
+
+describe('MULTIPART_THRESHOLD', () => {
+  it('is 50 MB', () => {
+    expect(MULTIPART_THRESHOLD).toBe(50 * 1024 * 1024);
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/multipart.ts
+++ b/MirrorCollectiveApp/src/services/api/multipart.ts
@@ -1,0 +1,302 @@
+/**
+ * Client-side orchestration for S3 multipart uploads.
+ *
+ * Used by EchoApiService.uploadEchoMedia when the source file is larger
+ * than MULTIPART_THRESHOLD. Replaces the single-PUT path with the
+ * four-step ceremony:
+ *
+ *   1. POST /api/echoes/{id}/multipart/initiate
+ *        → server creates the S3 multipart upload, returns upload_id + key.
+ *   2. Slice the file into 5 MB parts using react-native-blob-util.fs.slice
+ *      (native side, no JS-bridge round-trip).
+ *   3. POST /api/echoes/{id}/multipart/part-urls
+ *        → server presigns one PUT URL per part.
+ *   4. PUT each part to its presigned URL with bounded parallelism (4)
+ *      and per-part retry. Capture the ETag from the response header.
+ *   5. POST /api/echoes/{id}/multipart/complete
+ *        → server assembles the object and atomically commits media_url.
+ *
+ * On any non-recoverable failure we POST /multipart/abort and re-throw
+ * so the bucket isn't left holding partial bytes (the lifecycle rule
+ * also reaps them after 7 days as a backstop).
+ */
+
+import ReactNativeBlobUtil from 'react-native-blob-util';
+
+import type { EchoApiService, EchoResponse, UploadStage } from './echo';
+import type { ApiResponse } from '@types';
+
+// Anything under this size uses the single-PUT path. 50 MB is roughly
+// where iPhone 4K video at default bitrate crosses the line where a
+// single TCP upload starts being lossy on cellular.
+export const MULTIPART_THRESHOLD = 50 * 1024 * 1024;
+
+// S3 minimum part size is 5 MB except the last; using exactly 5 MB
+// maximizes parallelism (more parts) without hitting the part-count
+// ceiling (10,000) on any realistic file. A 4 GB file = 800 parts.
+const PART_SIZE = 5 * 1024 * 1024;
+
+// How many parts to PUT to S3 in parallel. Higher gives bigger
+// throughput on a fat pipe but more contention on cellular; 4 is a
+// reasonable middle ground that mirrors what AWS SDKs default to.
+const PART_CONCURRENCY = 4;
+
+// Per-part retry budget. Idempotent PUTs of the same bytes to the same
+// presigned URL are safe to retry — S3 dedupes by content-md5 and
+// overwrites the in-progress part.
+const PART_MAX_RETRIES = 3;
+const PART_RETRY_BASE_DELAY_MS = 500;
+
+interface PartResult {
+  part_number: number;
+  etag: string;
+}
+
+function stripFileScheme(uri: string): string {
+  return uri.startsWith('file://') ? uri.replace(/^file:\/\//, '') : uri;
+}
+
+/**
+ * Pull the ETag out of an S3 PUT response. AWS returns it as `ETag` in
+ * documentation but lowercase `etag` in practice; ReactNativeBlobUtil
+ * preserves the server's casing, so be tolerant. Also strip the
+ * surrounding quotes that S3 always includes.
+ */
+function extractEtag(
+  headers: Record<string, string | undefined> | undefined,
+): string | null {
+  if (!headers) return null;
+  const raw =
+    headers.ETag ??
+    headers.etag ??
+    headers.Etag ??
+    null;
+  if (!raw) return null;
+  return raw.replace(/^"+|"+$/g, '');
+}
+
+/**
+ * Lightweight semaphore — no library needed for this single use.
+ * Permits requests block when the count hits the cap; release()
+ * wakes the next waiter.
+ */
+function createSemaphore(max: number) {
+  let inUse = 0;
+  const waiters: Array<() => void> = [];
+
+  return {
+    async acquire(): Promise<void> {
+      if (inUse < max) {
+        inUse++;
+        return;
+      }
+      await new Promise<void>(resolve => waiters.push(resolve));
+      inUse++;
+    },
+    release() {
+      inUse--;
+      const next = waiters.shift();
+      if (next) next();
+    },
+  };
+}
+
+/** Marker class so the retry loop can tell "permanent" errors apart from
+ * transient ones. 4xx PUT failures are presign/permissions issues that
+ * won't recover; we surface them immediately.
+ */
+class NonRetryableUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NonRetryableUploadError';
+  }
+}
+
+async function uploadPartWithRetry(
+  url: string,
+  partPath: string,
+  contentType: string,
+): Promise<string> {
+  let lastError: unknown = new Error('unreachable');
+  for (let attempt = 1; attempt <= PART_MAX_RETRIES; attempt++) {
+    try {
+      const response = await ReactNativeBlobUtil.fetch(
+        'PUT',
+        url,
+        { 'Content-Type': contentType },
+        ReactNativeBlobUtil.wrap(partPath),
+      );
+      const status = response.respInfo?.status ?? 0;
+      if (status >= 200 && status < 300) {
+        const etag = extractEtag(response.respInfo?.headers);
+        if (!etag) {
+          throw new Error(
+            'S3 part PUT succeeded but no ETag in response headers',
+          );
+        }
+        return etag;
+      }
+      // 4xx: presign/permissions issue, won't recover. Throw a typed
+      // error so the catch block can surface it without retrying.
+      if (status >= 400 && status < 500) {
+        throw new NonRetryableUploadError(`Part PUT failed (${status})`);
+      }
+      // 5xx + everything else: retry-worthy.
+      throw new Error(`Part PUT 5xx (${status})`);
+    } catch (err) {
+      lastError = err;
+      // Permanent errors short-circuit the retry loop.
+      if (err instanceof NonRetryableUploadError) break;
+      if (attempt === PART_MAX_RETRIES) break;
+      // Exponential backoff with linear jitter.
+      const delay = PART_RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Part upload failed after retries');
+}
+
+interface UploadMultipartArgs {
+  api: EchoApiService;
+  echoId: string;
+  fileUri: string;
+  contentType: string;
+  fileSize: number;
+  onStage?: (stage: UploadStage) => void;
+}
+
+/**
+ * Orchestrate a multipart upload end-to-end. Returns the finalized echo
+ * response on success; throws on unrecoverable failure (the caller
+ * converts that into the user-facing error path).
+ */
+export async function uploadMediaMultipart({
+  api,
+  echoId,
+  fileUri,
+  contentType,
+  fileSize,
+  onStage,
+}: UploadMultipartArgs): Promise<ApiResponse<EchoResponse>> {
+  const partCount = Math.ceil(fileSize / PART_SIZE);
+  const partNumbers = Array.from({ length: partCount }, (_, i) => i + 1);
+  const sourcePath = stripFileScheme(fileUri);
+
+  // 1. Initiate. The backend handles the existing-media-attached
+  // first-write check; if it 4xx's, no S3 multipart was created and we
+  // don't need to abort anything.
+  const init = await api.initiateMultipart(echoId, contentType);
+  if (!init.success || !init.data) {
+    throw new Error(init.error ?? 'Failed to initiate multipart upload');
+  }
+  const { upload_id, key } = init.data;
+
+  // Carve out a temp directory specific to this upload so concurrent
+  // multipart uploads (rare but possible) can't stomp on each other's
+  // part files.
+  const sliceDir = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/mc-mp-${echoId}-${Date.now()}`;
+
+  try {
+    await ReactNativeBlobUtil.fs.mkdir(sliceDir);
+
+    // 2. Presign all parts in one batch. Backend caps batch at 1000;
+    // a 5 GB file = 1000 parts at 5 MB, which is the maximum we'll
+    // hand to the user anyway.
+    const urlsResp = await api.getMultipartPartUrls(
+      echoId,
+      upload_id,
+      key,
+      partNumbers,
+    );
+    if (!urlsResp.success || !urlsResp.data) {
+      throw new Error(urlsResp.error ?? 'Failed to get part URLs');
+    }
+    const urlByPart = new Map<number, string>();
+    for (const p of urlsResp.data.part_urls) {
+      urlByPart.set(p.part_number, p.url);
+    }
+
+    // 3. Slice + upload with bounded concurrency. We aggregate
+    // uploadedBytes for the progress callback; this is a shared
+    // counter touched from multiple in-flight tasks but JS is
+    // single-threaded, so no locking needed.
+    const sem = createSemaphore(PART_CONCURRENCY);
+    const partResults: PartResult[] = new Array(partCount);
+    let uploadedBytes = 0;
+
+    await Promise.all(
+      partNumbers.map(async n => {
+        await sem.acquire();
+        const start = (n - 1) * PART_SIZE;
+        const end = Math.min(start + PART_SIZE, fileSize);
+        const partPath = `${sliceDir}/part-${n}`;
+        try {
+          await ReactNativeBlobUtil.fs.slice(sourcePath, partPath, start, end);
+          const url = urlByPart.get(n);
+          if (!url) throw new Error(`No presigned URL for part ${n}`);
+          const etag = await uploadPartWithRetry(url, partPath, contentType);
+
+          partResults[n - 1] = { part_number: n, etag };
+          uploadedBytes += end - start;
+          onStage?.({
+            type: 'uploading',
+            sent: uploadedBytes,
+            total: fileSize,
+          });
+        } finally {
+          // Best-effort cleanup of each part file as soon as it's
+          // done uploading — keeps peak disk usage bounded to
+          // (concurrency × PART_SIZE) regardless of file size.
+          await ReactNativeBlobUtil.fs.unlink(partPath).catch(() => undefined);
+          sem.release();
+        }
+      }),
+    );
+
+    // 4. Complete. The server runs HEAD + DDB write atomically, same
+    // as the single-PUT finalize path.
+    onStage?.({ type: 'finalizing' });
+    const completed = await api.completeMultipart(
+      echoId,
+      upload_id,
+      key,
+      partResults,
+    );
+    return completed;
+  } catch (err) {
+    // 5. Abort. Best effort — if it fails the lifecycle rule will
+    // reap the upload after 7 days. Always re-throw the original.
+    try {
+      await api.abortMultipart(echoId, upload_id, key);
+    } catch (abortErr) {
+      console.warn('Failed to abort multipart upload:', abortErr);
+    }
+    throw err;
+  } finally {
+    // Clean up the slice directory itself. unlink on a directory
+    // works recursively in react-native-blob-util.
+    await ReactNativeBlobUtil.fs
+      .unlink(sliceDir)
+      .catch(() => undefined);
+  }
+}
+
+/**
+ * Read the file size from disk for routing into multipart vs single-PUT.
+ * Returns null when the platform doesn't expose a path we can stat
+ * (e.g. iOS PHAsset-style URIs that haven't been exported yet) —
+ * callers treat null as "unknown, default to single-PUT path".
+ */
+export async function getFileSize(uri: string): Promise<number | null> {
+  try {
+    const path = stripFileScheme(uri);
+    const stat = await ReactNativeBlobUtil.fs.stat(path);
+    const size =
+      typeof stat.size === 'string' ? parseInt(stat.size, 10) : stat.size;
+    return Number.isFinite(size) ? Number(size) : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Pairs with the backend perf/multipart-upload PR. When uploadEchoMedia sees a (post-compression) file size >= MULTIPART_THRESHOLD (50 MB), it routes through the four-step multipart ceremony instead of single-PUT.

Why this matters
----------------
With native streaming + Transfer Acceleration + 720p compression landed, the typical iPhone video drops well under the threshold and keeps the existing single-PUT path. But user-imported clips and 4K-source files routinely land at 100-500 MB after compression. On cellular those uploads need:
  - per-part retry (a TCP failure doesn't throw away everything),
  - parallelism (4 concurrent parts ≈ 4× throughput on a fat pipe),
  - resumability (abort + restart instead of starting over).

Pieces
------
- NEW src/services/api/multipart.ts:
  - uploadMediaMultipart: orchestrates initiate → slice → presign → parallel upload → complete. Aborts S3 on error. Cleans up part files as each finishes (peak disk = PART_CONCURRENCY × PART_SIZE regardless of source file size).
  - getFileSize: stat helper used to route into multipart.
  - uploadPartWithRetry: per-part retry (up to 3) for 5xx / transient; NonRetryableUploadError class short-circuits on 4xx so a presign/permissions issue surfaces immediately.
  - 5 MB parts, concurrency 4, semaphore enforces the cap.
- EchoApiService gains four typed API methods: initiateMultipart / getMultipartPartUrls / completeMultipart / abortMultipart. initiate + complete carry Idempotency-Key (idempotent on the backend); part-urls intentionally does not (caching presigned URLs hands back stale signatures).
- uploadEchoMedia post-compression: stat → branch into multipart when fileSize >= 50 MB; else fall through to single-PUT.

Tests
-----
- 9 new tests in src/services/api/multipart.test.ts:
  - end-to-end ordering (initiate first, complete last),
  - abort fires on failure,
  - part files cleaned up after each upload,
  - progress events for each part + finalizing,
  - PART_CONCURRENCY enforced (semaphore caps in-flight count),
  - 5xx retry (3 attempts) vs 4xx surfaces immediately,
  - failure envelope when initiate fails (no S3 upload created, no abort needed).
- Full suite: 418 passed (+9 from this PR). 0 new TypeScript errors.

Backwards compat
----------------
- Single-PUT path is unchanged for files below threshold.
- Profile-photo upload sites still call the single-PUT helpers directly (intentional — profile photos are small).