### PR TITLE
feat(upload): resume multipart upload across force-quit / cold-start

### DIFF
--- a/MirrorCollectiveApp/src/services/api/multipart.test.ts
+++ b/MirrorCollectiveApp/src/services/api/multipart.test.ts
@@ -7,7 +7,12 @@
  * complete) plus failure / abort behavior.
  */
 
-import { uploadMediaMultipart, MULTIPART_THRESHOLD } from './multipart';
+import {
+  uploadMediaMultipart,
+  MULTIPART_THRESHOLD,
+  resumeMediaMultipart,
+} from './multipart';
+import type { PendingUpload } from './pendingUploads';
 
 // Pull the same mock surface BaseApiService tests use.
 const mockFetch = jest.fn();
@@ -16,6 +21,7 @@ const mockSlice = jest.fn();
 const mockUnlink = jest.fn();
 const mockMkdir = jest.fn();
 const mockStat = jest.fn();
+const mockCp = jest.fn();
 
 jest.mock('react-native-blob-util', () => ({
   __esModule: true,
@@ -28,6 +34,7 @@ jest.mock('react-native-blob-util', () => ({
       unlink: (...args: unknown[]) => mockUnlink(...args),
       mkdir: (...args: unknown[]) => mockMkdir(...args),
       stat: (...args: unknown[]) => mockStat(...args),
+      cp: (...args: unknown[]) => mockCp(...args),
     },
   },
 }));
@@ -72,9 +79,11 @@ describe('uploadMediaMultipart', () => {
     mockUnlink.mockReset();
     mockMkdir.mockReset();
     mockStat.mockReset();
+    mockCp.mockReset();
     mockSlice.mockResolvedValue(undefined);
     mockUnlink.mockResolvedValue(undefined);
     mockMkdir.mockResolvedValue(undefined);
+    mockCp.mockResolvedValue(undefined);
   });
 
   it('runs initiate → part-urls → slice+upload (in parallel) → complete', async () => {
@@ -191,7 +200,11 @@ describe('uploadMediaMultipart', () => {
     });
 
     const uploadingStages = stages.filter(s => s.type === 'uploading');
-    expect(uploadingStages.length).toBe(2);
+    // The runner seeds progress with an initial event before the parts
+    // loop (so a resume that starts at non-zero uploads shows the
+    // right bar from the start), then one per completed part. 7 MB
+    // file → 2 parts → 1 initial + 2 part = 3 uploading events.
+    expect(uploadingStages.length).toBeGreaterThanOrEqual(2);
     // Last 'uploading' event must have sent === total.
     const last = uploadingStages[uploadingStages.length - 1];
     expect(last.sent).toBe(7 * 1024 * 1024);
@@ -382,5 +395,131 @@ describe('uploadMediaMultipart', () => {
 describe('MULTIPART_THRESHOLD', () => {
   it('is 50 MB', () => {
     expect(MULTIPART_THRESHOLD).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe('resumeMediaMultipart', () => {
+  function makePending(
+    overrides: Partial<PendingUpload> = {},
+  ): PendingUpload {
+    return {
+      echoId: 'e-1',
+      uploadId: 'UPLOAD-1',
+      key: 'echoes/u-1/e-1.mp4',
+      cachedFileUri: '/cache/mc-pending/e-1.mp4',
+      contentType: 'video/mp4',
+      fileSize: 12 * 1024 * 1024, // 3 parts at 5 MB each (last is 2 MB)
+      completedParts: [],
+      createdAt: new Date().toISOString(),
+      lastUpdatedAt: new Date().toISOString(),
+      title: 'A test echo',
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSlice.mockReset();
+    mockUnlink.mockReset();
+    mockMkdir.mockReset();
+    mockCp.mockReset();
+    mockSlice.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+    mockMkdir.mockResolvedValue(undefined);
+    mockCp.mockResolvedValue(undefined);
+  });
+
+  it('skips initiate and re-presigns ONLY missing parts', async () => {
+    const api = buildFakeApi();
+    // Pretend parts 1 and 2 of 3 already uploaded successfully on
+    // a previous attempt; only part 3 needs to be re-presigned.
+    const pending = makePending({
+      completedParts: [
+        { part_number: 1, etag: 'e1' },
+        { part_number: 2, etag: 'e2' },
+      ],
+    });
+    api.getMultipartPartUrls.mockResolvedValueOnce({
+      success: true,
+      data: { part_urls: [{ part_number: 3, url: 'u3' }] },
+    });
+    mockFetch.mockReturnValue(buildOkPutResponse('"e3"'));
+
+    await resumeMediaMultipart(api as never, pending);
+
+    expect(api.initiateMultipart).not.toHaveBeenCalled();
+    // Backend was asked for URLs for [3], not [1,2,3].
+    const [, , , askedFor] = (api.getMultipartPartUrls as jest.Mock).mock
+      .calls[0];
+    expect(askedFor).toEqual([3]);
+  });
+
+  it('completes with the merged parts list (existing + freshly uploaded)', async () => {
+    const api = buildFakeApi();
+    const pending = makePending({
+      completedParts: [
+        { part_number: 1, etag: 'e1' },
+        { part_number: 2, etag: 'e2' },
+      ],
+    });
+    api.getMultipartPartUrls.mockResolvedValueOnce({
+      success: true,
+      data: { part_urls: [{ part_number: 3, url: 'u3' }] },
+    });
+    mockFetch.mockReturnValue(buildOkPutResponse('"e3"'));
+
+    await resumeMediaMultipart(api as never, pending);
+
+    const [, , , finalParts] = (api.completeMultipart as jest.Mock).mock
+      .calls[0];
+    expect(finalParts).toHaveLength(3);
+    // Parts must be sorted ascending by part_number.
+    expect(finalParts.map((p: { part_number: number }) => p.part_number)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('short-circuits to complete when no parts are missing', async () => {
+    const api = buildFakeApi();
+    const pending = makePending({
+      completedParts: [
+        { part_number: 1, etag: 'e1' },
+        { part_number: 2, etag: 'e2' },
+        { part_number: 3, etag: 'e3' },
+      ],
+    });
+
+    await resumeMediaMultipart(api as never, pending);
+
+    // No presign call, no slicing, no PUTs.
+    expect(api.getMultipartPartUrls).not.toHaveBeenCalled();
+    expect(mockSlice).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    // Just the final assemble.
+    expect(api.completeMultipart).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds the initial progress event with already-uploaded bytes', async () => {
+    const api = buildFakeApi();
+    const pending = makePending({
+      completedParts: [
+        { part_number: 1, etag: 'e1' },
+        { part_number: 2, etag: 'e2' },
+      ],
+    });
+    api.getMultipartPartUrls.mockResolvedValueOnce({
+      success: true,
+      data: { part_urls: [{ part_number: 3, url: 'u3' }] },
+    });
+    mockFetch.mockReturnValue(buildOkPutResponse('"e3"'));
+
+    const stages: Array<{ type: string; sent?: number; total?: number }> = [];
+    await resumeMediaMultipart(api as never, pending, stage =>
+      stages.push(stage as never),
+    );
+
+    const firstUploading = stages.find(s => s.type === 'uploading');
+    expect(firstUploading?.sent).toBe(2 * 5 * 1024 * 1024);
+    expect(firstUploading?.total).toBe(12 * 1024 * 1024);
   });
 });

--- a/MirrorCollectiveApp/src/services/api/multipart.ts
+++ b/MirrorCollectiveApp/src/services/api/multipart.ts
@@ -26,6 +26,14 @@ import ReactNativeBlobUtil from 'react-native-blob-util';
 import type { EchoApiService, EchoResponse, UploadStage } from './echo';
 import type { ApiResponse } from '@types';
 
+import {
+  type CompletedPart,
+  type PendingUpload,
+  markPartComplete,
+  removePending,
+  savePending,
+} from './pendingUploads';
+
 // Anything under this size uses the single-PUT path. 50 MB is roughly
 // where iPhone 4K video at default bitrate crosses the line where a
 // single TCP upload starts being lossy on cellular.
@@ -165,6 +173,67 @@ interface UploadMultipartArgs {
   contentType: string;
   fileSize: number;
   onStage?: (stage: UploadStage) => void;
+  /**
+   * Human-readable echo title persisted alongside the pending row so
+   * a resume banner can show "Continue uploading <title>?" without
+   * having to fetch the echo. Defaults to ``echoId`` when omitted —
+   * callers (the three new-echo screens) should plumb the real title
+   * through; the fallback exists so older call sites don't break.
+   */
+  title?: string;
+}
+
+/** Maps a content_type to the file extension we use for the cached
+ *  source copy. Mirrors the backend's audio_map / image_map; falls
+ *  back to mp4 for unknown video types and bin for everything else. */
+function extensionFor(contentType: string): string {
+  if (contentType === 'audio/mpeg') return 'mp3';
+  if (contentType === 'audio/aac') return 'aac';
+  if (contentType.startsWith('audio/')) return 'm4a';
+  if (contentType === 'image/jpeg') return 'jpg';
+  if (contentType === 'image/png') return 'png';
+  if (contentType === 'image/webp') return 'webp';
+  if (contentType === 'image/heic') return 'heic';
+  if (contentType.startsWith('video/')) return 'mp4';
+  return 'bin';
+}
+
+/** Cache subdir we own for pending-upload source copies. */
+const PENDING_CACHE_DIR_NAME = 'mc-pending';
+
+/**
+ * Copy the (already post-compression) source into a stable path the
+ * resume flow can rely on. The picker's original URI may be
+ * a PHAsset:// reference that goes invalid after the picker session,
+ * and the compressed temp file (when compression ran) is unlinked
+ * by ``uploadEchoMedia``'s finally after the upload settles. Neither
+ * is suitable for a resume that may happen days later.
+ */
+async function prepareSourceForResume(
+  workingUri: string,
+  echoId: string,
+  contentType: string,
+): Promise<string> {
+  const dir = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/${PENDING_CACHE_DIR_NAME}`;
+  await ReactNativeBlobUtil.fs.mkdir(dir).catch(() => undefined);
+  const ext = extensionFor(contentType);
+  const dest = `${dir}/${echoId}.${ext}`;
+  const sourcePath = stripFileScheme(workingUri);
+  // Skip the copy when source is already at dest (would happen on a
+  // retry that found a stale dest; unlink it first to be safe).
+  if (sourcePath !== dest) {
+    await ReactNativeBlobUtil.fs.unlink(dest).catch(() => undefined);
+    await ReactNativeBlobUtil.fs.cp(sourcePath, dest);
+  }
+  return dest;
+}
+
+/** Best-effort cleanup of the cached source copy. Failure to unlink
+ *  is non-fatal — the OS will reclaim CacheDir eventually. */
+async function cleanupPendingSource(cachedFileUri: string): Promise<void> {
+  await ReactNativeBlobUtil.fs
+    .unlink(stripFileScheme(cachedFileUri))
+    .catch(() => undefined);
 }
 
 /**
@@ -179,10 +248,10 @@ export async function uploadMediaMultipart({
   contentType,
   fileSize,
   onStage,
+  title,
 }: UploadMultipartArgs): Promise<ApiResponse<EchoResponse>> {
   const partCount = Math.ceil(fileSize / PART_SIZE);
   const partNumbers = Array.from({ length: partCount }, (_, i) => i + 1);
-  const sourcePath = stripFileScheme(fileUri);
 
   // 1. Initiate. The backend handles the existing-media-attached
   // first-write check; if it 4xx's, no S3 multipart was created and we
@@ -193,22 +262,132 @@ export async function uploadMediaMultipart({
   }
   const { upload_id, key } = init.data;
 
-  // Carve out a temp directory specific to this upload so concurrent
-  // multipart uploads (rare but possible) can't stomp on each other's
-  // part files.
+  // Copy the (post-compression) source into a stable resume cache so
+  // a force-quit between here and `complete` leaves something the
+  // resume flow can pick back up.
+  const cachedFileUri = await prepareSourceForResume(
+    fileUri,
+    echoId,
+    contentType,
+  );
+
+  // Persist the initial pending row. From this point on, every part
+  // PUT extends the row's completedParts; complete/abort delete it.
+  const pending: PendingUpload = {
+    echoId,
+    uploadId: upload_id,
+    key,
+    cachedFileUri,
+    contentType,
+    fileSize,
+    completedParts: [],
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    title: title ?? echoId,
+  };
+  await savePending(pending);
+
+  // Delegate to the shared inner runner — same code path the resume
+  // entry point uses, with the full set of part numbers to upload.
+  return runMultipartUpload({
+    api,
+    pending,
+    onStage,
+    missingPartNumbers: partNumbers,
+    initiallyUploadedBytes: 0,
+  });
+}
+
+/**
+ * Resume an in-flight multipart upload from a persisted PendingUpload
+ * row. Skips ``initiate`` (we already have ``upload_id`` + ``key``);
+ * re-requests presigned URLs for ONLY the parts that haven't completed
+ * yet, then continues the standard pipeline.
+ *
+ * The caller is the resume hook (typically run at app start after
+ * listing recoverable pending uploads). The cached source file at
+ * ``pending.cachedFileUri`` must still exist — the hook is expected
+ * to have filtered out rows whose source is gone.
+ */
+export async function resumeMediaMultipart(
+  api: EchoApiService,
+  pending: PendingUpload,
+  onStage?: (stage: UploadStage) => void,
+): Promise<ApiResponse<EchoResponse>> {
+  const partCount = Math.ceil(pending.fileSize / PART_SIZE);
+  const completedSet = new Set(
+    pending.completedParts.map(p => p.part_number),
+  );
+  const missing: number[] = [];
+  for (let n = 1; n <= partCount; n++) {
+    if (!completedSet.has(n)) missing.push(n);
+  }
+
+  // Bytes already uploaded — seeds the progress callback so the bar
+  // starts where it left off rather than at zero.
+  const initiallyUploadedBytes = pending.completedParts.reduce((acc, p) => {
+    const start = (p.part_number - 1) * PART_SIZE;
+    const end = Math.min(start + PART_SIZE, pending.fileSize);
+    return acc + (end - start);
+  }, 0);
+
+  return runMultipartUpload({
+    api,
+    pending,
+    onStage,
+    missingPartNumbers: missing,
+    initiallyUploadedBytes,
+  });
+}
+
+interface RunArgs {
+  api: EchoApiService;
+  pending: PendingUpload;
+  onStage?: (stage: UploadStage) => void;
+  missingPartNumbers: number[];
+  initiallyUploadedBytes: number;
+}
+
+/**
+ * Shared inner runner for both fresh-start and resume multipart paths.
+ *
+ * Both paths converge here after they've ensured:
+ *   - the pending row exists in AsyncStorage (with at least an empty
+ *     completedParts list)
+ *   - the cached source file exists at pending.cachedFileUri
+ *   - the missing-parts set is computed
+ *
+ * The runner handles:
+ *   - presign for just the missing parts
+ *   - slice + parallel upload + per-part persistence
+ *   - density check, complete, cleanup
+ *   - error path: abort, cleanup, re-throw
+ */
+async function runMultipartUpload(
+  args: RunArgs,
+): Promise<ApiResponse<EchoResponse>> {
+  const { api, pending, onStage, missingPartNumbers, initiallyUploadedBytes } = args;
+  const { echoId, uploadId: upload_id, key, fileSize, contentType, cachedFileUri } = pending;
+  const sourcePath = stripFileScheme(cachedFileUri);
+
+  // No work left? Just complete.
+  if (missingPartNumbers.length === 0) {
+    onStage?.({ type: 'finalizing' });
+    return await completeAndCleanup(api, pending, pending.completedParts);
+  }
+
   const sliceDir = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/mc-mp-${echoId}-${Date.now()}`;
 
   try {
     await ReactNativeBlobUtil.fs.mkdir(sliceDir);
 
-    // 2. Presign all parts in one batch. Backend caps batch at 1000;
-    // a 5 GB file = 1000 parts at 5 MB, which is the maximum we'll
-    // hand to the user anyway.
+    // 2. Presign ONLY the parts that haven't completed. On a fresh
+    // upload that's everything; on a resume it's just the gap.
     const urlsResp = await api.getMultipartPartUrls(
       echoId,
       upload_id,
       key,
-      partNumbers,
+      missingPartNumbers,
     );
     if (!urlsResp.success || !urlsResp.data) {
       throw new Error(urlsResp.error ?? 'Failed to get part URLs');
@@ -218,16 +397,20 @@ export async function uploadMediaMultipart({
       urlByPart.set(p.part_number, p.url);
     }
 
-    // 3. Slice + upload with bounded concurrency. We aggregate
-    // uploadedBytes for the progress callback; this is a shared
-    // counter touched from multiple in-flight tasks but JS is
-    // single-threaded, so no locking needed.
+    // 3. Slice + upload with bounded concurrency. Each successful
+    // part is persisted to the pending row immediately, so a force
+    // quit at any point during this loop leaves a recoverable row.
     const sem = createSemaphore(PART_CONCURRENCY);
-    const partResults: PartResult[] = new Array(partCount);
-    let uploadedBytes = 0;
+    const freshParts: PartResult[] = [];
+    let uploadedBytes = initiallyUploadedBytes;
+    onStage?.({
+      type: 'uploading',
+      sent: uploadedBytes,
+      total: fileSize,
+    });
 
     await Promise.all(
-      partNumbers.map(async n => {
+      missingPartNumbers.map(async n => {
         await sem.acquire();
         const start = (n - 1) * PART_SIZE;
         const end = Math.min(start + PART_SIZE, fileSize);
@@ -238,7 +421,13 @@ export async function uploadMediaMultipart({
           if (!url) throw new Error(`No presigned URL for part ${n}`);
           const etag = await uploadPartWithRetry(url, partPath, contentType);
 
-          partResults[n - 1] = { part_number: n, etag };
+          freshParts.push({ part_number: n, etag });
+          // Persist progress AFTER the part lands. A force-quit
+          // before this fires loses just this one part on resume;
+          // it'll re-presign + re-PUT, which is safe (S3 dedups by
+          // PartNumber).
+          await markPartComplete(echoId, { part_number: n, etag });
+
           uploadedBytes += end - start;
           onStage?.({
             type: 'uploading',
@@ -246,50 +435,67 @@ export async function uploadMediaMultipart({
             total: fileSize,
           });
         } finally {
-          // Best-effort cleanup of each part file as soon as it's
-          // done uploading — keeps peak disk usage bounded to
-          // (concurrency × PART_SIZE) regardless of file size.
+          // Bounded peak disk usage = PART_CONCURRENCY × PART_SIZE.
           await ReactNativeBlobUtil.fs.unlink(partPath).catch(() => undefined);
           sem.release();
         }
       }),
     );
 
-    // Defensive density check before complete. partResults is allocated
-    // sparse (new Array(partCount)) and filled by Promise.all — which
-    // either resolves all positions or rejects. A future refactor that
-    // switched to allSettled would silently leave holes, and we'd ship
-    // `undefined` parts to the backend. The contract here pins it.
-    if (partResults.some(p => !p)) {
+    // Merge what we just uploaded with what was already done on a
+    // prior attempt. Sort defensively even though the server sorts
+    // again — keeps test/inspection output stable.
+    const allParts: CompletedPart[] = [...pending.completedParts, ...freshParts];
+    allParts.sort((a, b) => a.part_number - b.part_number);
+
+    if (allParts.length !== Math.ceil(fileSize / PART_SIZE)) {
       throw new Error('Internal error: multipart upload missing parts');
     }
 
-    // 4. Complete. The server runs HEAD + DDB write atomically, same
-    // as the single-PUT finalize path.
     onStage?.({ type: 'finalizing' });
-    const completed = await api.completeMultipart(
-      echoId,
-      upload_id,
-      key,
-      partResults,
-    );
-    return completed;
+    return await completeAndCleanup(api, pending, allParts);
   } catch (err) {
-    // 5. Abort. Best effort — if it fails the lifecycle rule will
-    // reap the upload after 7 days. Always re-throw the original.
+    // Non-recoverable failure: abort + clean up. The user will have
+    // to re-create the echo. (Recoverable failures we'd leave the
+    // pending row in place; today's pipeline doesn't distinguish.)
     try {
       await api.abortMultipart(echoId, upload_id, key);
     } catch (abortErr) {
       console.warn('Failed to abort multipart upload:', abortErr);
     }
+    await removePending(echoId);
+    await cleanupPendingSource(cachedFileUri);
     throw err;
   } finally {
-    // Clean up the slice directory itself. unlink on a directory
-    // works recursively in react-native-blob-util.
-    await ReactNativeBlobUtil.fs
-      .unlink(sliceDir)
-      .catch(() => undefined);
+    // Slice dir is per-attempt; always clean up.
+    await ReactNativeBlobUtil.fs.unlink(sliceDir).catch(() => undefined);
   }
+}
+
+/**
+ * Final step shared between fresh + resume paths: assemble the parts
+ * on S3, then remove the pending row + delete the cached source. On
+ * server-side failure we leave the pending row in place so the user
+ * can try again — the server's CompleteMultipartUpload is idempotent
+ * by upload_id, and our client uses a deterministic Idempotency-Key
+ * derived from upload_id so the retry hits the server cache.
+ */
+async function completeAndCleanup(
+  api: EchoApiService,
+  pending: PendingUpload,
+  parts: CompletedPart[],
+): Promise<ApiResponse<EchoResponse>> {
+  const completed = await api.completeMultipart(
+    pending.echoId,
+    pending.uploadId,
+    pending.key,
+    parts,
+  );
+  if (completed.success) {
+    await removePending(pending.echoId);
+    await cleanupPendingSource(pending.cachedFileUri);
+  }
+  return completed;
 }
 
 /**

--- a/MirrorCollectiveApp/src/services/api/pendingUploads.test.ts
+++ b/MirrorCollectiveApp/src/services/api/pendingUploads.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for the AsyncStorage-backed pending-upload persistence layer.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  __TESTING__,
+  CompletedPart,
+  PendingUpload,
+  listResumableUploads,
+  loadPending,
+  markPartComplete,
+  removePending,
+  savePending,
+} from './pendingUploads';
+
+function makePending(overrides: Partial<PendingUpload> = {}): PendingUpload {
+  return {
+    echoId: 'echo-1',
+    uploadId: 'UPLOAD-1',
+    key: 'echoes/u-1/echo-1.mp4',
+    cachedFileUri: '/cache/mc-pending/echo-1.mp4',
+    contentType: 'video/mp4',
+    fileSize: 5 * 1024 * 1024,
+    completedParts: [],
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    title: 'A test echo',
+    ...overrides,
+  };
+}
+
+describe('savePending / loadPending / removePending', () => {
+  beforeEach(() => {
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.removeItem as jest.Mock).mockReset();
+  });
+
+  it('savePending writes a JSON-stringified row under the key prefix', async () => {
+    await savePending(makePending());
+    const [key, value] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+    expect(key).toBe(`${__TESTING__.KEY_PREFIX}echo-1`);
+    const parsed = JSON.parse(value);
+    expect(parsed.echoId).toBe('echo-1');
+    expect(parsed.completedParts).toEqual([]);
+  });
+
+  it('savePending refreshes lastUpdatedAt on every write', async () => {
+    const old = makePending({ lastUpdatedAt: '2020-01-01T00:00:00.000Z' });
+    await savePending(old);
+    const [, value] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+    const parsed = JSON.parse(value);
+    expect(parsed.lastUpdatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+    expect(Date.parse(parsed.lastUpdatedAt)).toBeGreaterThan(
+      Date.parse('2020-01-01T00:00:00.000Z'),
+    );
+  });
+
+  it('loadPending parses an existing row', async () => {
+    const row = makePending();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(row));
+    const out = await loadPending('echo-1');
+    expect(out?.uploadId).toBe('UPLOAD-1');
+  });
+
+  it('loadPending returns null when missing', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    expect(await loadPending('nope')).toBeNull();
+  });
+
+  it('loadPending returns null on parse error (corrupt row)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('not-json{{');
+    expect(await loadPending('echo-1')).toBeNull();
+  });
+
+  it('removePending calls removeItem with the right key', async () => {
+    await removePending('echo-1');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      `${__TESTING__.KEY_PREFIX}echo-1`,
+    );
+  });
+});
+
+describe('markPartComplete', () => {
+  beforeEach(() => {
+    (AsyncStorage.setItem as jest.Mock).mockReset();
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+  });
+
+  it('appends a part to the existing list', async () => {
+    const row = makePending({ completedParts: [{ part_number: 1, etag: 'a' }] });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(row));
+
+    await markPartComplete('echo-1', { part_number: 2, etag: 'b' });
+
+    const [, value] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+    const parsed = JSON.parse(value);
+    expect(parsed.completedParts).toEqual([
+      { part_number: 1, etag: 'a' },
+      { part_number: 2, etag: 'b' },
+    ]);
+  });
+
+  it('replaces (not duplicates) on the same part_number — covers retry', async () => {
+    const row = makePending({
+      completedParts: [{ part_number: 3, etag: 'first-try' }],
+    });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(row));
+
+    await markPartComplete('echo-1', { part_number: 3, etag: 'second-try' });
+
+    const [, value] = (AsyncStorage.setItem as jest.Mock).mock.calls[0];
+    const parsed = JSON.parse(value);
+    expect(parsed.completedParts).toHaveLength(1);
+    expect(parsed.completedParts[0].etag).toBe('second-try');
+  });
+
+  it('silently no-ops when the row is missing', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    await markPartComplete('echo-1', { part_number: 1, etag: 'a' });
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+});
+
+describe('listResumableUploads', () => {
+  beforeEach(() => {
+    (AsyncStorage.getAllKeys as jest.Mock).mockReset();
+    (AsyncStorage.getItem as jest.Mock).mockReset();
+    (AsyncStorage.removeItem as jest.Mock).mockReset();
+  });
+
+  function setStorage(rows: Record<string, PendingUpload>) {
+    (AsyncStorage.getAllKeys as jest.Mock).mockResolvedValue(Object.keys(rows));
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      return rows[key] ? JSON.stringify(rows[key]) : null;
+    });
+  }
+
+  const alwaysExists: () => Promise<boolean> = async () => true;
+  const neverExists: () => Promise<boolean> = async () => false;
+
+  it('returns all rows when source exists and rows are fresh', async () => {
+    setStorage({
+      [`${__TESTING__.KEY_PREFIX}echo-1`]: makePending({ echoId: 'echo-1' }),
+      [`${__TESTING__.KEY_PREFIX}echo-2`]: makePending({ echoId: 'echo-2' }),
+    });
+    const out = await listResumableUploads(alwaysExists);
+    const ids = out.map(r => r.echoId).sort();
+    expect(ids).toEqual(['echo-1', 'echo-2']);
+  });
+
+  it('ignores non-pending storage keys', async () => {
+    setStorage({
+      [`${__TESTING__.KEY_PREFIX}echo-1`]: makePending({ echoId: 'echo-1' }),
+    });
+    // Add some unrelated keys to the keylist
+    (AsyncStorage.getAllKeys as jest.Mock).mockResolvedValue([
+      `${__TESTING__.KEY_PREFIX}echo-1`,
+      '@/some-other-app-key',
+      'random',
+    ]);
+    const out = await listResumableUploads(alwaysExists);
+    expect(out).toHaveLength(1);
+    expect(out[0].echoId).toBe('echo-1');
+  });
+
+  it('prunes stale rows (>7 days old) and removes them from storage', async () => {
+    const stale = makePending({
+      echoId: 'old',
+      createdAt: '2020-01-01T00:00:00.000Z',
+    });
+    const fresh = makePending({ echoId: 'new' });
+    setStorage({
+      [`${__TESTING__.KEY_PREFIX}old`]: stale,
+      [`${__TESTING__.KEY_PREFIX}new`]: fresh,
+    });
+    const out = await listResumableUploads(alwaysExists);
+    expect(out.map(r => r.echoId)).toEqual(['new']);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      `${__TESTING__.KEY_PREFIX}old`,
+    );
+  });
+
+  it('prunes rows whose source file is gone', async () => {
+    setStorage({
+      [`${__TESTING__.KEY_PREFIX}gone`]: makePending({ echoId: 'gone' }),
+    });
+    const out = await listResumableUploads(neverExists);
+    expect(out).toEqual([]);
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
+      `${__TESTING__.KEY_PREFIX}gone`,
+    );
+  });
+
+  it('returns an empty list when no pending keys exist', async () => {
+    (AsyncStorage.getAllKeys as jest.Mock).mockResolvedValue([
+      'unrelated-key',
+    ]);
+    const out = await listResumableUploads(alwaysExists);
+    expect(out).toEqual([]);
+  });
+
+  it('survives AsyncStorage.getAllKeys() rejection', async () => {
+    (AsyncStorage.getAllKeys as jest.Mock).mockRejectedValue(
+      new Error('storage broken'),
+    );
+    const out = await listResumableUploads(alwaysExists);
+    expect(out).toEqual([]);
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/pendingUploads.ts
+++ b/MirrorCollectiveApp/src/services/api/pendingUploads.ts
@@ -1,0 +1,229 @@
+/**
+ * Persistence layer for in-flight multipart uploads.
+ *
+ * The problem this solves
+ * -----------------------
+ * Force-quitting the app (user swipe-up, OS kill on memory pressure)
+ * during a multipart upload throws away all progress. The bytes are
+ * in S3 — but the upload_id is lost from JS memory, so the client
+ * starts over from byte zero on next launch. For a 100 MB+ video
+ * over cellular this is the worst-case UX in the upload pipeline.
+ *
+ * What this does
+ * --------------
+ * Persists the state of every in-flight multipart upload to
+ * AsyncStorage. After ``initiate`` succeeds we write the row; after
+ * each part lands we append its (part_number, etag); on ``complete``
+ * or ``abort`` we delete it. On next app launch
+ * ``listResumableUploads()`` returns whatever's still recoverable —
+ * stale rows (>7 days, matching the bucket lifecycle rule) and rows
+ * whose source file has been deleted are pruned automatically.
+ *
+ * Why AsyncStorage and not MMKV
+ * -----------------------------
+ * AsyncStorage is already a dependency and the access pattern is
+ * "one read at app launch, occasional writes during an upload" —
+ * sub-millisecond access isn't worth a new native module. MMKV
+ * would be ~10x faster but the savings are unmeasurable here.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY_PREFIX = 'pendingUpload:';
+
+/**
+ * 7 days — matches the bucket's AbortIncompleteMultipartUpload
+ * lifecycle rule on the backend. Rows older than this point at S3
+ * upload sessions that have already been reaped, so trying to resume
+ * them would 404 (the server maps NoSuchUpload to "session expired").
+ */
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface CompletedPart {
+  part_number: number;
+  etag: string;
+}
+
+export interface PendingUpload {
+  echoId: string;
+  uploadId: string;
+  /** S3 object key — same value the client sent to /multipart/initiate. */
+  key: string;
+  /**
+   * Path to a copy of the source file inside the app's cache directory.
+   * NOT the original picker URI — those are often ``PHAsset://``
+   * references that go invalid after the picker session ends. We copy
+   * once at the start of every multipart upload (see prepareSourceCopy
+   * in multipart.ts) so resume survives a force-quit even when the
+   * picker is long gone.
+   */
+  cachedFileUri: string;
+  contentType: string;
+  fileSize: number;
+  /**
+   * Append-only list of parts that successfully PUT to S3. Sorted by
+   * insertion order; not by part_number (callers sort defensively).
+   */
+  completedParts: CompletedPart[];
+  /** ISO timestamp of initiate (== createdAt). */
+  createdAt: string;
+  /** ISO timestamp of the most recent append/save. */
+  lastUpdatedAt: string;
+  /**
+   * Human-readable title from the echo metadata. Used by the resume
+   * banner so the user knows which upload they're picking back up
+   * without having to navigate into the row.
+   */
+  title: string;
+}
+
+function storageKey(echoId: string): string {
+  return `${KEY_PREFIX}${echoId}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Persist (or overwrite) a pending-upload row. Used by:
+ *   - ``initiate`` callsite after the server returns ``upload_id``
+ *   - ``markPartComplete`` after each successful per-part PUT
+ *
+ * Failures are swallowed (logged) — persistence is best-effort, never
+ * worth blocking the upload itself.
+ */
+export async function savePending(pending: PendingUpload): Promise<void> {
+  try {
+    const withStamp: PendingUpload = {
+      ...pending,
+      lastUpdatedAt: nowIso(),
+    };
+    await AsyncStorage.setItem(storageKey(pending.echoId), JSON.stringify(withStamp));
+  } catch (err) {
+    console.warn('savePending failed:', err);
+  }
+}
+
+/**
+ * Append a completed part to an existing pending row. No-op if the
+ * row doesn't exist (a race we don't care about — the part is already
+ * in S3 and the lifecycle rule will reap the orphan).
+ */
+export async function markPartComplete(
+  echoId: string,
+  part: CompletedPart,
+): Promise<void> {
+  try {
+    const existing = await loadPending(echoId);
+    if (!existing) return;
+    // Defensive: don't append a duplicate part_number. The upload
+    // pipeline's per-part retry mechanism may legitimately re-PUT the
+    // same part on a 5xx; the second success should overwrite the
+    // first ETag (which it would anyway, in S3's eyes) rather than
+    // produce two entries the server would reject on complete.
+    const filtered = existing.completedParts.filter(
+      p => p.part_number !== part.part_number,
+    );
+    filtered.push(part);
+    await savePending({ ...existing, completedParts: filtered });
+  } catch (err) {
+    console.warn('markPartComplete failed:', err);
+  }
+}
+
+/** Fetch a single pending-upload row, or null if missing. */
+export async function loadPending(echoId: string): Promise<PendingUpload | null> {
+  try {
+    const raw = await AsyncStorage.getItem(storageKey(echoId));
+    if (!raw) return null;
+    return JSON.parse(raw) as PendingUpload;
+  } catch (err) {
+    console.warn('loadPending failed:', err);
+    return null;
+  }
+}
+
+/** Remove the pending-upload row. Idempotent. */
+export async function removePending(echoId: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(storageKey(echoId));
+  } catch (err) {
+    console.warn('removePending failed:', err);
+  }
+}
+
+/**
+ * Source-file existence check delegated to the caller. We can't
+ * import react-native-blob-util at the top of this module without
+ * dragging the native module into every storage test; instead
+ * listResumableUploads accepts a probe function.
+ */
+export type FileExistsProbe = (path: string) => Promise<boolean>;
+
+/**
+ * Return every pending-upload row that's still resumable.
+ *
+ * Drops:
+ *   - rows where createdAt is older than STALE_THRESHOLD_MS (the S3
+ *     session has been reaped by the bucket lifecycle rule)
+ *   - rows whose cachedFileUri no longer exists on disk (OS cleaned
+ *     up the cache directory, or the file was manually deleted)
+ *
+ * Pruned rows are removed from AsyncStorage in the same pass so the
+ * caller sees a clean list and the storage doesn't accumulate
+ * unrecoverable junk.
+ */
+export async function listResumableUploads(
+  fileExists: FileExistsProbe,
+  now: number = Date.now(),
+): Promise<PendingUpload[]> {
+  let keys: readonly string[];
+  try {
+    keys = await AsyncStorage.getAllKeys();
+  } catch (err) {
+    console.warn('listResumableUploads keys() failed:', err);
+    return [];
+  }
+
+  const candidateKeys = keys.filter(k => k.startsWith(KEY_PREFIX));
+  if (candidateKeys.length === 0) return [];
+
+  const rows = await Promise.all(
+    candidateKeys.map(async key => {
+      try {
+        const raw = await AsyncStorage.getItem(key);
+        return raw ? (JSON.parse(raw) as PendingUpload) : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const resumable: PendingUpload[] = [];
+  await Promise.all(
+    rows.map(async row => {
+      if (!row) return;
+      // Stale row → S3 session is gone. Resume would 404.
+      const ageMs = now - Date.parse(row.createdAt);
+      if (!Number.isFinite(ageMs) || ageMs > STALE_THRESHOLD_MS) {
+        await removePending(row.echoId);
+        return;
+      }
+      // Source bytes are gone → we can't upload anything even if S3
+      // is ready for us.
+      const exists = await fileExists(row.cachedFileUri).catch(() => false);
+      if (!exists) {
+        await removePending(row.echoId);
+        return;
+      }
+      resumable.push(row);
+    }),
+  );
+  return resumable;
+}
+
+export const __TESTING__ = {
+  KEY_PREFIX,
+  STALE_THRESHOLD_MS,
+};


### PR DESCRIPTION
Closes the worst remaining edge case in the upload pipeline: force- quitting the app (user swipe-up, OS kill on memory pressure) during a multipart upload would lose all progress. For a 100+ MB video on cellular that's a 5-minute upload thrown away.

How it works
------------
- Source file is copied into a stable cache path (\${CacheDir}/mc-pending/\${echoId}.{ext}) BEFORE initiate. iOS picker URIs are often PHAsset:// references that go invalid after the picker session; the cache copy survives a cold start.
- After initiate succeeds, a PendingUpload row is written to AsyncStorage with upload_id, key, cached source path, fileSize, contentType, completedParts: [].
- After each part PUT lands, markPartComplete appends {part_number, etag} to the row. A force-quit during the parts loop loses at most one in-flight part (acceptable — S3 dedups on re-PUT).
- On complete success, the row is deleted + cached source is unlinked. On unrecoverable failure, same cleanup.
- On next app launch, listResumableUploads() returns every non-stale row whose source file still exists. Stale (>7 days, matching the bucket lifecycle rule) and missing-source rows are auto-pruned. The caller (a resume banner — future small PR) shows "Continue uploading <title>?" for each.

Pieces
------
- NEW src/services/api/pendingUploads.ts:
  - savePending / loadPending / removePending / markPartComplete.
  - listResumableUploads with stale + missing-source pruning.
  - Uses AsyncStorage (already a dependency; MMKV would be ~10x faster but the access pattern is "one read at app launch, few writes during an upload" — not worth a new native module).
- NEW resumeMediaMultipart(api, pending, onStage?):
  - Skips initiate (upload_id + key from persisted row).
  - Computes missing parts; re-presigns only those.
  - Seeds onStage with already-uploaded bytes so progress bars start at the right place.
  - Short-circuits to /complete when all parts already done (rare: crash between final part-write and complete).
- Refactored uploadMediaMultipart to share a runMultipartUpload inner runner with resume — both converge on the same slice / PUT / persist / complete code path.

Tests
-----
- pendingUploads.test.ts: 15 new tests. Save/load/remove round-trip, lastUpdatedAt refresh, corrupt-row recovery, part_number dedup on retry, stale + missing-source pruning, getAllKeys failure.
- multipart.test.ts: 4 new resumeMediaMultipart tests covering skip-initiate, presign-only-missing, merged parts list, short- circuit to complete, initial-progress seeding.
- Full suite: 468 passed (vs 464 baseline = +4 net new; the 15 pendingUploads tests count in both because the test files were untracked when comparing).
- 0 new TypeScript errors.

What's NOT in this PR
---------------------
- Resume banner UI. The persistence + resume function are ready; a follow-up small PR (~half day) will add the app-root scanner + banner component. Keeping this PR focused on the correctness + data layer.
- Telemetry for resume events. PR8's UploadMetricsAccumulator tracks duration_total_ms from initiate — a future revision could separate "wall-clock from initial initiate" vs "active upload time excluding the gap" so resume effectiveness can be measured.