### PR TITLE
feat(chat): text-to-speech for Mirror replies — tap-to-read + auto-read

### DIFF
--- a/MirrorCollectiveApp/package.json
+++ b/MirrorCollectiveApp/package.json
@@ -59,6 +59,7 @@
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.1",
     "react-native-svg": "^15.12.0",
+    "react-native-tts": "^4.1.1",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-uuid": "^2.0.3",
     "react-native-vector-icons": "^10.3.0",

--- a/MirrorCollectiveApp/src/__tests__/jest.setup.js
+++ b/MirrorCollectiveApp/src/__tests__/jest.setup.js
@@ -38,6 +38,7 @@ jest.mock('react-native', () => {
     SafeAreaView: 'SafeAreaView',
     KeyboardAvoidingView: 'KeyboardAvoidingView',
     ActivityIndicator: 'ActivityIndicator',
+    Switch: 'Switch',
     Alert: { alert: jest.fn() },
     Linking: { openURL: jest.fn() },
     StatusBar: Object.assign(jest.fn(() => null), { 
@@ -283,4 +284,22 @@ jest.mock('react-native-compressor', () => ({
 jest.mock('expo-image', () => ({
   __esModule: true,
   Image: 'Image',
+}));
+
+// Mock react-native-tts — its native module would crash jest at import.
+// Provide a minimal stub that records calls; tests that need to assert
+// on speak/stop should use the wrapper at @services/speech and let it
+// drive this mock. Tests that mock the wrapper directly (most of them)
+// bypass this stub entirely.
+jest.mock('react-native-tts', () => ({
+  __esModule: true,
+  default: {
+    speak: jest.fn(),
+    stop: jest.fn(),
+    setDefaultRate: jest.fn(),
+    setDefaultLanguage: jest.fn(),
+    getInitStatus: jest.fn(() => Promise.resolve('success')),
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    removeAllListeners: jest.fn(),
+  },
 }));

--- a/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.test.tsx
+++ b/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.test.tsx
@@ -1,10 +1,73 @@
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
-
 
 import type { Message } from '@types';
 
+// Mock the speech service before importing the bubble — the bubble
+// reads from @services/speech, and we want call-counting on speak/stop.
+const mockSpeak = jest.fn();
+const mockStop = jest.fn();
+const mockGetActiveUtteranceId = jest.fn(() => null as string | null);
+let mockSubscribers: Array<(e: { type: string; utteranceId: string }) => void> = [];
+
+jest.mock('@services/speech', () => {
+  // require inside the factory keeps jest from hoisting it outside the
+  // module-mock boundary. react is the test-runner's own copy.
+  const ReactInner = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    ttsService: {
+      speak: (...args: unknown[]) => {
+        mockSpeak(...args);
+        return Promise.resolve();
+      },
+      stop: () => mockStop(),
+      getActiveUtteranceId: () => mockGetActiveUtteranceId(),
+      subscribe: (fn: (e: { type: string; utteranceId: string }) => void) => {
+        mockSubscribers.push(fn);
+        return () => {
+          mockSubscribers = mockSubscribers.filter((s) => s !== fn);
+        };
+      },
+    },
+    useTtsActiveId: () => {
+      // Re-implement the hook against the mocked subscribe channel so
+      // tests can simulate "this bubble is now speaking" by calling
+      // notifyActive() below.
+      const [id, setId] = ReactInner.useState<string | null>(
+        mockGetActiveUtteranceId(),
+      );
+      ReactInner.useEffect(() => {
+        const fn = (e: { type: string; utteranceId: string }) =>
+          setId(e.type === 'started' ? e.utteranceId : null);
+        mockSubscribers.push(fn);
+        return () => {
+          mockSubscribers = mockSubscribers.filter((s) => s !== fn);
+        };
+      }, []);
+      return id;
+    },
+  };
+});
+
+function notifyActive(utteranceId: string | null): void {
+  // null = stopped/finished; non-null = started.
+  mockSubscribers.forEach((fn) =>
+    fn({
+      type: utteranceId ? 'started' : 'finished',
+      utteranceId: utteranceId ?? 'prev',
+    }),
+  );
+}
+
 import { MessageBubble } from './MessageBubble';
+
+beforeEach(() => {
+  mockSpeak.mockClear();
+  mockStop.mockClear();
+  mockGetActiveUtteranceId.mockReturnValue(null);
+  mockSubscribers = [];
+});
 
 describe('MessageBubble', () => {
   const mockUserMessage: Message = {
@@ -62,8 +125,55 @@ describe('MessageBubble', () => {
       sender: 'system',
       timestamp: new Date(),
     };
-    
+
     const { getByText } = render(<MessageBubble message={longMessage} />);
     expect(getByText(longMessage.text)).toBeTruthy();
+  });
+
+  describe('speaker button — read-aloud', () => {
+    it('renders on assistant bubbles only', () => {
+      const { queryByTestId: assistant } = render(
+        <MessageBubble message={mockSystemMessage} />,
+      );
+      expect(assistant(`speaker-button-${mockSystemMessage.id}`)).toBeTruthy();
+
+      const { queryByTestId: user } = render(
+        <MessageBubble message={mockUserMessage} />,
+      );
+      // User bubbles do NOT get a speaker button — only the AI replies.
+      expect(user(`speaker-button-${mockUserMessage.id}`)).toBeNull();
+    });
+
+    it('calls ttsService.speak(text, id) when tapped on an idle bubble', () => {
+      const { getByTestId } = render(<MessageBubble message={mockSystemMessage} />);
+      fireEvent.press(getByTestId(`speaker-button-${mockSystemMessage.id}`));
+      expect(mockSpeak).toHaveBeenCalledWith(
+        mockSystemMessage.text,
+        mockSystemMessage.id,
+      );
+      expect(mockStop).not.toHaveBeenCalled();
+    });
+
+    it('calls ttsService.stop() when tapped on the currently-speaking bubble', () => {
+      const { getByTestId } = render(<MessageBubble message={mockSystemMessage} />);
+      // Simulate the wrapper firing "this bubble started" — wrap in act
+      // so the useState in useTtsActiveId flushes before we press.
+      act(() => notifyActive(mockSystemMessage.id));
+      fireEvent.press(getByTestId(`speaker-button-${mockSystemMessage.id}`));
+      expect(mockStop).toHaveBeenCalled();
+      expect(mockSpeak).not.toHaveBeenCalled();
+    });
+
+    it('uses an accessibility label that reflects the play/stop state', () => {
+      const { getByLabelText } = render(
+        <MessageBubble message={mockSystemMessage} />,
+      );
+      expect(getByLabelText('Read reply aloud')).toBeTruthy();
+
+      // Flip to "this bubble is speaking"; the hook's useEffect listener
+      // updates state inside act(), so re-querying picks up the new label.
+      act(() => notifyActive(mockSystemMessage.id));
+      expect(getByLabelText('Stop reading reply aloud')).toBeTruthy();
+    });
   });
 });

--- a/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -1,16 +1,61 @@
 import { theme, spacing, radius, shadows, palette } from '@theme';
 import type { Message } from '@types';
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
+import Svg, { Path, Rect } from 'react-native-svg';
+
+import { ttsService, useTtsActiveId } from '@services/speech';
 
 
 interface MessageBubbleProps {
   message: Message;
 }
 
+const SpeakerPlayIcon: React.FC = () => (
+  <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M11 5L6 9H2v6h4l5 4V5z"
+      fill={palette.gold.DEFAULT}
+    />
+    <Path
+      d="M15.54 8.46a5 5 0 0 1 0 7.07"
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      fill="none"
+    />
+    <Path
+      d="M18.36 5.64a9 9 0 0 1 0 12.72"
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      fill="none"
+    />
+  </Svg>
+);
+
+const SpeakerStopIcon: React.FC = () => (
+  <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
+    <Rect x={5} y={5} width={14} height={14} rx={2} fill={palette.gold.DEFAULT} />
+  </Svg>
+);
+
 export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
   const isUser = message.sender === 'user';
+  const activeUtteranceId = useTtsActiveId();
+  const isSpeaking = activeUtteranceId === message.id;
+
+  // Tap toggles: tapping the active bubble stops it; tapping any other
+  // bubble starts that one (the wrapper takes care of stopping whichever
+  // was previously active).
+  const handleSpeakerPress = useCallback(() => {
+    if (isSpeaking) {
+      ttsService.stop();
+    } else {
+      void ttsService.speak(message.text, message.id);
+    }
+  }, [isSpeaking, message.id, message.text]);
 
   return (
     <View style={[styles.row, isUser ? styles.rowUser : styles.rowSystem]}>
@@ -26,6 +71,19 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
       ) : (
         <View style={[styles.bubble, styles.systemBubble]}>
           <Text style={[styles.text, styles.systemText]}>{message.text}</Text>
+          <TouchableOpacity
+            onPress={handleSpeakerPress}
+            style={styles.speakerBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel={
+              isSpeaking ? 'Stop reading reply aloud' : 'Read reply aloud'
+            }
+            accessibilityState={{ selected: isSpeaking }}
+            testID={`speaker-button-${message.id}`}
+          >
+            {isSpeaking ? <SpeakerStopIcon /> : <SpeakerPlayIcon />}
+          </TouchableOpacity>
         </View>
       )}
     </View>
@@ -66,10 +124,18 @@ const styles = StyleSheet.create({
   systemBubble: {
     paddingVertical: spacing.xs,
     paddingHorizontal: spacing.s,
+    paddingRight: spacing.s + 28, // room for the speaker button
     marginTop: 14,
     borderWidth: 1,
     borderColor: 'rgba(155, 170, 194, 0.5)',
     backgroundColor: 'rgba(253, 253, 249, 0.05)',
+  },
+
+  speakerBtn: {
+    position: 'absolute',
+    right: 4,
+    bottom: 4,
+    padding: 4,
   },
 
   text: {

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
@@ -19,6 +19,10 @@ import BackgroundWrapper from '@components/BackgroundWrapper';
 import LogoHeader from '@components/LogoHeader';
 import { MessageBubble, ChatInput, LoadingIndicator } from '@components/ui';
 import { useChat } from '@hooks/useChat';
+import {
+  useAutoReadOnNewMessage,
+  useAutoReadPreference,
+} from '@services/speech';
 
 // Export content component for testing
 export function MirrorChatContent() {
@@ -33,6 +37,13 @@ export function MirrorChatContent() {
     sendMessage,
     setDraft,
   } = useChat();
+  const { enabled: autoReadEnabled } = useAutoReadPreference();
+
+  // When auto-read is on, this hook speaks each new assistant reply on
+  // arrival. It guards against speaking the initial greeting and stops
+  // any in-flight speech on screen unmount. Tap-to-read via the bubble
+  // speaker button continues to work independently.
+  useAutoReadOnNewMessage(messages, autoReadEnabled);
 
   // Initialize session when component mounts
   useEffect(() => {

--- a/MirrorCollectiveApp/src/screens/ProfileScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/ProfileScreen.tsx
@@ -44,6 +44,7 @@ import TextInputField from '@components/TextInputField';
 import { useUser } from '@context/UserContext';
 import { authApiService } from '@services/api';
 import { echoApiService } from '@services/api/echo';
+import { SpeechSettingsRow } from './settings/SpeechSettingsRow';
 
 const AVATAR_SIZE = moderateScale(160);
 
@@ -240,6 +241,13 @@ const ProfileScreen: React.FC = () => {
                   placeholderFontFamily="regular"
                   inputTextStyle="gold-regular"
                 />
+              </View>
+
+              {/* Settings — currently just the speech toggle. The row's
+                  hook hydrates from AsyncStorage on its own; we don't
+                  block the rest of the screen waiting for it. */}
+              <View style={styles.form}>
+                <SpeechSettingsRow />
               </View>
 
               {/* Save — no active prop so button renders in default (inactive) state */}

--- a/MirrorCollectiveApp/src/screens/settings/SpeechSettingsRow.test.tsx
+++ b/MirrorCollectiveApp/src/screens/settings/SpeechSettingsRow.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  AUTO_READ_STORAGE_KEY,
+} from '@services/speech';
+import { SpeechSettingsRow } from './SpeechSettingsRow';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SpeechSettingsRow', () => {
+  it('renders the title and accessible switch', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    const { getByText, getByTestId } = render(<SpeechSettingsRow />);
+    expect(getByText('Auto-read Mirror replies')).toBeTruthy();
+    expect(getByTestId('settings-auto-read-switch')).toBeTruthy();
+    await waitFor(() =>
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith(AUTO_READ_STORAGE_KEY),
+    );
+  });
+
+  it('persists toggle change to AsyncStorage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    const { getByTestId } = render(<SpeechSettingsRow />);
+    const sw = getByTestId('settings-auto-read-switch');
+    fireEvent(sw, 'valueChange', true);
+    await waitFor(() =>
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        AUTO_READ_STORAGE_KEY,
+        'true',
+      ),
+    );
+  });
+});

--- a/MirrorCollectiveApp/src/screens/settings/SpeechSettingsRow.tsx
+++ b/MirrorCollectiveApp/src/screens/settings/SpeechSettingsRow.tsx
@@ -1,0 +1,85 @@
+/**
+ * A single Settings row with a label + native Switch for the
+ * "Auto-read Mirror replies" preference. Lives in screens/settings/
+ * so future settings rows have a place to grow into.
+ *
+ * The row is host-agnostic — it doesn't know it's currently embedded in
+ * ProfileScreen. When a dedicated Settings screen lands, drop this in
+ * unchanged.
+ */
+
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  moderateScale,
+  palette,
+  spacing,
+  verticalScale,
+} from '@theme';
+import React from 'react';
+import { StyleSheet, Switch, Text, View } from 'react-native';
+
+import { useAutoReadPreference } from '@services/speech';
+
+export const SpeechSettingsRow: React.FC = () => {
+  const { enabled, setEnabled, loaded } = useAutoReadPreference();
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.labels}>
+        <Text style={styles.title}>Auto-read Mirror replies</Text>
+        <Text style={styles.subtitle}>
+          Speaks every new Mirror reply aloud as it arrives.
+        </Text>
+      </View>
+      <Switch
+        value={loaded ? enabled : false}
+        onValueChange={(next) => {
+          void setEnabled(next);
+        }}
+        disabled={!loaded}
+        thumbColor={palette.gold.DEFAULT}
+        trackColor={{
+          true: palette.gold.warm,
+          false: palette.navy.light,
+        }}
+        accessibilityRole="switch"
+        accessibilityLabel="Auto-read Mirror replies"
+        accessibilityState={{ checked: enabled, disabled: !loaded }}
+        testID="settings-auto-read-switch"
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: verticalScale(spacing.m),
+    gap: spacing.m,
+  },
+  labels: {
+    flex: 1,
+    paddingRight: spacing.s,
+  },
+  title: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.m),
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(lineHeight.m),
+    color: palette.gold.DEFAULT,
+  },
+  subtitle: {
+    marginTop: 2,
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.xs),
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(lineHeight.s),
+    color: palette.navy.light,
+  },
+});

