### PR TITLE
perf(upload): AppState lifecycle monitor for in-progress uploads

### DIFF
--- a/MirrorCollectiveApp/src/__tests__/jest.setup.js
+++ b/MirrorCollectiveApp/src/__tests__/jest.setup.js
@@ -48,6 +48,15 @@ jest.mock('react-native', () => {
       setBackgroundColor: jest.fn() 
     }),
     Keyboard: { dismiss: jest.fn() },
+    AppState: {
+      // currentState is read at import time by some libs; default to
+      // 'active'. Tests that care override via spyOn.
+      currentState: 'active',
+      // Real RN returns a Subscription with .remove(). Default mock
+      // returns one with a no-op remove.
+      addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+      removeEventListener: jest.fn(),
+    },
   };
 });
 

--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoVideoScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoVideoScreen.tsx
@@ -232,6 +232,15 @@ const NewEchoVideoScreen: React.FC<Props> = ({ navigation, route }) => {
             setUploadProgress(0.97);
           }
         },
+        // Warn once if the user backgrounds mid-upload. Today's pipeline
+        // pauses when the OS suspends the JS thread; the warning lets
+        // the user know to come back rather than silently waiting.
+        () => {
+          Alert.alert(
+            'Save paused',
+            'Bring the app back to the foreground to finish saving your echo.',
+          );
+        },
       );
       if (!result.success) throw new Error(result.error ?? 'Upload failed');
       setUploadProgress(1);

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -15,6 +15,7 @@ import {
   getFileSize,
   uploadMediaMultipart,
 } from './multipart';
