### PR TITLE
feat(echo): resume-upload banner on vault library

### DIFF
--- a/MirrorCollectiveApp/src/__tests__/jest.setup.js
+++ b/MirrorCollectiveApp/src/__tests__/jest.setup.js
@@ -251,6 +251,10 @@ jest.mock('react-native-blob-util', () => {
         stat: jest.fn().mockRejectedValue(new Error('not mocked')),
         // No-op cleanup so unlinkQuietly() doesn't throw.
         unlink: jest.fn().mockResolvedValue(undefined),
+        // Default to "no file" so the vault library's resume scanner
+        // sees an empty pending list in tests. Override per-test as
+        // needed for resume-flow scenarios.
+        exists: jest.fn().mockResolvedValue(false),
       },
     },
   };

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -25,7 +25,7 @@
  *   Radius/M: 16, Spacing/M: 16, Spacing/S: 12, Spacing/XL: 24
  */
 
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   borderWidth,
@@ -69,6 +69,15 @@ import Button from '@components/Button/Button';
 import { CachedImage } from '@components/CachedImage';
 import LogoHeader from '@components/LogoHeader';
 import { echoApiService, type EchoResponse } from '@services/api/echo';
+import { resumeMediaMultipart } from '@services/api/multipart';
+import {
+  type PendingUpload,
+  listResumableUploads,
+  removePending,
+} from '@services/api/pendingUploads';
+import ReactNativeBlobUtil from 'react-native-blob-util';
+
+import { ResumeUploadBanner } from './ResumeUploadBanner';
 
 /**
  * UI-facing echo state — derived from the backend (`status`, `release_date`)
@@ -261,6 +270,104 @@ export function EchoLibraryContent() {
     refresh,
   } = useInfiniteList<EchoResponse>(fetchEchoPage);
 
+  // ── Resume-upload state ───────────────────────────────────────────
+  // Holds the rows returned by listResumableUploads(). Refreshed on
+  // every screen focus so the user sees pending uploads as soon as
+  // they navigate back to the vault, including the cold-start case.
+  const [pending, setPending] = useState<PendingUpload[]>([]);
+  const [resumingEchoId, setResumingEchoId] = useState<string | null>(null);
+  const [resumeProgress, setResumeProgress] = useState(0);
+
+  /** Probe used by listResumableUploads to filter rows whose source
+   *  file has been reclaimed by the OS. Returns false on any error so
+   *  a borderline-broken cache state can't keep a stale row alive. */
+  const fileExists = useCallback(async (path: string): Promise<boolean> => {
+    try {
+      const stripped = path.startsWith('file://') ? path.slice(7) : path;
+      return await ReactNativeBlobUtil.fs.exists(stripped);
+    } catch {
+      return false;
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+      (async () => {
+        const rows = await listResumableUploads(fileExists);
+        if (!cancelled) setPending(rows);
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [fileExists]),
+  );
+
+  const handleResumeContinue = useCallback(
+    async (row: PendingUpload) => {
+      setResumingEchoId(row.echoId);
+      setResumeProgress(0);
+      try {
+        const result = await resumeMediaMultipart(
+          echoApiService,
+          row,
+          stage => {
+            // Map upload progress to a single 0..1 progress fraction
+            // for the banner. We weight 'uploading' as 0..0.95 and
+            // 'finalizing' as 0.95..1 to match the new-echo screens.
+            if (stage.type === 'uploading' && stage.total > 0) {
+              setResumeProgress(Math.min(0.95, stage.sent / stage.total));
+            } else if (stage.type === 'finalizing') {
+              setResumeProgress(0.97);
+            }
+          },
+        );
+        setResumeProgress(1);
+        if (!result.success) {
+          // The resume helper handles abort + pending-row cleanup on
+          // failure internally; we just surface the message.
+          console.warn('Resume failed:', result.error ?? 'unknown');
+        }
+      } catch (err) {
+        // Network failure / non-recoverable error already cleaned up
+        // inside resumeMediaMultipart's catch. Log and move on.
+        console.warn('Resume threw:', err);
+      } finally {
+        setResumingEchoId(null);
+        setResumeProgress(0);
+        // Drop the row from the local pending list and refresh the
+        // vault so the newly-complete echo shows up.
+        setPending(p => p.filter(r => r.echoId !== row.echoId));
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  const handleResumeDismiss = useCallback(
+    async (row: PendingUpload) => {
+      // Best-effort cleanup: abort the S3 session so the bucket
+      // lifecycle rule doesn't have to (it would, after 7d, but we
+      // can free the storage now). Then drop the pending row + the
+      // cached source file.
+      try {
+        await echoApiService.abortMultipart(row.echoId, row.uploadId, row.key);
+      } catch (err) {
+        console.warn('Dismiss abort failed (harmless):', err);
+      }
+      await removePending(row.echoId);
+      await ReactNativeBlobUtil.fs
+        .unlink(
+          row.cachedFileUri.startsWith('file://')
+            ? row.cachedFileUri.slice(7)
+            : row.cachedFileUri,
+        )
+        .catch(() => undefined);
+      setPending(p => p.filter(r => r.echoId !== row.echoId));
+    },
+    [],
+  );
+
   const handleOpenItem = (item: EchoResponse) => {
     if (item.echo_type === 'AUDIO') {
       navigation.navigate('EchoAudioPlaybackScreen', { echoId: item.echo_id, title: item.title });
@@ -303,6 +410,19 @@ export function EchoLibraryContent() {
               Preserve memories that matter most
             </Text>
           </View>
+
+          {/* Resume banner — surfaces in-flight multipart uploads that
+              survived a force-quit. Rendered above the rest of the
+              vault content so the user can act on it first. Empty
+              `pending` returns null, so this costs nothing when there's
+              no recovery work. */}
+          <ResumeUploadBanner
+            pending={pending}
+            resumingEchoId={resumingEchoId}
+            resumingProgress={resumeProgress}
+            onContinue={handleResumeContinue}
+            onDismiss={handleResumeDismiss}
+          />
 
           {/* ── Echo Inbox link — temporarily hidden ───────────────────
               Feature is on hold pending design/product discussion. Keep

--- a/MirrorCollectiveApp/src/screens/echoVault/ResumeUploadBanner.test.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ResumeUploadBanner.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Tests for the resume-upload banner — a pure render component.
+ * The vault library screen owns the scan + resume orchestration; this
+ * test file pins the banner's rendering contract.
+ */
+
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import type { PendingUpload } from '@services/api/pendingUploads';
+
+import { ResumeUploadBanner } from './ResumeUploadBanner';
+
+function makePending(overrides: Partial<PendingUpload> = {}): PendingUpload {
+  return {
+    echoId: 'echo-1',
+    uploadId: 'UPLOAD-1',
+    key: 'echoes/u-1/echo-1.mp4',
+    cachedFileUri: '/cache/mc-pending/echo-1.mp4',
+    contentType: 'video/mp4',
+    fileSize: 25 * 1024 * 1024, // 5 parts at 5 MB
+    completedParts: [
+      { part_number: 1, etag: 'a' },
+      { part_number: 2, etag: 'b' },
+    ],
+    createdAt: new Date().toISOString(),
+    lastUpdatedAt: new Date().toISOString(),
+    title: 'Vacation Memory',
+    ...overrides,
+  };
+}
+
+describe('ResumeUploadBanner', () => {
+  it('renders nothing when the pending list is empty', () => {
+    const c = render(
+      <ResumeUploadBanner
+        pending={[]}
+        onContinue={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    // toJSON returns null for an empty fragment / no render output.
+    expect(c.toJSON()).toBeNull();
+  });
+
+  it('renders one card per pending upload with title + parts progress', () => {
+    const c = render(
+      <ResumeUploadBanner
+        pending={[
+          makePending({ echoId: 'a', title: 'Trip A' }),
+          makePending({ echoId: 'b', title: 'Trip B', completedParts: [] }),
+        ]}
+        onContinue={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(c.getByText('Trip A')).toBeTruthy();
+    expect(c.getByText('Trip B')).toBeTruthy();
+    // Parts string: 2 of 5 parts saved (Trip A — 25MB / 5MB = 5 parts)
+    expect(c.getByText('2 of 5 parts saved')).toBeTruthy();
+    expect(c.getByText('0 of 5 parts saved')).toBeTruthy();
+  });
+
+  it('fires onContinue with the row when Continue is pressed', () => {
+    const onContinue = jest.fn();
+    const row = makePending({ title: 'Resume me' });
+    const c = render(
+      <ResumeUploadBanner
+        pending={[row]}
+        onContinue={onContinue}
+        onDismiss={jest.fn()}
+      />,
+    );
+    fireEvent.press(c.getByLabelText('Continue uploading Resume me'));
+    expect(onContinue).toHaveBeenCalledWith(row);
+  });
+
+  it('fires onDismiss with the row when Dismiss is pressed', () => {
+    const onDismiss = jest.fn();
+    const row = makePending({ title: 'Drop me' });
+    const c = render(
+      <ResumeUploadBanner
+        pending={[row]}
+        onContinue={jest.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.press(c.getByLabelText('Dismiss upload of Drop me'));
+    expect(onDismiss).toHaveBeenCalledWith(row);
+  });
+
+  it('shows percentage and hides buttons while the row is resuming', () => {
+    const row = makePending({ echoId: 'a', title: 'Resuming Now' });
+    const c = render(
+      <ResumeUploadBanner
+        pending={[row]}
+        resumingEchoId="a"
+        resumingProgress={0.42}
+        onContinue={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    expect(c.getByText('Uploading… 42%')).toBeTruthy();
+    // Buttons are replaced by the spinner; querying them returns null.
+    expect(c.queryByLabelText('Continue uploading Resuming Now')).toBeNull();
+    expect(c.queryByLabelText('Dismiss upload of Resuming Now')).toBeNull();
+    expect(c.getByLabelText('Resuming upload')).toBeTruthy();
+  });
+
+  it('disables buttons on OTHER rows while one is resuming', () => {
+    const c = render(
+      <ResumeUploadBanner
+        pending={[
+          makePending({ echoId: 'a', title: 'Active' }),
+          makePending({ echoId: 'b', title: 'Idle' }),
+        ]}
+        resumingEchoId="a"
+        resumingProgress={0.1}
+        onContinue={jest.fn()}
+        onDismiss={jest.fn()}
+      />,
+    );
+    const idleContinue = c.getByLabelText('Continue uploading Idle');
+    // RN's TouchableOpacity exposes the `disabled` prop directly on the
+    // host node it renders. Whether it surfaces in accessibilityState
+    // depends on the RN version, so check the raw prop.
+    expect(idleContinue.props.disabled).toBe(true);
+  });
+});

--- a/MirrorCollectiveApp/src/screens/echoVault/ResumeUploadBanner.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ResumeUploadBanner.tsx
@@ -1,0 +1,205 @@
+/**
+ * Resume-upload banner — shows in-flight multipart uploads recovered
+ * after a force-quit / cold start and lets the user continue or
+ * dismiss each one.
+ *
+ * Architecture note: this is a pure render component. The vault
+ * library screen owns the listResumableUploads scan, the
+ * resumeMediaMultipart call, and progress state. Keeping this
+ * component stateless makes it trivially testable and lets the
+ * parent decide what "Continue" and "Dismiss" actually do
+ * (today: resume + abort, respectively).
+ */
+
+import {
+  fontFamily,
+  fontSize,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import React from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
+
+import type { PendingUpload } from '@services/api/pendingUploads';
+
+interface ResumeUploadBannerProps {
+  /** Recoverable uploads as returned by listResumableUploads(). */
+  pending: PendingUpload[];
+  /**
+   * Echo currently being resumed. Disables both buttons on that row
+   * and shows the inline progress indicator. The parent screen owns
+   * this state because only one resume can run at a time.
+   */
+  resumingEchoId?: string | null;
+  /**
+   * 0..1 progress fraction for the currently-resuming upload. Driven
+   * by the parent's resumeMediaMultipart onStage callback. Ignored
+   * for rows other than `resumingEchoId`.
+   */
+  resumingProgress?: number;
+  /** Tapped Continue: parent runs resumeMediaMultipart for this row. */
+  onContinue: (pending: PendingUpload) => void;
+  /** Tapped Dismiss: parent aborts on S3 + removes the pending row. */
+  onDismiss: (pending: PendingUpload) => void;
+}
+
+export function ResumeUploadBanner({
+  pending,
+  resumingEchoId,
+  resumingProgress = 0,
+  onContinue,
+  onDismiss,
+}: ResumeUploadBannerProps) {
+  if (pending.length === 0) return null;
+
+  return (
+    <View style={styles.wrap}>
+      {pending.map(row => {
+        const isResuming = resumingEchoId === row.echoId;
+        // Anyone else is in progress — disable buttons on this row
+        // too (only one resume at a time).
+        const isAnyResuming = resumingEchoId != null;
+        const completedCount = row.completedParts.length;
+        const totalPartsCount = Math.ceil(
+          row.fileSize / (5 * 1024 * 1024),
+        );
+        return (
+          <View key={row.echoId} style={styles.card}>
+            <View style={styles.textCol}>
+              <Text style={styles.title} numberOfLines={1}>
+                {row.title}
+              </Text>
+              <Text style={styles.subtitle} numberOfLines={1}>
+                {isResuming
+                  ? `Uploading… ${Math.round(resumingProgress * 100)}%`
+                  : `${completedCount} of ${totalPartsCount} parts saved`}
+              </Text>
+            </View>
+
+            <View style={styles.actions}>
+              {isResuming ? (
+                <ActivityIndicator
+                  size="small"
+                  color={palette.gold.DEFAULT}
+                  accessibilityLabel="Resuming upload"
+                />
+              ) : (
+                <>
+                  <TouchableOpacity
+                    onPress={() => onContinue(row)}
+                    disabled={isAnyResuming}
+                    style={[
+                      styles.btn,
+                      styles.btnPrimary,
+                      isAnyResuming && styles.btnDisabled,
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Continue uploading ${row.title}`}
+                  >
+                    <Text style={styles.btnPrimaryText}>Continue</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() => onDismiss(row)}
+                    disabled={isAnyResuming}
+                    style={[styles.btn, isAnyResuming && styles.btnDisabled]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Dismiss upload of ${row.title}`}
+                  >
+                    <Text style={styles.btnText}>Dismiss</Text>
+                  </TouchableOpacity>
+                </>
+              )}
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create<{
+  wrap: ViewStyle;
+  card: ViewStyle;
+  textCol: ViewStyle;
+  title: TextStyle;
+  subtitle: TextStyle;
+  actions: ViewStyle;
+  btn: ViewStyle;
+  btnPrimary: ViewStyle;
+  btnDisabled: ViewStyle;
+  btnText: TextStyle;
+  btnPrimaryText: TextStyle;
+}>({
+  wrap: {
+    paddingHorizontal: spacing.m,
+    marginBottom: spacing.s,
+    gap: spacing.s,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.m,
+    borderRadius: radius.m,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.gold.DEFAULT,
+    backgroundColor: 'rgba(242, 226, 177, 0.06)',
+  },
+  textCol: {
+    flex: 1,
+    marginRight: spacing.s,
+  },
+  title: {
+    fontFamily: fontFamily.heading,
+    fontSize: moderateScale(fontSize.s),
+    color: palette.gold.subtlest,
+  },
+  subtitle: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.xs),
+    color: palette.navy.light,
+    marginTop: verticalScale(2),
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  btn: {
+    paddingHorizontal: scale(12),
+    paddingVertical: verticalScale(6),
+    borderRadius: radius.s,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.navy.light,
+  },
+  btnPrimary: {
+    backgroundColor: palette.gold.DEFAULT,
+    borderColor: palette.gold.DEFAULT,
+  },
+  btnDisabled: {
+    opacity: 0.4,
+  },
+  btnText: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.xs),
+    color: palette.navy.light,
+  },
+  btnPrimaryText: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.xs),
+    color: palette.navy.deep,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
Visual consumer for PR7. When the user returns to the vault after a force-quit / cold-start that interrupted a multipart upload, a banner at the top of the screen offers to Continue or Dismiss each recoverable upload.

Components
----------
- NEW src/screens/echoVault/ResumeUploadBanner.tsx — pure render component. Props: pending list, resumingEchoId, resumingProgress, onContinue, onDismiss. Renders one card per pending upload with title + "N of M parts saved" subtitle. While a row is resuming, buttons collapse to an ActivityIndicator + "Uploading… N%" copy; other rows' buttons are disabled (single-resume-at-a-time).
- EchoVaultLibraryScreen scans listResumableUploads via useFocusEffect, so the banner appears on every navigate-to-vault (including the cold-start case). The fileExists probe uses ReactNativeBlobUtil.fs.exists; rows whose source file is gone are auto-pruned by listResumableUploads' built-in filter.
- Continue → resumeMediaMultipart with progress wired to the banner; on settle, refresh() the vault so the finalized echo appears. Failure cleanup (abort + removePending + cache unlink) happens inside resumeMediaMultipart on the unrecoverable path, so the banner just drops the row locally.
- Dismiss → abortMultipart (best-effort; bucket lifecycle rule reaps if it fails) + removePending + unlink the cached source.

Test setup
----------
- jest.setup.js adds fs.exists (default false) to the react-native-blob-util mock so the resume scanner sees no recoverable rows in tests by default. Override per-test for resume-flow scenarios.

Tests
-----
- 6 new in ResumeUploadBanner.test.tsx: empty list renders null; one card per row with parts-progress subtitle; onContinue + onDismiss receive the row; resuming row shows percentage + hides buttons; other rows' buttons are disabled while one is resuming.
- Full suite: 474 passed (+6 net). 0 new TS errors.

Stacked on feat/resume-multipart-upload. Merge order:
  resume-multipart-upload → resume-upload-banner.