### PR TITLE
perf(api): per-route timeout override for known-slow endpoints

### DIFF
--- a/MirrorCollectiveApp/src/services/api/base.test.ts
+++ b/MirrorCollectiveApp/src/services/api/base.test.ts
@@ -47,6 +47,13 @@ class TestApiService extends BaseApiService {
   ): Promise<any> {
     return this.makeRequest<T>(endpoint, method, body, false);
   }
+
+  callWithTimeout<T = any>(
+    endpoint: string,
+    timeoutMs: number,
+  ): Promise<any> {
+    return this.makeRequest<T>(endpoint, 'POST', {}, false, undefined, { timeoutMs });
+  }
 }
 
 const svc = new TestApiService();
@@ -169,5 +176,85 @@ describe('BaseApiService — 429 retry-with-backoff', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('BaseApiService — per-route timeout override', () => {
+  /**
+   * Mock fetch that listens to the abort signal and rejects when it
+   * fires (real fetch behaves this way). Without this the test
+   * promise never settles and Jest times out before our assertions.
+   */
+  function mockNeverResolvingFetch(): () => AbortSignal | undefined {
+    let captured: AbortSignal | undefined;
+    (global.fetch as jest.Mock).mockImplementation(
+      (_url: string, init: { signal?: AbortSignal }) => {
+        captured = init.signal;
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          });
+        });
+      },
+    );
+    return () => captured;
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('uses the API_CONFIG.TIMEOUT default when no override is given', async () => {
+    // The mocked config has TIMEOUT: 5000.
+    const getSignal = mockNeverResolvingFetch();
+    const promise = svc.call('/api/slow').catch(() => undefined);
+
+    // Hasn't aborted yet at t = 4999.
+    await Promise.resolve();
+    jest.advanceTimersByTime(4999);
+    expect(getSignal()?.aborted).toBe(false);
+
+    // Aborts at t = 5000.
+    jest.advanceTimersByTime(1);
+    expect(getSignal()?.aborted).toBe(true);
+
+    await promise;
+  });
+
+  it('honors the timeoutMs override (does NOT abort at the default)', async () => {
+    const getSignal = mockNeverResolvingFetch();
+    const promise = svc
+      .callWithTimeout('/api/slow', 30_000)
+      .catch(() => undefined);
+
+    // At t = 5001 the DEFAULT timeout would have fired — assert it didn't.
+    await Promise.resolve();
+    jest.advanceTimersByTime(5001);
+    expect(getSignal()?.aborted).toBe(false);
+
+    // Aborts at t = 30000.
+    jest.advanceTimersByTime(30_000 - 5001);
+    expect(getSignal()?.aborted).toBe(true);
+
+    await promise;
+  });
+
+  it('still aborts at the override deadline', async () => {
+    const getSignal = mockNeverResolvingFetch();
+    const promise = svc
+      .callWithTimeout('/api/slow', 20_000)
+      .catch(() => undefined);
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(19_999);
+    expect(getSignal()?.aborted).toBe(false);
+    jest.advanceTimersByTime(1);
+    expect(getSignal()?.aborted).toBe(true);
+    await promise;
   });
 });

--- a/MirrorCollectiveApp/src/services/api/base.ts
+++ b/MirrorCollectiveApp/src/services/api/base.ts
@@ -51,6 +51,21 @@ function computeRetryDelayMs(
   return Math.min(jittered, RETRY_MAX_DELAY_MS);
 }
 