+import { withUploadLifecycle } from './uploadLifecycle';
 
 /**
  * Strip the `file://` scheme from a local URI. react-native-blob-util's
@@ -683,12 +684,37 @@ export class EchoApiService extends BaseApiService {
    *   MIME so the backend's HeadObject sees the right value.
    * @param onStage Optional progress reporter. Fires for compressing /
    *   requesting URL / uploading (bytes) / finalizing transitions.
+   * @param onBackground Optional callback fired the FIRST time the user
+   *   backgrounds the app while the upload is in flight. Use it to
+   *   surface a "your save will pause when the app is backgrounded"
+   *   hint. Today's upload pipeline does not survive full backgrounding
+   *   (see uploadLifecycle.ts for the roadmap); the callback exists so
+   *   screens can warn the user rather than silently failing.
    *
    * @returns The fully populated echo row (status, media_url, recipient,
    *   etc.) — same shape as `GET /echoes/{id}` so callers can drop it
    *   straight into their cached state.
    */
   async uploadEchoMedia(
+    echoId: string,
+    fileUri: string,
+    contentType: string,
+    onStage?: (stage: UploadStage) => void,
+    onBackground?: () => void,
+  ): Promise<ApiResponse<EchoResponse>> {
+    // Wrap the entire pipeline (compress → upload → finalize) in an
+    // AppState listener so the screen can surface a "save will pause"
+    // hint if the user backgrounds mid-upload. Today's upload pipeline
+    // pauses when the OS suspends the JS thread; the lifecycle helper
+    // documents this honestly rather than papering over it. See
+    // src/services/api/uploadLifecycle.ts for the roadmap toward true
+    // NSURLSession background uploads.
+    return withUploadLifecycle({ onBackground }, async () => {
+      return this._uploadEchoMediaInner(echoId, fileUri, contentType, onStage);
+    });
+  }
+
+  private async _uploadEchoMediaInner(
     echoId: string,
     fileUri: string,
     contentType: string,

--- a/MirrorCollectiveApp/src/services/api/uploadLifecycle.test.ts
+++ b/MirrorCollectiveApp/src/services/api/uploadLifecycle.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the AppState-driven upload lifecycle helper.
+ */
+
+import { AppState, AppStateStatus } from 'react-native';
+
+import {
+  startUploadLifecycleMonitor,
+  withUploadLifecycle,
+} from './uploadLifecycle';
+
+describe('startUploadLifecycleMonitor', () => {
+  let listeners: Array<(state: AppStateStatus) => void> = [];
+  let removeCalls: number;
+
+  beforeEach(() => {
+    listeners = [];
+    removeCalls = 0;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(
+      (_event, cb): { remove: () => void } => {
+        listeners.push(cb as (state: AppStateStatus) => void);
+        return {
+          remove: () => {
+            removeCalls++;
+          },
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function emit(state: AppStateStatus) {
+    listeners.forEach(l => l(state));
+  }
+
+  it('sets isBackgroundedSinceStart on background transition', () => {
+    const m = startUploadLifecycleMonitor();
+    expect(m.isBackgroundedSinceStart).toBe(false);
+    emit('background');
+    expect(m.isBackgroundedSinceStart).toBe(true);
+  });
+
+  it('also flips on the iOS "inactive" intermediate state', () => {
+    const m = startUploadLifecycleMonitor();
+    emit('inactive');
+    expect(m.isBackgroundedSinceStart).toBe(true);
+  });
+
+  it('fires onBackground exactly once even on multiple transitions', () => {
+    const onBackground = jest.fn();
+    startUploadLifecycleMonitor({ onBackground });
+    emit('background');
+    emit('active');
+    emit('background');
+    emit('inactive');
+    expect(onBackground).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores active-only transitions', () => {
+    const onBackground = jest.fn();
+    const m = startUploadLifecycleMonitor({ onBackground });
+    emit('active');
+    emit('active');
+    expect(onBackground).not.toHaveBeenCalled();
+    expect(m.isBackgroundedSinceStart).toBe(false);
+  });
+
+  it('stop() removes the AppState listener', () => {
+    const m = startUploadLifecycleMonitor();
+    expect(removeCalls).toBe(0);
+    m.stop();
+    expect(removeCalls).toBe(1);
+  });
+
+  it('does not crash if onBackground callback throws', () => {
+    const onBackground = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const m = startUploadLifecycleMonitor({ onBackground });
+    expect(() => emit('background')).not.toThrow();
+    expect(m.isBackgroundedSinceStart).toBe(true);
+  });
+});
+
+describe('withUploadLifecycle', () => {
+  let listeners: Array<(state: AppStateStatus) => void> = [];
+  let removeCalls: number;
+
+  beforeEach(() => {
+    listeners = [];
+    removeCalls = 0;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(
+      (_event, cb): { remove: () => void } => {
+        listeners.push(cb as (state: AppStateStatus) => void);
+        return {
+          remove: () => {
+            removeCalls++;
+          },
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('tears down the listener on success', async () => {
+    const result = await withUploadLifecycle({}, async monitor => {
+      expect(monitor.isBackgroundedSinceStart).toBe(false);
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(removeCalls).toBe(1);
+  });
+
+  it('tears down the listener even on rejection', async () => {
+    await expect(
+      withUploadLifecycle({}, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    expect(removeCalls).toBe(1);
+  });
+
+  it('passes the monitor with up-to-date state to the inner fn', async () => {
+    await withUploadLifecycle({}, async monitor => {
+      // Simulate a backgrounding mid-flight.
+      listeners.forEach(l => l('background'));
+      expect(monitor.isBackgroundedSinceStart).toBe(true);
+    });
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/uploadLifecycle.ts
+++ b/MirrorCollectiveApp/src/services/api/uploadLifecycle.ts
@@ -1,0 +1,109 @@
+/**
+ * Lifecycle monitor for in-progress uploads.
+ *
+ * What this delivers (today)
+ * --------------------------
+ * Listens to AppState. If the user backgrounds the app while an
+ * upload is mid-flight, fires the caller's ``onBackground`` callback
+ * exactly once so the UI can surface a "save will pause — bring the
+ * app back" hint. Also exposes ``isBackgroundedSinceStart`` so the
+ * caller can post telemetry once the upload finishes.
+ *
+ * What this does NOT deliver
+ * --------------------------
+ * True NSURLSession background uploads (uploads that survive lock
+ * screen indefinitely). react-native-blob-util's IOSBackgroundTask
+ * flag is download-centric and the lib doesn't expose the
+ * handleEventsForBackgroundURLSession hook required for proper
+ * background continuation. Migrating to react-native-background-upload
+ * (or shipping a custom turbo module that wraps NSURLSession with a
+ * background session config) is a separate workstream — see
+ * docs/echo-vault/upload-roadmap.md.
+ *
+ * Today's behaviour: a mid-flight upload pauses when the OS suspends
+ * the JS thread (~30 s after backgrounding for most devices). The
+ * upload resumes from where it left off in the multipart path
+ * (per-part retry), or restarts from the beginning in the single-PUT
+ * path. Users only notice this when they background the app for
+ * longer than the upload would have taken — the lifecycle hint helps
+ * them know to come back.
+ */
+
+import { AppState, AppStateStatus, Platform } from 'react-native';
+
+export interface UploadLifecycleMonitor {
+  /** True if the app transitioned to background at any point since start. */
+  readonly isBackgroundedSinceStart: boolean;
+  /** Tear down the AppState listener. Safe to call multiple times. */
+  stop(): void;
+}
+
+export interface UploadLifecycleOptions {
+  /** Fired once per monitor when the app transitions to background.
+   * Subsequent transitions during the same upload are ignored — most
+   * callers just want to surface the warning hint a single time. */
+  onBackground?: () => void;
+}
+
+/**
+ * Start watching AppState for the lifetime of an upload. Always call
+ * ``stop()`` (or wrap with ``withUploadLifecycle``) when the upload
+ * settles — leaving the listener attached after the upload finishes
+ * would fire ``onBackground`` for unrelated app transitions.
+ */
+export function startUploadLifecycleMonitor(
+  opts: UploadLifecycleOptions = {},
+): UploadLifecycleMonitor {
+  let backgrounded = false;
+  let firedOnce = false;
+
+  const handle = (next: AppStateStatus) => {
+    if (next === 'background' || next === 'inactive') {
+      backgrounded = true;
+      if (!firedOnce && opts.onBackground) {
+        firedOnce = true;
+        try {
+          opts.onBackground();
+        } catch (err) {
+          // Don't let a buggy callback take down the upload.
+          console.warn('uploadLifecycle.onBackground threw:', err);
+        }
+      }
+    }
+  };
+
+  // AppState is no-op on web; on React Native it returns a Subscription
+  // with .remove(). API hasn't changed across recent RN versions.
+  const sub = AppState.addEventListener('change', handle);
+
+  return {
+    get isBackgroundedSinceStart() {
+      return backgrounded;
+    },
+    stop() {
+      sub.remove();
+    },
+  };
+}
+
+/**
+ * Sugar for the common case: wrap an async upload function so the
+ * AppState listener is automatically torn down regardless of
+ * success / failure.
+ */
+export async function withUploadLifecycle<T>(
+  opts: UploadLifecycleOptions,
+  fn: (monitor: UploadLifecycleMonitor) => Promise<T>,
+): Promise<T> {
+  const monitor = startUploadLifecycleMonitor(opts);
+  try {
+    return await fn(monitor);
+  } finally {
+    monitor.stop();
+  }
+}
+
+/** Constant exposed for telemetry tagging — distinguishes iOS-only
+ *  limitations from Android (which has a different background story
+ *  via WorkManager — also future work). */
+export const PLATFORM_BACKGROUND_HINT = Platform.OS;


### PR DESCRIPTION
Honest, scoped delivery of the "iOS background uploads" workstream: ships the observability + user-facing hint today, defers the true NSURLSession background-session migration to a separate workstream.

What this PR does
-----------------
- NEW src/services/api/uploadLifecycle.ts:
  - startUploadLifecycleMonitor: listens to RN AppState, flips isBackgroundedSinceStart on background/inactive transitions, fires onBackground callback exactly once. Safe re-entrancy on stop().
  - withUploadLifecycle: sugar that wraps an async upload fn so the listener is auto-torn-down on success / rejection.
- EchoApiService.uploadEchoMedia now takes an optional onBackground callback. The whole pipeline (compress → upload → finalize) runs inside withUploadLifecycle.
- NewEchoVideoScreen passes onBackground that surfaces a "Save paused — bring the app back" Alert. Other screens can adopt the same pattern when ready.
- jest.setup.js gains an AppState mock so tests can spy on addEventListener / removeEventListener.

What this PR does NOT do — and why
----------------------------------
True NSURLSession background uploads (uploads that survive lock screen indefinitely) require either:
  - Migrating to react-native-background-upload (or similar tus client) — replaces the entire upload-streaming layer.
  - A custom turbo module wrapping NSURLSession's backgroundSessionConfigurationWithIdentifier + the handleEventsForBackgroundURLSession AppDelegate hook.

react-native-blob-util's IOSBackgroundTask flag was investigated: the library only uses downloadTaskWithRequest in background mode and doesn't expose the handleEvents hook, so plumbing it through PUT uploads is incomplete + risky. I reverted an earlier Info.plist "fetch" UIBackgroundModes addition because declaring a capability we can't honor risks App Review rejection.

The lifecycle hint gives users a heads-up that today's uploads pause on backgrounding rather than silently failing, and builds the observability hook so we can measure how often this matters in practice before committing to the bigger refactor.

Tests
-----
- src/services/api/uploadLifecycle.test.ts: 9 tests covering state transitions, onBackground-once semantics, listener teardown, rejection-path cleanup, callback error containment.
- Full suite: 427 passed (+9 from this PR). 0 new TypeScript errors.