### PR TITLE
feat(echo): wire poster_url into vault avatar + video player

### DIFF
--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -144,11 +144,26 @@ const EchoSentCheckIcon: React.FC = () => (
 interface AvatarProps {
   motif?: string;
   profileImage?: string;
+  /**
+   * When a video echo has a poster frame attached, use that as the
+   * avatar instead of the recipient identity image. The recipient
+   * still surfaces via the rightLabel column; the avatar slot is
+   * better spent showing what the echo CONTAINS than who it's FOR.
+   * Falls back to the recipient profile → motif → placeholder ladder
+   * when no poster is available.
+   */
+  poster?: string;
 }
-const EchoAvatar: React.FC<AvatarProps> = ({ motif, profileImage }) => (
+const EchoAvatar: React.FC<AvatarProps> = ({ motif, profileImage, poster }) => (
   <View style={styles.avatarGlow}>
     <View style={styles.avatarRing}>
-      {profileImage ? (
+      {poster ? (
+        <CachedImage
+          source={{ uri: poster }}
+          style={styles.avatarImg}
+          contentFit="cover"
+        />
+      ) : profileImage ? (
         // CachedImage strips presigned-URL query params for the cache
         // key, so paging back through the vault list doesn't re-download
         // the same avatar bytes on every refresh.
@@ -202,6 +217,7 @@ function renderEchoRow(
             <EchoAvatar
               motif={item.recipient?.motif}
               profileImage={item.recipient?.profile_image_url}
+              poster={item.echo_type === 'VIDEO' ? item.poster_url : undefined}
             />
             <View style={styles.rowText}>
               <Text style={styles.rowTitle} numberOfLines={2}>

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVideoPlaybackScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVideoPlaybackScreen.tsx
@@ -250,6 +250,13 @@ const EchoVideoPlaybackScreen: React.FC<Props> = ({ navigation, route }) => {
                   bufferForPlaybackMs: 2000,
                   bufferForPlaybackAfterRebufferMs: 3000,
                 }}
+                // Show the client-extracted poster while the first
+                // video frame is being decoded. Without this the user
+                // sees a black rectangle for ~500-2000ms (depending
+                // on buffer fill); with it they see the thumbnail
+                // immediately and the video fades in over it.
+                poster={echo.poster_url}
+                posterResizeMode="cover"
               />
               
               {/* Overlay controls */}


### PR DESCRIPTION
Pairs with feat/video-poster-frame-client which ships the data flow. This is the visual consumer.

EchoVaultLibraryScreen
----------------------
EchoAvatar gains an optional poster prop. When set, the poster image renders in the avatar slot instead of the recipient identity image. Caller wires it for VIDEO echoes only:

  poster={item.echo_type === 'VIDEO' ? item.poster_url : undefined}

Rationale: in a list of saved echoes, "what does this video LOOK like" carries more visual signal than "who is it FOR" — the recipient name still surfaces in the rightLabel column. For non-video echoes the existing recipient profile → motif → Group placeholder ladder is unchanged.

EchoVideoPlaybackScreen
-----------------------
The <Video> component now passes the poster_url to its `poster` prop. Without this the user sees a black rectangle for the 500-2000ms the first frame takes to decode; with it they see the thumbnail immediately and the video fades in over it. Plain backward-compatible additive change.

Inbox is intentionally NOT touched — its Figma explicitly omits avatar circles ("No avatar circles in rows" — see top-of-file comment). Surfacing poster_url in the inbox response is still useful because the playback screen reads it on detail-fetch.

Tests: zero regressions (485 passed, 28 fail baseline unchanged). 0 new TypeScript errors.