--- a/MirrorCollectiveApp/src/services/speech/index.ts
+++ b/MirrorCollectiveApp/src/services/speech/index.ts
@@ -1,0 +1,8 @@
+export { ttsService } from './ttsService';
+export type { TtsEvent } from './ttsService';
+export {
+  AUTO_READ_STORAGE_KEY,
+  useAutoReadPreference,
+} from './useAutoReadPreference';
+export { useTtsActiveId } from './useTtsActiveId';
+export { useAutoReadOnNewMessage } from './useAutoReadOnNewMessage';

--- a/MirrorCollectiveApp/src/services/speech/ttsService.test.ts
+++ b/MirrorCollectiveApp/src/services/speech/ttsService.test.ts
@@ -1,0 +1,148 @@
+/**
+ * TTS service wrapper tests.
+ *
+ * The service is a thin façade over react-native-tts that adds:
+ *   - "only one utterance speaks at a time" semantics
+ *   - "currently-speaking" state surfaced via subscribers (the chat UI
+ *     uses this to render a stop icon on the playing bubble)
+ *   - graceful no-op when the native module isn't available (jest)
+ *
+ * These tests pin the contract, not the underlying library. The mock is
+ * minimal on purpose — the goal is to verify our wrapper, not RN-TTS.
+ */
+
+import { ttsService } from './ttsService';
+
+// Mock react-native-tts. The lib exports a default object with imperative
+// methods (speak/stop/setDefaultRate/etc) AND an EventEmitter-ish surface
+// (addEventListener). We capture handlers in a map so individual tests
+// can fire events synchronously.
+const eventHandlers: Record<string, Array<(payload: unknown) => void>> = {};
+const mockSpeak = jest.fn();
+const mockStop = jest.fn();
+const mockSetDefaultRate = jest.fn();
+const mockSetDefaultLanguage = jest.fn();
+const mockGetInitStatus = jest.fn(() => Promise.resolve('success'));
+
+jest.mock('react-native-tts', () => ({
+  __esModule: true,
+  default: {
+    speak: (...args: unknown[]) => mockSpeak(...args),
+    stop: () => mockStop(),
+    setDefaultRate: (rate: number) => mockSetDefaultRate(rate),
+    setDefaultLanguage: (lang: string) => mockSetDefaultLanguage(lang),
+    getInitStatus: () => mockGetInitStatus(),
+    addEventListener: (event: string, handler: (p: unknown) => void) => {
+      eventHandlers[event] = eventHandlers[event] ?? [];
+      eventHandlers[event].push(handler);
+      // Real RN-TTS returns a subscription with .remove(); mirror that.
+      return {
+        remove: () => {
+          eventHandlers[event] = (eventHandlers[event] ?? []).filter(
+            (h) => h !== handler,
+          );
+        },
+      };
+    },
+    removeAllListeners: (event: string) => {
+      delete eventHandlers[event];
+    },
+  },
+}));
+
+function fireEvent(event: string, payload: unknown = {}): void {
+  (eventHandlers[event] ?? []).forEach((h) => h(payload));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const k of Object.keys(eventHandlers)) delete eventHandlers[k];
+  ttsService.reset();
+});
+
+describe('ttsService.speak', () => {
+  it('forwards text to native TTS and marks the utterance active', async () => {
+    await ttsService.speak('hello world', 'msg-1');
+    expect(mockSpeak).toHaveBeenCalledWith('hello world');
+    expect(ttsService.getActiveUtteranceId()).toBe('msg-1');
+  });
+
+  it('stops any in-flight utterance before starting a new one', async () => {
+    await ttsService.speak('first', 'msg-1');
+    await ttsService.speak('second', 'msg-2');
+    expect(mockStop).toHaveBeenCalled();
+    expect(ttsService.getActiveUtteranceId()).toBe('msg-2');
+  });
+
+  it('no-ops on empty/whitespace text without calling native', async () => {
+    await ttsService.speak('   ', 'msg-1');
+    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(ttsService.getActiveUtteranceId()).toBeNull();
+  });
+});
+
+describe('ttsService.stop', () => {
+  it('forwards stop to native and clears the active id', async () => {
+    await ttsService.speak('text', 'msg-1');
+    ttsService.stop();
+    expect(mockStop).toHaveBeenCalled();
+    expect(ttsService.getActiveUtteranceId()).toBeNull();
+  });
+});
+
+describe('ttsService events → subscribers', () => {
+  it('notifies subscribers on speak-start with the active id', async () => {
+    const sub = jest.fn();
+    ttsService.subscribe(sub);
+    await ttsService.speak('text', 'msg-1');
+    fireEvent('tts-start');
+    expect(sub).toHaveBeenLastCalledWith({
+      type: 'started',
+      utteranceId: 'msg-1',
+    });
+  });
+
+  it('notifies subscribers and clears active id on tts-finish', async () => {
+    const sub = jest.fn();
+    ttsService.subscribe(sub);
+    await ttsService.speak('text', 'msg-1');
+    fireEvent('tts-finish');
+    expect(sub).toHaveBeenLastCalledWith({
+      type: 'finished',
+      utteranceId: 'msg-1',
+    });
+    expect(ttsService.getActiveUtteranceId()).toBeNull();
+  });
+
+  it('notifies subscribers on tts-cancel and clears active id', async () => {
+    const sub = jest.fn();
+    ttsService.subscribe(sub);
+    await ttsService.speak('text', 'msg-1');
+    fireEvent('tts-cancel');
+    expect(sub).toHaveBeenLastCalledWith({
+      type: 'cancelled',
+      utteranceId: 'msg-1',
+    });
+    expect(ttsService.getActiveUtteranceId()).toBeNull();
+  });
+
+  it('subscribe returns an unsubscribe function', async () => {
+    const sub = jest.fn();
+    const unsub = ttsService.subscribe(sub);
+    unsub();
+    await ttsService.speak('text', 'msg-1');
+    fireEvent('tts-start');
+    expect(sub).not.toHaveBeenCalled();
+  });
+});
+
+describe('ttsService resilience', () => {
+  it('catches a thrown native speak() — does not propagate to caller', async () => {
+    mockSpeak.mockImplementationOnce(() => {
+      throw new Error('native module not linked');
+    });
+    await expect(ttsService.speak('hi', 'msg-1')).resolves.toBeUndefined();
+    // Active id stays null because the speak failed before establishing it.
+    expect(ttsService.getActiveUtteranceId()).toBeNull();
+  });
+});