+/**
+ * Per-call options for makeRequest. Lives in an options bag so future
+ * additions don't keep growing the positional-arg list.
+ */
+export interface MakeRequestOptions {
+  /**
+   * Override the default request timeout for this single call. Useful for
+   * routes whose server-side work is legitimately slow (e.g. S3
+   * CompleteMultipartUpload for 1000+ part files). Default is
+   * `API_CONFIG.TIMEOUT` (10 s) — keep it tight on routes that should be
+   * fast so a real backend hang doesn't go unnoticed.
+   */
+  timeoutMs?: number;
+}
+
 export class BaseApiService {
   public readonly baseUrl: string;
   private readonly timeout: number;
@@ -66,6 +81,7 @@ export class BaseApiService {
     data?: any,
     requiresAuth: boolean = false,
     extraHeaders?: Record<string, string>,
+    options?: MakeRequestOptions,
   ): Promise<ApiResponse<T>> {
     let lastError: any;
     for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
@@ -76,6 +92,7 @@ export class BaseApiService {
           data,
           requiresAuth,
           extraHeaders,
+          options,
         );
       } catch (error: any) {
         lastError = error;
@@ -110,9 +127,14 @@ export class BaseApiService {
     data?: any,
     requiresAuth: boolean = false,
     extraHeaders?: Record<string, string>,
+    options?: MakeRequestOptions,
   ): Promise<ApiResponse<T>> {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    // Per-call override beats the instance default. Callers that pass a
+    // timeoutMs here are opting in to a longer wait for routes whose
+    // server-side work is known-slow (S3 assembly, etc.).
+    const effectiveTimeout = options?.timeoutMs ?? this.timeout;
+    const timeoutId = setTimeout(() => controller.abort(), effectiveTimeout);
     let response: Response | undefined;
 
     try {

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -577,6 +577,12 @@ export class EchoApiService extends BaseApiService {
     // because the finalize call comes AFTER the S3 PUT succeeded: a
     // duplicate finalize without dedup would race the first one and
     // can produce a "media already finalized" reject on the second.
+    //
+    // Longer timeout (20 s) than the default 10 s: the server-side
+    // HeadObject + DDB write is normally <3 s, but a cold S3 partition
+    // or transient cross-AZ latency can push it past 10 s, and a
+    // timeout here is bad UX — the upload bytes ARE in S3 at this
+    // point, the user just sees a "could not be confirmed" error.
     const response = await this.makeRequest<EchoResponse>(
       `/api/echoes/${encodeURIComponent(echoId)}/finalize-media`,
       'POST',
@@ -586,6 +592,7 @@ export class EchoApiService extends BaseApiService {
       },
       true,
       { 'Idempotency-Key': uuidV4() },
+      { timeoutMs: 20_000 },
     );
     return ApiErrorHandler.handleApiResponse(response, 'Media finalized');
   }
@@ -636,12 +643,21 @@ export class EchoApiService extends BaseApiService {
     key: string,
     parts: Array<{ part_number: number; etag: string }>,
   ): Promise<ApiResponse<EchoResponse>> {
+    // 30 s timeout — well above the 10 s default. S3's
+    // CompleteMultipartUpload is roughly O(parts) on the server side;
+    // a 2 GB file split into 400 parts can take 5-10 s to assemble,
+    // and a 5 GB / 1000-part file can land at 10-15 s. Plus the
+    // server-side HeadObject + DDB write that finalize_upload runs
+    // afterward. A tight timeout here would surface as "upload
+    // failed" to the user even though the bytes successfully landed
+    // and S3 was simply busy assembling them.
     const response = await this.makeRequest<EchoResponse>(
       `/api/echoes/${encodeURIComponent(echoId)}/multipart/complete`,
       'POST',
       { upload_id: uploadId, key, parts },
       true,
       { 'Idempotency-Key': uuidV4() },
+      { timeoutMs: 30_000 },
     );
     return ApiErrorHandler.handleApiResponse(response, 'Multipart upload completed');
   }


### PR DESCRIPTION
Closes the gap flagged in PR-stack review: the 10 s default in API_CONFIG.TIMEOUT is appropriate for fast routes (vault list, profile fetch, chat) where a 10 s response IS a real backend hang worth surfacing — but it's too tight for two endpoints whose server-side work is legitimately slow:

  - multipart/complete: S3 CompleteMultipartUpload assembles parts server-side; ~1-5 s for typical 5-50 MB files, but a 2 GB file split into 400+ parts can take 8-15 s. Plus the HEAD + DDB write the handler runs afterward.
  - finalize-media: HEAD + DDB write is usually <3 s, but a cold S3 partition or transient cross-AZ latency can push it past 10 s. The bytes are in S3 at this point — a timeout here produces a misleading "upload failed" for an upload that actually succeeded.

Note: the actual S3 PUT (the long part of the upload) is on a DIFFERENT transport — ReactNativeBlobUtil.fetch, with its own ~60 s native timeout — so neither the 10 s default nor this override applies to it. This PR is purely about backend RPC calls that go through BaseApiService.

Pieces
------
- BaseApiService.makeRequest gains an optional MakeRequestOptions bag with { timeoutMs? }. Passes through to _attemptRequest which honors it via the existing AbortController. Default behavior unchanged when the option is omitted.
- EchoApiService.completeMultipart → 30 s override.
- EchoApiService.finalizeMedia → 20 s override.

Tests
-----
- 3 new in base.test.ts: default uses API_CONFIG.TIMEOUT, override beats default, override aborts at its own deadline. Uses fake timers + a fetch mock that listens to AbortSignal so the test doesn't hang waiting for promises that should reject.
- Full suite: 430 passed (vs 427 baseline = +3). 0 new TS errors.

Why an options bag (not a 6th positional param)
-----------------------------------------------
Keeps the door open for future per-call config (priority hint, cache policy, structured-error mode) without a 7th / 8th argument. makeRequest's existing 5 positional args are already at the edge of readability.