### PR TITLE
feat(echo): client-side video poster extraction + attach

### DIFF
--- a/MirrorCollectiveApp/src/__tests__/jest.setup.js
+++ b/MirrorCollectiveApp/src/__tests__/jest.setup.js
@@ -263,6 +263,13 @@ jest.mock('react-native-compressor', () => ({
   __esModule: true,
   Video: { compress: jest.fn((uri) => Promise.resolve(uri)) },
   Image: { compress: jest.fn((uri) => Promise.resolve(uri)) },
+  // Poster-frame extractor. Default: rejects so the poster pipeline
+  // silently no-ops in tests that don't opt in. Override per-test:
+  //   jest.requireMock('react-native-compressor').createVideoThumbnail
+  //     .mockResolvedValue({ path: '/cache/thumb.jpg', size: 1, mime: 'image/jpeg', width: 1, height: 1 })
+  createVideoThumbnail: jest.fn(() =>
+    Promise.reject(new Error('not mocked')),
+  ),
 }));
 
 // Mock expo-image — its native module touches a TurboModule registry

--- a/MirrorCollectiveApp/src/services/api/echo.test.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.test.ts
@@ -500,6 +500,51 @@ describe('EchoApiService', () => {
     });
   });
 
+  describe('attachPoster', () => {
+    beforeEach(() => {
+      (global.fetch as jest.Mock).mockReset();
+    });
+
+    it('POSTs to /api/echoes/{id}/attach-poster with the key', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { echo_id: 'e-1', poster_url: 'https://signed/poster' },
+        }),
+      });
+
+      await echoApiService.attachPoster('e-1', 'echoes/u-1/e-1_poster.jpg');
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url).toContain('/api/echoes/e-1/attach-poster');
+      expect((init as { method: string }).method).toBe('POST');
+      const body = JSON.parse((init as { body: string }).body);
+      expect(body).toEqual({ key: 'echoes/u-1/e-1_poster.jpg' });
+    });
+
+    it('URL-encodes the echoId in the path', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: {} }),
+      });
+      await echoApiService.attachPoster('a/b c', 'echoes/u-1/a-b-c_poster.jpg');
+      const [url] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(url as string).toContain('/api/echoes/a%2Fb%20c/attach-poster');
+    });
+
+    it('does NOT send an Idempotency-Key (overwrite is naturally idempotent)', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: {} }),
+      });
+      await echoApiService.attachPoster('e-1', 'echoes/u-1/e-1_p.jpg');
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+      const headers = (init as { headers: Record<string, string> }).headers;
+      expect(headers['Idempotency-Key']).toBeUndefined();
+    });
+  });
+
   describe('completeMultipart', () => {
     it('uses a deterministic Idempotency-Key derived from upload_id', async () => {
       // Two calls with the SAME upload_id must produce the SAME key —

--- a/MirrorCollectiveApp/src/services/api/echo.ts
+++ b/MirrorCollectiveApp/src/services/api/echo.ts
@@ -4,6 +4,7 @@ import type { ApiResponse } from '@types';
 import {
   compressImageIfNeeded,
   compressVideoIfNeeded,
+  createPosterThumbnail,
   unlinkQuietly,
 } from '@utils/media/compress';
 import { uuidV4 } from '@utils/uuid';
@@ -92,6 +93,13 @@ export interface EchoResponse {
   status?: EchoStatus;
   created_at: string;
   media_url?: string;
+  /**
+   * Video-only: presigned URL for a poster JPEG extracted client-side
+   * at upload time. Use as the thumbnail in list cards and as the
+   * Video player's poster prop. Absent for audio / text / pre-PR6
+   * video rows.
+   */
+  poster_url?: string;
   content?: string;
   recipient?: {
     recipient_id: string;
@@ -612,6 +620,34 @@ export class EchoApiService extends BaseApiService {
     return ApiErrorHandler.handleApiResponse(response, 'Media finalized');
   }
 
+  /**
+   * Attach a client-extracted poster frame to a video echo.
+   *
+   * The poster is a JPEG produced by
+   * ``react-native-compressor.createVideoThumbnail`` from the same
+   * video the client just uploaded. After uploading the JPEG via the
+   * standard single-PUT path, the client calls this to commit it as
+   * the thumbnail on the echo row.
+   *
+   * No idempotency key — the poster slot is naturally idempotent (a
+   * retry just overwrites the same URL). Default timeout is fine.
+   */
+  async attachPoster(
+    echoId: string,
+    key: string,
+  ): Promise<ApiResponse<{ echo_id: string; poster_url: string }>> {
+    const response = await this.makeRequest<{
+      echo_id: string;
+      poster_url: string;
+    }>(
+      `/api/echoes/${encodeURIComponent(echoId)}/attach-poster`,
+      'POST',
+      { key },
+      true,
+    );
+    return ApiErrorHandler.handleApiResponse(response, 'Poster attached');
+  }
+
   // ========== Multipart upload (files > MULTIPART_THRESHOLD) ==========
   //
   // Wraps the four backend routes that bridge to S3's MultipartUpload
@@ -854,6 +890,13 @@ export class EchoApiService extends BaseApiService {
           onStage,
         });
         accumulator?.markStageEnd('upload');
+        // Fire-and-forget poster extraction for video. Failure is
+        // non-fatal — the echo is already saved; the poster just
+        // won't appear in lists until the user re-uploads. See
+        // _attachPosterIfVideo for details.
+        if (result.success && contentType.startsWith('video/')) {
+          void this._attachPosterIfVideo(echoId, workingUri);
+        }
         return result;
       }
 
@@ -899,12 +942,71 @@ export class EchoApiService extends BaseApiService {
             'Upload completed but could not be confirmed. Please try saving again.',
         };
       }
+      // Fire-and-forget poster extraction for video echoes. Doesn't
+      // block the user's save — if it fails, the echo is still saved
+      // and the list just won't show a thumbnail for this video.
+      if (contentType.startsWith('video/')) {
+        void this._attachPosterIfVideo(echoId, workingUri);
+      }
       return finalized;
     } finally {
       // Best-effort cleanup of the compressed temp file. The original
       // (picker-supplied) URI is the platform's — never touch it.
       if (workingUri !== fileUri) {
         await unlinkQuietly(workingUri);
+      }
+    }
+  }
+
+  /**
+   * Extract a poster frame from a video and attach it to the echo.
+   *
+   * Runs as fire-and-forget AFTER a successful video upload. Failure
+   * at any step is non-fatal — the echo is already saved; the worst
+   * outcome is "no thumbnail in vault list for this video," which
+   * the UI handles by falling back to the existing motif/avatar.
+   *
+   * Pipeline:
+   *   1. createVideoThumbnail(workingUri) → JPEG at app cache path
+   *   2. getUploadUrl(image/jpeg, echoId) → presigned URL + S3 key
+   *   3. uploadMedia(uploadUrl, posterPath) → bytes land in S3
+   *   4. attachPoster(echoId, key) → backend writes poster_url to DDB
+   *   5. cleanup the local poster file
+   *
+   * No retry on failure (don't compound a low-impact secondary task).
+   * No idempotency key (the backend route allows overwrite, so a
+   * retried call is harmless).
+   */
+  private async _attachPosterIfVideo(
+    echoId: string,
+    videoUri: string,
+  ): Promise<void> {
+    let posterPath: string | null = null;
+    try {
+      posterPath = await createPosterThumbnail(videoUri);
+      if (!posterPath) return; // generation failed; logged inside helper
+
+      const presigned = await this.getUploadUrl('image/jpeg', echoId, 'echo');
+      if (!presigned.success || !presigned.data) {
+        console.warn(
+          'Poster upload-url failed:',
+          presigned.error ?? 'unknown',
+        );
+        return;
+      }
+      const { upload_url, key } = presigned.data;
+
+      await this.uploadMedia(upload_url, posterPath, 'image/jpeg');
+      const attached = await this.attachPoster(echoId, key);
+      if (!attached.success) {
+        console.warn('attachPoster failed:', attached.error ?? 'unknown');
+      }
+    } catch (err) {
+      // Never propagate — caller is `void`-ing this.
+      console.warn('Poster attach pipeline failed:', err);
+    } finally {
+      if (posterPath) {
+        await unlinkQuietly(posterPath);
       }
     }
   }

--- a/MirrorCollectiveApp/src/utils/media/compress.ts
+++ b/MirrorCollectiveApp/src/utils/media/compress.ts
@@ -18,7 +18,11 @@
  */
 
 import ReactNativeBlobUtil from 'react-native-blob-util';
-import { Image, Video } from 'react-native-compressor';
+import {
+  Image,
+  Video,
+  createVideoThumbnail,
+} from 'react-native-compressor';
 
 export interface CompressResult {
   /** The URI the caller should upload — original or compressed. */
@@ -133,5 +137,30 @@ export async function unlinkQuietly(uri: string): Promise<void> {
     await ReactNativeBlobUtil.fs.unlink(path);
   } catch (err) {
     console.warn('Failed to unlink compressed temp file:', uri, err);
+  }
+}
+
+/**
+ * Extract a single JPEG frame from a video for use as a poster thumbnail.
+ *
+ * Uses ``react-native-compressor.createVideoThumbnail`` which native-side
+ * runs AVAssetImageGenerator (iOS) / MediaMetadataRetriever (Android)
+ * and writes a JPEG to the app cache directory. The default frame is
+ * t=1s; we let the library decide so we don't fight its codec defaults.
+ *
+ * Returns the local file path (caller is responsible for uploading +
+ * cleanup) or null if extraction fails. Never throws — poster
+ * generation is opportunistic and a failure shouldn't cascade into
+ * the user-facing save flow.
+ */
+export async function createPosterThumbnail(
+  videoUri: string,
+): Promise<string | null> {
+  try {
+    const result = await createVideoThumbnail(videoUri);
+    return result?.path ?? null;
+  } catch (err) {
+    console.warn('createVideoThumbnail failed:', err);
+    return null;
   }
 }


### PR DESCRIPTION
Pairs with the backend PR feat/video-poster-frame. After every successful video upload, fires the poster-extraction pipeline as fire-and-forget so the user's save isn't blocked.

Pipeline (inside _attachPosterIfVideo)
--------------------------------------
1. createVideoThumbnail(workingUri) — RNC native frame extraction.
2. getUploadUrl('image/jpeg', echoId) — presigned PUT URL.
3. uploadMedia(uploadUrl, posterPath) — single-PUT stream.
4. attachPoster(echoId, key) — backend HEAD verifies + commits poster_url to DDB.
5. unlinkQuietly(posterPath) — clean up the local temp JPEG.

Any step's failure is logged + swallowed. The echo is already saved by the time this pipeline starts; the worst outcome is "no thumbnail in vault list for this video" which the UI handles by falling back to the existing motif / avatar.

Pieces
------
- NEW createPosterThumbnail in src/utils/media/compress.ts — wraps RNC's createVideoThumbnail; returns null on failure (never throws).
- NEW EchoApiService.attachPoster(echoId, key) — POSTs to the new backend route. No idempotency key (overwrite is naturally idempotent on the server).
- EchoResponse type gains optional poster_url for the vault + inbox
  + detail consumers.
- _uploadEchoMediaInner fires the pipeline after a successful video upload on BOTH the multipart and single-PUT paths.
- jest.setup.js mocks createVideoThumbnail (default reject so the pipeline silently no-ops in tests).

Tests
-----
- 3 new attachPoster tests: route shape, echoId URL-encoding, no Idempotency-Key header (since poster attach is naturally idempotent).
- Existing tests unaffected. Full suite: 485 passed.

UI consumer follow-up
---------------------
This PR ships the data flow. A small follow-up PR can wire poster_url into the visual layer: EchoVaultLibraryScreen video cards, EchoInboxScreen video previews, EchoVideoPlaybackScreen's poster prop. Holding off on those changes keeps this PR focused on the upload-side pipeline.