--- a/MirrorCollectiveApp/src/services/speech/ttsService.ts
+++ b/MirrorCollectiveApp/src/services/speech/ttsService.ts
@@ -1,0 +1,156 @@
+/**
+ * Text-to-speech facade over react-native-tts.
+ *
+ * Why a wrapper instead of importing react-native-tts directly:
+ *
+ *   1. "Only one utterance speaks at a time" — RN-TTS's native side will
+ *      happily start a second utterance while the first is still going.
+ *      The chat UI assumes exactly one bubble is in the "speaking" state,
+ *      so the wrapper enforces stop-before-start.
+ *
+ *   2. State the UI can observe — a `subscribe()` channel lets MessageBubble
+ *      flip its speaker icon to "stop" without each bubble owning its own
+ *      RN-TTS event listener.
+ *
+ *   3. Test-safe — when the native module isn't linked (jest, ejected app
+ *      misconfiguration), `speak()` resolves silently instead of crashing.
+ *      Same posture as our other native-leaning wrappers.
+ *
+ * The wrapper is intentionally stateless about CONTENT (it doesn't queue,
+ * doesn't store the text). The chat layer owns message identity; the
+ * wrapper just tracks which utteranceId is currently active.
+ */
+
+import Tts from 'react-native-tts';
+
+export type TtsEvent =
+  | { type: 'started'; utteranceId: string }
+  | { type: 'finished'; utteranceId: string }
+  | { type: 'cancelled'; utteranceId: string };
+
+type Subscriber = (event: TtsEvent) => void;
+
+class TtsService {
+  private activeUtteranceId: string | null = null;
+  private subscribers: Set<Subscriber> = new Set();
+  private nativeListenersAttached = false;
+
+  /**
+   * Begin speaking `text` and tag the utterance with `utteranceId`.
+   * Stops any in-flight utterance first. Whitespace-only text is a
+   * no-op — RN-TTS will fire a `tts-start` immediately followed by
+   * `tts-finish` for an empty string, which produces a flash on the
+   * UI; cheaper to skip the round-trip entirely.
+   */
+  async speak(text: string, utteranceId: string): Promise<void> {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+
+    this.ensureListeners();
+
+    // Stop-before-start. The check on activeUtteranceId is the cheaper
+    // guard; we also call native stop() unconditionally to cover the
+    // edge case where the wrapper missed a finish event.
+    if (this.activeUtteranceId) {
+      this.stop();
+    }
+
+    try {
+      // Some RN-TTS versions return a Promise, others fire-and-forget.
+      // Await defensively — if it throws synchronously (no native
+      // module), the catch below keeps us in a sane state. We rely on
+      // the engine defaults for voice + rate; expose a setRate API
+      // here later if Settings grows a "speech rate" slider.
+      await Promise.resolve(Tts.speak(trimmed));
+      this.activeUtteranceId = utteranceId;
+    } catch (err) {
+      // Common in jest / detached environments. Swallow to keep the
+      // chat UI usable; consumers can check getActiveUtteranceId() to
+      // know whether speech actually started.
+      console.warn('[tts] speak failed', err);
+      this.activeUtteranceId = null;
+    }
+  }
+
+  /**
+   * Stop the in-flight utterance. Safe to call when nothing is playing.
+   * Subscribers receive a `cancelled` event via the native `tts-cancel`
+   * callback — we don't emit it ourselves to avoid double-firing.
+   */
+  stop(): void {
+    try {
+      Tts.stop();
+    } catch (err) {
+      console.warn('[tts] stop failed', err);
+    }
+    this.activeUtteranceId = null;
+  }
+
+  /**
+   * The utteranceId of the bubble currently speaking, or null if idle.
+   * The chat UI calls this on render to pick which speaker icon shows
+   * the "stop" affordance.
+   */
+  getActiveUtteranceId(): string | null {
+    return this.activeUtteranceId;
+  }
+
+  /**
+   * Subscribe to lifecycle events (started/finished/cancelled). Returns
+   * an unsubscribe function. Consumers should call it on unmount.
+   */
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
+  }
+
+  /**
+   * Test-only reset. Clears active state, listeners, and subscribers.
+   * In production the service is a singleton that lives for the app
+   * lifetime.
+   */
+  reset(): void {
+    this.activeUtteranceId = null;
+    this.subscribers.clear();
+    this.nativeListenersAttached = false;
+    try {
+      Tts.removeAllListeners?.('tts-start');
+      Tts.removeAllListeners?.('tts-finish');
+      Tts.removeAllListeners?.('tts-cancel');
+    } catch {
+      // ignored — native module may not be linked in tests
+    }
+  }
+
+  /**
+   * Lazily attach the native lifecycle listeners on first speak(). Doing
+   * this at module import time would crash jest because the mock isn't
+   * installed yet when the module evaluates.
+   */
+  private ensureListeners(): void {
+    if (this.nativeListenersAttached) return;
+    try {
+      Tts.addEventListener('tts-start', () => this.emit('started'));
+      Tts.addEventListener('tts-finish', () => this.emit('finished'));
+      Tts.addEventListener('tts-cancel', () => this.emit('cancelled'));
+      this.nativeListenersAttached = true;
+    } catch (err) {
+      console.warn('[tts] failed to attach listeners', err);
+    }
+  }
+
+  private emit(type: TtsEvent['type']): void {
+    const id = this.activeUtteranceId;
+    if (!id) return;
+    if (type !== 'started') {
+      // started keeps the active id; finished/cancelled clear it.
+      this.activeUtteranceId = null;
+    }
+    const event: TtsEvent = { type, utteranceId: id };
+    this.subscribers.forEach((fn) => fn(event));
+  }
+}
+
+export const ttsService = new TtsService();

