### PR TITLE
feat(telemetry): fire upload-telemetry event per upload outcome

### DIFF
--- a/MirrorCollectiveApp/src/services/api/echo.test.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.test.ts
@@ -690,6 +690,14 @@ describe('EchoApiService', () => {
       mockUnlink.mockResolvedValue(undefined);
 
       // Source is large enough to trigger compression; result size is unknown.
+      // Three stat calls in sequence:
+      //   1. uploadEchoMedia → originalBytes (telemetry)
+      //   2. compressVideoIfNeeded → decide skip-or-compress
+      //   3. compressVideoIfNeeded → measure compressed result
+      // Force the first two above the 10 MB compression threshold so
+      // compression actually runs and produces the temp file we want
+      // to assert gets unlinked.
+      mockStat.mockResolvedValueOnce({ size: '50000000' });
       mockStat.mockResolvedValueOnce({ size: '50000000' });
       mockStat.mockResolvedValue({ size: '5000000' });
       Video.compress.mockResolvedValueOnce('/cache/clip.compressed.mp4');
@@ -738,6 +746,14 @@ describe('EchoApiService', () => {
       mockStat.mockReset();
       mockUnlink.mockResolvedValue(undefined);
 
+      // Three stat calls in sequence:
+      //   1. uploadEchoMedia → originalBytes (telemetry)
+      //   2. compressVideoIfNeeded → decide skip-or-compress
+      //   3. compressVideoIfNeeded → measure compressed result
+      // Force the first two above the 10 MB compression threshold so
+      // compression actually runs and produces the temp file we want
+      // to assert gets unlinked.
+      mockStat.mockResolvedValueOnce({ size: '50000000' });
       mockStat.mockResolvedValueOnce({ size: '50000000' });
       mockStat.mockResolvedValue({ size: '5000000' });
       Video.compress.mockResolvedValueOnce('/cache/clip.compressed.mp4');

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -8,6 +8,8 @@ import {
 } from '@utils/media/compress';
 import { uuidV4 } from '@utils/uuid';
 
+import { AppState } from 'react-native';
+
 import { BaseApiService } from './base';
 import { ApiErrorHandler } from './errorHandler';
 import {
@@ -16,6 +18,10 @@ import {
   uploadMediaMultipart,
 } from './multipart';
 import { withUploadLifecycle } from './uploadLifecycle';
+import {
+  UploadMetricsAccumulator,
+  fireUploadTelemetry,
+} from './uploadTelemetry';
 
 /**
  * Strip the `file://` scheme from a local URI. react-native-blob-util's
@@ -737,13 +743,63 @@ export class EchoApiService extends BaseApiService {
   ): Promise<ApiResponse<EchoResponse>> {
     // Wrap the entire pipeline (compress → upload → finalize) in an
     // AppState listener so the screen can surface a "save will pause"
-    // hint if the user backgrounds mid-upload. Today's upload pipeline
-    // pauses when the OS suspends the JS thread; the lifecycle helper
-    // documents this honestly rather than papering over it. See
-    // src/services/api/uploadLifecycle.ts for the roadmap toward true
-    // NSURLSession background uploads.
-    return withUploadLifecycle({ onBackground }, async () => {
-      return this._uploadEchoMediaInner(echoId, fileUri, contentType, onStage);
+    // hint if the user backgrounds mid-upload. The monitor also feeds
+    // backgrounded_during_upload into the telemetry event below.
+    return withUploadLifecycle({ onBackground }, async monitor => {
+      // Pre-pipeline: measure source size so the telemetry event has
+      // a denominator for "compression ratio" analyses. Failing to
+      // stat (PHAsset URI, etc.) yields 0 — not meaningful but
+      // doesn't break anything.
+      const originalBytes = (await getFileSize(fileUri)) ?? 0;
+      const accumulator = new UploadMetricsAccumulator(
+        echoId,
+        contentType,
+        originalBytes,
+        'single-put', // _uploadEchoMediaInner flips to 'multipart' if the
+        // post-compression size crosses MULTIPART_THRESHOLD.
+      );
+
+      try {
+        const result = await this._uploadEchoMediaInner(
+          echoId,
+          fileUri,
+          contentType,
+          onStage,
+          accumulator,
+        );
+        // Fire-and-forget — never block on telemetry. void to keep
+        // the promise floating; uploadTelemetry handles its own
+        // errors internally.
+        void fireUploadTelemetry(
+          accumulator.build({
+            status: result.success ? 'success' : 'failed',
+            failureStage: result.success
+              ? undefined
+              : // The inner function only returns a failure envelope
+                // for the finalize step today (other failures throw);
+                // accumulator.lastEnteredStage gives a defensible
+                // best-guess for the failed-envelope case.
+                accumulator.lastEnteredStage ?? 'finalize',
+            errorMessage: result.success ? undefined : result.error,
+            backgroundedDuringUpload: monitor.isBackgroundedSinceStart,
+            appStateAtCompletion:
+              AppState.currentState === 'background' ? 'background' : 'active',
+          }),
+        );
+        return result;
+      } catch (err) {
+        void fireUploadTelemetry(
+          accumulator.build({
+            status: 'failed',
+            failureStage: accumulator.lastEnteredStage ?? 'upload',
+            errorMessage: err instanceof Error ? err.message : String(err),
+            backgroundedDuringUpload: monitor.isBackgroundedSinceStart,
+            appStateAtCompletion:
+              AppState.currentState === 'background' ? 'background' : 'active',
+          }),
+        );
+        throw err;
+      }
     });
   }
 
@@ -752,6 +808,7 @@ export class EchoApiService extends BaseApiService {
     fileUri: string,
     contentType: string,
     onStage?: (stage: UploadStage) => void,
+    accumulator?: UploadMetricsAccumulator,
   ): Promise<ApiResponse<EchoResponse>> {
     // workingUri tracks the file we're actually uploading. If
     // compression runs, it's a compressed copy in the cache dir; the
@@ -763,23 +820,32 @@ export class EchoApiService extends BaseApiService {
     try {
       // 1. Compress when the source is large.
       if (contentType.startsWith('video/')) {
+        accumulator?.markStageStart('compress');
         const { uri } = await compressVideoIfNeeded(fileUri, fraction => {
           onStage?.({ type: 'compressing', fraction });
         });
         workingUri = uri;
+        accumulator?.markStageEnd('compress');
       } else if (contentType.startsWith('image/')) {
+        accumulator?.markStageStart('compress');
         onStage?.({ type: 'compressing', fraction: 0 });
         const { uri } = await compressImageIfNeeded(fileUri);
         workingUri = uri;
         onStage?.({ type: 'compressing', fraction: 1 });
+        accumulator?.markStageEnd('compress');
       }
 
       // 2. Decide single-PUT vs multipart based on (post-compression)
       // file size. Anything we can't measure (PHAsset-style URI before
       // export) defaults to single-PUT.
       const fileSize = await getFileSize(workingUri);
+      if (fileSize !== null) {
+        accumulator?.setCompressedBytes(fileSize);
+      }
       if (fileSize !== null && fileSize >= MULTIPART_THRESHOLD) {
-        return await uploadMediaMultipart({
+        accumulator?.setUploadPath('multipart');
+        accumulator?.markStageStart('upload');
+        const result = await uploadMediaMultipart({
           api: this,
           echoId,
           fileUri: workingUri,
@@ -787,17 +853,22 @@ export class EchoApiService extends BaseApiService {
           fileSize,
           onStage,
         });
+        accumulator?.markStageEnd('upload');
+        return result;
       }
 
       // 3. Single-PUT path. Ask the backend for a presigned PUT URL.
+      accumulator?.markStageStart('presign');
       onStage?.({ type: 'requesting_url' });
       const presigned = await this.getUploadUrl(contentType, echoId, 'echo');
       if (!presigned.success || !presigned.data) {
         return forwardFailure<EchoResponse>(presigned);
       }
       const { upload_url, key } = presigned.data;
+      accumulator?.markStageEnd('presign');
 
       // 4. Stream the (possibly compressed) file to S3.
+      accumulator?.markStageStart('upload');
       await this.uploadMedia(
         upload_url,
         workingUri,
@@ -806,13 +877,16 @@ export class EchoApiService extends BaseApiService {
           onStage?.({ type: 'uploading', sent, total });
         },
       );
+      accumulator?.markStageEnd('upload');
 
       // 5. Atomic commit. Server HEADs S3, captures truth, writes DDB.
       // If this fails, the bytes are in S3 but the echo row has no
       // media_url — the user must re-attempt media attach. We surface
       // a specific error message so the UI can tell them so.
+      accumulator?.markStageStart('finalize');
       onStage?.({ type: 'finalizing' });
       const finalized = await this.finalizeMedia(echoId, key, contentType);
+      accumulator?.markStageEnd('finalize');
       if (!finalized.success) {
         // Use || (not ??) — backend may return `error: ''` for a 500.
         // The user-facing copy is intentionally specific: the bytes ARE

--- a/MirrorCollectiveApp/src/services/api/uploadTelemetry.test.ts
+++ b/MirrorCollectiveApp/src/services/api/uploadTelemetry.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the upload-telemetry helper + accumulator.
+ */
+
+import {
+  UploadMetricsAccumulator,
+  fireUploadTelemetry,
+  scrubErrorMessage,
+} from './uploadTelemetry';
+
+jest.mock('@services/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('mock-token'),
+  },
+}));
+
+jest.mock('@constants/config', () => ({
+  API_CONFIG: {
+    HOST: 'https://api.example.test',
+    TIMEOUT: 5000,
+  },
+}));
+
+describe('scrubErrorMessage', () => {
+  it.each([
+    ['Cannot read /var/mobile/Cache/clip.mp4', '/var/mobile'],
+    ['Open file:///Users/jane/Documents/x.jpg failed', '/Users/jane'],
+    ['content://media/external/video/1 not found', 'content://media'],
+  ])('replaces %s with [path]', (raw, sentinel) => {
+    const out = scrubErrorMessage(raw);
+    expect(out).toContain('[path]');
+    expect(out).not.toContain(sentinel);
+  });
+
+  it('passes through messages without paths', () => {
+    expect(scrubErrorMessage('S3 upload failed (403)')).toBe('S3 upload failed (403)');
+  });
+
+  it('truncates at 200 chars', () => {
+    expect(scrubErrorMessage('x'.repeat(500))).toHaveLength(200);
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(scrubErrorMessage('')).toBe('');
+  });
+});
+
+describe('UploadMetricsAccumulator', () => {
+  function freezeTime(ms: number) {
+    jest.spyOn(Date, 'now').mockReturnValue(ms);
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records per-stage durations', () => {
+    freezeTime(1000);
+    const acc = new UploadMetricsAccumulator('e-1', 'video/mp4', 1_000_000, 'single-put');
+
+    freezeTime(1100);
+    acc.markStageStart('compress');
+    freezeTime(1500); // 400ms compress
+    acc.markStageEnd('compress');
+
+    freezeTime(1600);
+    acc.markStageStart('upload');
+    freezeTime(3600); // 2000ms upload
+    acc.markStageEnd('upload');
+
+    freezeTime(3700);
+    acc.markStageStart('finalize');
+    freezeTime(3850); // 150ms finalize
+    acc.markStageEnd('finalize');
+
+    freezeTime(4000); // build time
+    const event = acc.build({
+      status: 'success',
+      backgroundedDuringUpload: false,
+      appStateAtCompletion: 'active',
+    });
+
+    expect(event.duration_compress_ms).toBe(400);
+    expect(event.duration_upload_ms).toBe(2000);
+    expect(event.duration_finalize_ms).toBe(150);
+    expect(event.duration_total_ms).toBe(3000); // 4000 - 1000
+  });
+
+  it('exposes lastEnteredStage for failure classification', () => {
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    acc.markStageStart('compress');
+    expect(acc.lastEnteredStage).toBe('compress');
+    acc.markStageEnd('compress');
+    expect(acc.lastEnteredStage).toBeNull();
+    acc.markStageStart('upload');
+    expect(acc.lastEnteredStage).toBe('upload');
+  });
+
+  it('scrubs error_message via scrubErrorMessage when building', () => {
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    const event = acc.build({
+      status: 'failed',
+      failureStage: 'upload',
+      errorMessage: 'Failed to open /var/mobile/Cache/x.mp4',
+      backgroundedDuringUpload: false,
+      appStateAtCompletion: 'active',
+    });
+    expect(event.error_message).toContain('[path]');
+    expect(event.error_message).not.toContain('/var/mobile');
+  });
+
+  it('flips upload_path mid-pipeline (single-put → multipart)', () => {
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    acc.setUploadPath('multipart');
+    acc.setPartsCount(12);
+    const event = acc.build({
+      status: 'success',
+      backgroundedDuringUpload: false,
+      appStateAtCompletion: 'active',
+    });
+    expect(event.upload_path).toBe('multipart');
+    expect(event.parts_count).toBe(12);
+  });
+
+  it('treats partsCount as null when not set (single-put path)', () => {
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    const event = acc.build({
+      status: 'success',
+      backgroundedDuringUpload: false,
+      appStateAtCompletion: 'active',
+    });
+    expect(event.parts_count).toBeNull();
+  });
+});
+
+describe('fireUploadTelemetry', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({ ok: true });
+  });
+
+  it('POSTs to /api/telemetry/echo-upload with the event body', async () => {
+    const acc = new UploadMetricsAccumulator(
+      'e-1',
+      'video/mp4',
+      1_000,
+      'single-put',
+    );
+    await fireUploadTelemetry(
+      acc.build({
+        status: 'success',
+        backgroundedDuringUpload: false,
+        appStateAtCompletion: 'active',
+      }),
+    );
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('/api/telemetry/echo-upload');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer mock-token');
+    const parsed = JSON.parse(init.body);
+    expect(parsed.echo_id).toBe('e-1');
+    expect(parsed.status).toBe('success');
+  });
+
+  it('drops silently when no token is available', async () => {
+    const tokenManager =
+      jest.requireMock('@services/tokenManager').tokenManager;
+    tokenManager.getValidToken.mockResolvedValueOnce(null);
+
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    await fireUploadTelemetry(
+      acc.build({
+        status: 'success',
+        backgroundedDuringUpload: false,
+        appStateAtCompletion: 'active',
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('never throws on network failure (fire-and-forget contract)', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network'));
+    const acc = new UploadMetricsAccumulator('e', 'video/mp4', 1, 'single-put');
+    // Should resolve, not reject.
+    await expect(
+      fireUploadTelemetry(
+        acc.build({
+          status: 'success',
+          backgroundedDuringUpload: false,
+          appStateAtCompletion: 'active',
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/uploadTelemetry.ts
+++ b/MirrorCollectiveApp/src/services/api/uploadTelemetry.ts
@@ -1,0 +1,252 @@
+/**
+ * Client-side echo-upload telemetry.
+ *
+ * Fires one structured event per upload outcome (success / failed /
+ * aborted) so we can answer in CloudWatch Logs Insights:
+ *
+ *   - What % of uploads are backgrounded mid-flight?
+ *   - p50/p95 wall-clock duration by upload_path?
+ *   - Which stage fails most often (compress / presign / upload / finalize)?
+ *
+ * Fire-and-forget by design — telemetry must never block the user
+ * or take down a successful upload. A 5 s timeout bounds the wait.
+ * Authentication is required (matches the backend route's auth
+ * gate); if no token is present we drop silently.
+ */
+
+import { Platform } from 'react-native';
+
+import { API_CONFIG } from '@constants/config';
+import { tokenManager } from '@services/tokenManager';
+
+import { version as APP_VERSION } from '../../../package.json';
+
+const TELEMETRY_ENDPOINT = '/api/telemetry/echo-upload';
+
+// Client-side bound matching the server's; defends against shipping
+// huge payloads if a future error path produces verbose messages.
+const MAX_ERROR_MESSAGE_LEN = 200;
+
+// Telemetry must never hang the upload. 5 s is comfortably above any
+// healthy backend response time and well below any user-visible
+// "stuck" window. AbortController + fetch handles the cancellation.
+const TELEMETRY_TIMEOUT_MS = 5_000;
+
+export type UploadPath = 'single-put' | 'multipart';
+export type UploadStatus = 'success' | 'failed' | 'aborted';
+export type UploadFailureStage =
+  | 'compress'
+  | 'presign'
+  | 'upload'
+  | 'finalize';
+export type AppStateAtCompletion = 'active' | 'background';
+
+export interface UploadTelemetryEvent {
+  // What was uploaded
+  echo_id: string;
+  content_type: string;
+  original_bytes: number;
+  compressed_bytes: number | null;
+  upload_path: UploadPath;
+  parts_count: number | null;
+
+  // Outcome
+  status: UploadStatus;
+  failure_stage?: UploadFailureStage;
+  error_message?: string;
+
+  // Performance (ms)
+  duration_compress_ms: number | null;
+  duration_upload_ms: number;
+  duration_finalize_ms: number | null;
+  duration_total_ms: number;
+
+  // Lifecycle / client context
+  backgrounded_during_upload: boolean;
+  retry_count: number;
+  app_state_at_completion: AppStateAtCompletion;
+  platform: 'ios' | 'android';
+  app_version: string;
+}
+
+/**
+ * Truncate + path-scrub an error message before it leaves the device.
+ *
+ * The server also scrubs (belt + suspenders) but doing it here keeps
+ * the payload small over the wire and avoids leaking iOS-side paths
+ * to network observers (proxies, HAR exports, etc.). The patterns
+ * mirror the server's _scrub_error_message.
+ */
+export function scrubErrorMessage(raw: string): string {
+  if (!raw) return '';
+  const scrubbed = raw.replace(
+    /(?:file:\/\/)?(?:content:\/\/[^\s]+|\/(?:var|Users|Library|System|private|tmp)\/[^\s]+)/gi,
+    '[path]',
+  );
+  return scrubbed.length > MAX_ERROR_MESSAGE_LEN
+    ? scrubbed.slice(0, MAX_ERROR_MESSAGE_LEN)
+    : scrubbed;
+}
+
+/**
+ * POST one upload telemetry event. Returns immediately; never throws.
+ * Caller does not await — this is fire-and-forget.
+ */
+export async function fireUploadTelemetry(
+  event: UploadTelemetryEvent,
+): Promise<void> {
+  try {
+    const token = await tokenManager.getValidToken();
+    if (!token) {
+      // No auth = nothing the server can attribute. Drop silently
+      // rather than firing an event we know will 401.
+      return;
+    }
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      TELEMETRY_TIMEOUT_MS,
+    );
+    try {
+      await fetch(`${API_CONFIG.HOST}${TELEMETRY_ENDPOINT}`, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(event),
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch {
+    // Never throw — telemetry is fire-and-forget. Any thrown error
+    // (timeout, network, parse) is swallowed so the user flow never
+    // breaks because telemetry hiccuped.
+  }
+}
+
+/**
+ * In-place accumulator for upload metrics. The pipeline mutates this
+ * across stages; at the end the orchestrator calls
+ * ``buildTelemetryEvent`` and fires the result. Keeping the
+ * accumulator separate from the event shape lets the pipeline track
+ * timings even before it knows the final status.
+ */
+export class UploadMetricsAccumulator {
+  readonly startedAt = Date.now();
+  // Stage start timestamps; null until the stage actually runs.
+  private compressStartedAt: number | null = null;
+  private uploadStartedAt: number | null = null;
+  private finalizeStartedAt: number | null = null;
+  // Stage durations; populated by markStageEnd.
+  private compressDurationMs: number | null = null;
+  private uploadDurationMs: number = 0;
+  private finalizeDurationMs: number | null = null;
+  // Outcome metadata accumulated as we learn it.
+  private retryCount = 0;
+  private partsCount: number | null = null;
+  private compressedBytes: number | null = null;
+  // Most recently entered stage — used to classify a thrown error
+  // into a failure_stage without the caller having to introspect
+  // exception types.
+  private currentStage: UploadFailureStage | null = null;
+  // Caller (uploadEchoMedia) may switch from single-put → multipart
+  // mid-pipeline once the post-compression size crosses threshold.
+  private path: UploadPath;
+
+  constructor(
+    public readonly echoId: string,
+    public readonly contentType: string,
+    public readonly originalBytes: number,
+    initialPath: UploadPath,
+  ) {
+    this.path = initialPath;
+  }
+
+  setUploadPath(p: UploadPath): void {
+    this.path = p;
+  }
+
+  get uploadPath(): UploadPath {
+    return this.path;
+  }
+
+  get lastEnteredStage(): UploadFailureStage | null {
+    return this.currentStage;
+  }
+
+  markStageStart(stage: UploadFailureStage): void {
+    const now = Date.now();
+    this.currentStage = stage;
+    if (stage === 'compress') this.compressStartedAt = now;
+    else if (stage === 'upload') this.uploadStartedAt = now;
+    else if (stage === 'finalize') this.finalizeStartedAt = now;
+    // 'presign' has no duration tracked separately — too short to be
+    // useful and the timestamp would just be overhead. The stage
+    // marker still helps with failure classification.
+  }
+
+  markStageEnd(stage: UploadFailureStage): void {
+    const now = Date.now();
+    if (stage === 'compress' && this.compressStartedAt !== null) {
+      this.compressDurationMs = now - this.compressStartedAt;
+    } else if (stage === 'upload' && this.uploadStartedAt !== null) {
+      this.uploadDurationMs = now - this.uploadStartedAt;
+    } else if (stage === 'finalize' && this.finalizeStartedAt !== null) {
+      this.finalizeDurationMs = now - this.finalizeStartedAt;
+    }
+    if (this.currentStage === stage) this.currentStage = null;
+  }
+
+  setCompressedBytes(n: number): void {
+    this.compressedBytes = n;
+  }
+
+  setPartsCount(n: number): void {
+    this.partsCount = n;
+  }
+
+  incrementRetryCount(): void {
+    this.retryCount += 1;
+  }
+
+  /**
+   * Build the final telemetry event. Caller supplies status + any
+   * failure metadata; the accumulator fills in everything else.
+   */
+  build(args: {
+    status: UploadStatus;
+    failureStage?: UploadFailureStage;
+    errorMessage?: string;
+    backgroundedDuringUpload: boolean;
+    appStateAtCompletion: AppStateAtCompletion;
+  }): UploadTelemetryEvent {
+    return {
+      echo_id: this.echoId,
+      content_type: this.contentType,
+      original_bytes: this.originalBytes,
+      compressed_bytes: this.compressedBytes,
+      upload_path: this.path,
+      parts_count: this.partsCount,
+
+      status: args.status,
+      failure_stage: args.failureStage,
+      error_message: args.errorMessage
+        ? scrubErrorMessage(args.errorMessage)
+        : undefined,
+
+      duration_compress_ms: this.compressDurationMs,
+      duration_upload_ms: this.uploadDurationMs,
+      duration_finalize_ms: this.finalizeDurationMs,
+      duration_total_ms: Date.now() - this.startedAt,
+
+      backgrounded_during_upload: args.backgroundedDuringUpload,
+      retry_count: this.retryCount,
+      app_state_at_completion: args.appStateAtCompletion,
+      platform: Platform.OS === 'android' ? 'android' : 'ios',
+      app_version: APP_VERSION,
+    };
+  }
+}


### PR DESCRIPTION
Client side of the upload-telemetry workstream. Pairs with the backend PR feat/upload-telemetry which adds POST /api/telemetry/echo-upload.

What this PR ships
------------------
- NEW src/services/api/uploadTelemetry.ts:
  - UploadMetricsAccumulator: tracks per-stage durations (compress / upload / finalize), the active stage (so a throw self-classifies into a failure_stage), retry count, compressed_bytes, parts_count. Exposes a build() that emits the full event shape the backend's EchoUploadBeacon expects.
  - scrubErrorMessage: regex strip filesystem paths + truncate at 200. Mirrors the server's _scrub_error_message so the wire payload is already clean (defense in depth — the server scrubs again).
  - fireUploadTelemetry: fire-and-forget POST. AbortController-bounded 5 s timeout. Silently drops if no token (matches the existing fireTelemetry pattern in reflection-room). Never throws.

- uploadEchoMedia wires it in:
  - Captures originalBytes via getFileSize before the pipeline starts.
  - Builds accumulator; passes into _uploadEchoMediaInner.
  - Inner function marks stage transitions (compress / presign / upload / finalize) so the accumulator knows the active stage.
  - When uploadPath flips to 'multipart' (post-compression size >= threshold), accumulator.setUploadPath() updates the event.
  - On success OR thrown failure, the outer wrapper fires telemetry with the captured metrics + AppState lifecycle data (the monitor's isBackgroundedSinceStart flag answers "was this upload interrupted by backgrounding?").

Why these specific metrics
--------------------------
They answer the three questions that gate any future investment in true NSURLSession background uploads:

  - bg interruption rate by upload_path  → "is backgrounding actually a user-visible problem in production?"
  - p95 duration_total_ms by upload_path → "did the perf workstream actually deliver the wins we expected?"
  - failure_stage histogram              → "which stage do we invest
    in next? compression? S3? finalize?"

Tests (14 new)
--------------
- scrubErrorMessage: 4 path patterns, no-op for clean strings, 200-char cap, empty-string handling.
- UploadMetricsAccumulator: per-stage durations recorded correctly; lastEnteredStage flips on start/end; error_message scrubbed at build time; upload_path flip mid-pipeline; partsCount null default.
- fireUploadTelemetry: POSTs to the right endpoint with the right shape + auth header; drops silently when no token; never throws on network failure.
- Also updated the existing temp-file-cleanup tests in echo.test.ts: the new originalBytes stat at the top of uploadEchoMedia consumes one extra mockResolvedValueOnce, so the compression-path tests needed one more 50-MB stat value queued before the default.

Full suite: 463 passed (+14 net). 0 new TypeScript errors.

Privacy contract
----------------
- No file content, no media URIs, no S3 keys, no email leave the device.
- user_id is hashed on the server (the client never sends it; the backend derives it from the JWT). The JWT is already in the Authorization header for every authed call — no new identity surface.
- error_message is scrubbed of paths + truncated to 200 chars on the client before transmission. The server re-scrubs (belt + suspenders).