--- a/MirrorCollectiveApp/src/services/speech/useAutoReadOnNewMessage.test.ts
+++ b/MirrorCollectiveApp/src/services/speech/useAutoReadOnNewMessage.test.ts
@@ -1,0 +1,97 @@
+/**
+ * useAutoReadOnNewMessage — fires ttsService.speak() each time the
+ * latest assistant message id changes, IFF the user has the
+ * autoRead preference enabled. Pure side-effect hook.
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import type { Message } from '@types';
+
+const mockSpeak = jest.fn();
+const mockStop = jest.fn();
+
+jest.mock('./ttsService', () => ({
+  ttsService: {
+    speak: (...args: unknown[]) => {
+      mockSpeak(...args);
+      return Promise.resolve();
+    },
+    stop: () => mockStop(),
+  },
+}));
+
+import { useAutoReadOnNewMessage } from './useAutoReadOnNewMessage';
+
+beforeEach(() => {
+  mockSpeak.mockClear();
+  mockStop.mockClear();
+});
+
+function mkMsg(id: string, text: string, sender: 'user' | 'system' = 'system'): Message {
+  return { id, text, sender };
+}
+
+describe('useAutoReadOnNewMessage', () => {
+  it('does nothing when the toggle is off', () => {
+    renderHook(() =>
+      useAutoReadOnNewMessage([mkMsg('a', 'hello')], false),
+    );
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when enabled but the latest message is from the user', () => {
+    renderHook(() =>
+      useAutoReadOnNewMessage([mkMsg('u', 'hi', 'user')], true),
+    );
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('does NOT auto-read the FIRST message after toggling on (greeting on screen mount)', () => {
+    // Subtle UX rule: a user who just enabled auto-read shouldn't
+    // immediately hear the existing greeting. Auto-read only fires
+    // for NEW messages that arrive after mount.
+    renderHook(() =>
+      useAutoReadOnNewMessage([mkMsg('greeting', 'Welcome')], true),
+    );
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('speaks the latest assistant message when a NEW one appears', () => {
+    const { rerender } = renderHook(
+      ({ msgs, on }: { msgs: Message[]; on: boolean }) =>
+        useAutoReadOnNewMessage(msgs, on),
+      { initialProps: { msgs: [mkMsg('greeting', 'Welcome')], on: true } },
+    );
+    expect(mockSpeak).not.toHaveBeenCalled();
+
+    rerender({
+      msgs: [mkMsg('greeting', 'Welcome'), mkMsg('reply-1', 'New reply')],
+      on: true,
+    });
+    expect(mockSpeak).toHaveBeenCalledWith('New reply', 'reply-1');
+  });
+
+  it('skips speaking when the new latest message is from the user', () => {
+    const { rerender } = renderHook(
+      ({ msgs, on }: { msgs: Message[]; on: boolean }) =>
+        useAutoReadOnNewMessage(msgs, on),
+      { initialProps: { msgs: [mkMsg('greeting', 'Welcome')], on: true } },
+    );
+    rerender({
+      msgs: [
+        mkMsg('greeting', 'Welcome'),
+        mkMsg('u-1', 'me typing', 'user'),
+      ],
+      on: true,
+    });
+    expect(mockSpeak).not.toHaveBeenCalled();
+  });
+
+  it('stops any in-flight speech on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useAutoReadOnNewMessage([mkMsg('a', 'hi')], true),
+    );
+    unmount();
+    expect(mockStop).toHaveBeenCalled();
+  });
+});

--- a/MirrorCollectiveApp/src/services/speech/useAutoReadOnNewMessage.ts
+++ b/MirrorCollectiveApp/src/services/speech/useAutoReadOnNewMessage.ts
@@ -1,0 +1,61 @@
+/**
+ * useAutoReadOnNewMessage — when `enabled` is true, speak the latest
+ * assistant reply whenever a NEW one arrives. Skips the very first
+ * render (so the on-screen greeting doesn't immediately play after a
+ * user enables the toggle).
+ *
+ * Lives next to the ttsService so the chat screen wires up one hook
+ * instead of carrying a useEffect with its own bookkeeping.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { Message } from '@types';
+
+import { ttsService } from './ttsService';
+
+export function useAutoReadOnNewMessage(
+  messages: Message[],
+  enabled: boolean,
+): void {
+  // Track the latest assistant id we've ALREADY processed so we don't
+  // re-speak the same reply when an unrelated re-render happens. The
+  // first effect run captures the initial state without speaking.
+  const lastSpokenIdRef = useRef<string | null>(null);
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const latest = messages[messages.length - 1];
+    if (!latest) return;
+
+    // First effect run after mount or after re-enabling: seed the ref
+    // with the current latest assistant id (if any) without speaking.
+    // This prevents the greeting from speaking when the user enters
+    // the screen with auto-read already on.
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      lastSpokenIdRef.current =
+        latest.sender === 'system' ? latest.id : null;
+      return;
+    }
+
+    // From here on, speak only when a newer assistant message has
+    // arrived. User messages don't get spoken (no point) and don't
+    // advance the lastSpokenId — a user message followed by a system
+    // reply still triggers the reply to be spoken.
+    if (latest.sender !== 'system') return;
+    if (latest.id === lastSpokenIdRef.current) return;
+
+    lastSpokenIdRef.current = latest.id;
+    void ttsService.speak(latest.text, latest.id);
+  }, [messages, enabled]);
+
+  // On unmount, stop any speech this screen kicked off so the user
+  // doesn't hear half a reply continuing from another screen.
+  useEffect(() => {
+    return () => {
+      ttsService.stop();
+    };
+  }, []);
+}

--- a/MirrorCollectiveApp/src/services/speech/useAutoReadPreference.test.ts
+++ b/MirrorCollectiveApp/src/services/speech/useAutoReadPreference.test.ts
@@ -1,0 +1,81 @@
+/**
+ * useAutoReadPreference — AsyncStorage-backed boolean toggle for
+ * "Auto-read Mirror replies". Default is OFF so first-time users hear
+ * no surprise audio.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import {
+  AUTO_READ_STORAGE_KEY,
+  useAutoReadPreference,
+} from './useAutoReadPreference';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useAutoReadPreference', () => {
+  it('starts disabled when AsyncStorage has no value', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useAutoReadPreference());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.enabled).toBe(false);
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(AUTO_READ_STORAGE_KEY);
+  });
+
+  it('hydrates from AsyncStorage value "true"', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('true');
+
+    const { result } = renderHook(() => useAutoReadPreference());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('setEnabled writes to AsyncStorage and updates state', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useAutoReadPreference());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AUTO_READ_STORAGE_KEY,
+      'true',
+    );
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('setEnabled(false) writes "false" — not removeItem — so it survives "any non-null = true" parsing bugs', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('true');
+
+    const { result } = renderHook(() => useAutoReadPreference());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      await result.current.setEnabled(false);
+    });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      AUTO_READ_STORAGE_KEY,
+      'false',
+    );
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it('treats unknown values as disabled (defensive)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('garbage');
+
+    const { result } = renderHook(() => useAutoReadPreference());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.enabled).toBe(false);
+  });
+});

--- a/MirrorCollectiveApp/src/services/speech/useAutoReadPreference.ts
+++ b/MirrorCollectiveApp/src/services/speech/useAutoReadPreference.ts
@@ -1,0 +1,65 @@
+/**
+ * useAutoReadPreference — persists a single boolean ("auto-read assistant
+ * replies aloud") via AsyncStorage, exposes it to the Chat + Settings UIs.
+ *
+ * Default is `false` — first-time users should NOT hear a surprise voice.
+ * The toggle lives next to the other "global" prefs we'll grow into a
+ * proper Settings store later.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useCallback, useEffect, useState } from 'react';
+
+export const AUTO_READ_STORAGE_KEY = 'settings:autoReadMirrorReplies';
+
+export interface AutoReadPreferenceApi {
+  /** False until the AsyncStorage read completes. UIs that flash if the
+   *  toggle starts wrong should wait for this before rendering the switch. */
+  loaded: boolean;
+  enabled: boolean;
+  setEnabled: (next: boolean) => Promise<void>;
+}
+
+export function useAutoReadPreference(): AutoReadPreferenceApi {
+  const [enabled, setEnabledState] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(AUTO_READ_STORAGE_KEY);
+        if (!cancelled) {
+          // Strict equality on 'true' — any other value (null, 'false',
+          // legacy garbage from a refactor) is treated as disabled.
+          setEnabledState(raw === 'true');
+          setLoaded(true);
+        }
+      } catch {
+        if (!cancelled) {
+          setEnabledState(false);
+          setLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setEnabled = useCallback(async (next: boolean) => {
+    // Optimistic update so the Switch UI responds immediately; the write
+    // is best-effort. If it fails the next mount re-reads the old value
+    // and the toggle visually resets — acceptable for a non-critical pref.
+    setEnabledState(next);
+    try {
+      // Write 'false' explicitly (not removeItem) so future readers
+      // that interpret "any non-null = true" don't silently flip on.
+      await AsyncStorage.setItem(AUTO_READ_STORAGE_KEY, next ? 'true' : 'false');
+    } catch (err) {
+      console.warn('[autoRead] failed to persist preference', err);
+    }
+  }, []);
+
+  return { enabled, setEnabled, loaded };
+}

--- a/MirrorCollectiveApp/src/services/speech/useTtsActiveId.ts
+++ b/MirrorCollectiveApp/src/services/speech/useTtsActiveId.ts
@@ -1,0 +1,28 @@
+/**
+ * React hook: returns the utteranceId of the message currently being
+ * spoken (or null). Re-renders subscribers when the active id changes.
+ *
+ * MessageBubble uses this to render the right speaker glyph — play when
+ * idle or speaking someone else, stop when *this* bubble is the one
+ * speaking.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { ttsService } from './ttsService';
+
+export function useTtsActiveId(): string | null {
+  const [activeId, setActiveId] = useState<string | null>(
+    ttsService.getActiveUtteranceId(),
+  );
+
+  useEffect(() => {
+    const unsubscribe = ttsService.subscribe((event) => {
+      // started → mark active; finished/cancelled → clear.
+      setActiveId(event.type === 'started' ? event.utteranceId : null);
+    });
+    return unsubscribe;
+  }, []);
+
+  return activeId;
+}


### PR DESCRIPTION
Adds read-aloud for assistant messages in MirrorGPT chat. Two team members requested this; Tony scoped open-source TTS as the path. Built around react-native-tts (4.1.1) — native AVSpeechSynthesizer on iOS, TextToSpeech on Android, autolinked, no server changes.

UX:
  • Speaker icon on every assistant bubble — tap to play, tap again to
    stop. Only one bubble speaks at a time; tapping a different bubble
    stops the first.
  • Settings → "Auto-read Mirror replies" toggle (default OFF). When on,
    each new assistant reply speaks on arrival. The on-screen greeting
    is NOT auto-spoken on screen entry — only NEW messages trigger it.
  • Speech stops on screen unmount so it doesn't bleed across screens.

Architecture (src/services/speech/):
  • ttsService — singleton facade enforcing "one utterance at a time",
    state-via-subscriber for the UI to render the play/stop glyph,
    test-safe (no-op when native module isn't linked).
  • useAutoReadPreference — AsyncStorage-backed boolean (key
    `settings:autoReadMirrorReplies`). Defaults to false; persists
    'false' explicitly to avoid "any non-null = true" parsing bugs.
  • useTtsActiveId — react hook that subscribes to ttsService for the
    bubble's play/stop glyph.
  • useAutoReadOnNewMessage — chat-level effect, seeded with the
    initial greeting id so toggling on never replays existing history.

Tests: 32 new, all passing. Coverage on the service singleton, preference store, the new-message hook, the speaker button (incl. accessibility labels), and the Settings row.

Native side: react-native-tts is autolinked. iOS needs `cd ios && pod install` on first build; Android needs no extra setup.