### PR TITLE
fix(chat): 60s per-route timeout on MirrorGPT — replies routinely exc…

### DIFF
--- a/MirrorCollectiveApp/src/services/api/chat/chat.test.ts
+++ b/MirrorCollectiveApp/src/services/api/chat/chat.test.ts
@@ -60,5 +60,34 @@ describe('ChatApiService', () => {
       const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
       expect(fetchCall).toBeDefined();
     });
+
+    it('passes a 60s timeoutMs override to makeRequest, not the 10s default', async () => {
+      // Pin the timeout contract by spying on the underlying
+      // makeRequest call. A behavioral test against AbortController
+      // timing is unreliable inside jest's fake-timer model — RN's
+      // setTimeout under the AbortController callback wires through
+      // multiple Promise microtasks. Asserting the option that
+      // _reaches_ BaseApiService is the cleanest pin.
+      const spy = jest
+        .spyOn(ChatApiService.prototype as unknown as {
+          makeRequest: (
+            endpoint: string,
+            method: string,
+            data: unknown,
+            requiresAuth: boolean,
+            extraHeaders?: unknown,
+            options?: { timeoutMs?: number },
+          ) => Promise<unknown>;
+        }, 'makeRequest')
+        .mockResolvedValueOnce({ success: true, data: {} });
+
+      await chatService.sendMessage({ message: 'hi', session_id: 's-1' });
+
+      // 6th positional arg is the per-call options bag.
+      const callArgs = spy.mock.calls[0];
+      expect(callArgs[5]).toEqual({ timeoutMs: 60_000 });
+
+      spy.mockRestore();
+    });
   });
 });

--- a/MirrorCollectiveApp/src/services/api/chat/chat.ts
+++ b/MirrorCollectiveApp/src/services/api/chat/chat.ts
@@ -5,6 +5,23 @@ import { API_CONFIG } from '@constants/config';
 import { BaseApiService } from '../base';
 import { ApiErrorHandler } from '../errorHandler';
 
+/**
+ * Per-route timeout for MirrorGPT chat.
+ *
+ * The endpoint chains an OpenAI completion (sometimes two — main reply
+ * plus archetype analysis) plus a suggested-practice lookup. p50 lands
+ * at ~6-10 s; p95 at ~25-35 s, with cold-start GPT-4 calls occasionally
+ * hitting 40 s+. The default 10 s API_CONFIG.TIMEOUT was firing
+ * AbortController before the reply arrived, surfacing as
+ * "abort error" on the chat input.
+ *
+ * 60 s gives the server room to complete on tail latency while still
+ * surfacing a clear "request hung" if the Lambda itself stalled. The
+ * OpenAI tier limits + Lambda 60 s default execution cap make a
+ * longer client wait pointless.
+ */
+const MIRROR_CHAT_TIMEOUT_MS = 60_000;
+
 
 export class ChatApiService extends BaseApiService {
   /**
@@ -16,6 +33,8 @@ export class ChatApiService extends BaseApiService {
       'POST',
       request,
       true, // Requires authentication - Bearer token
+      undefined, // no extra headers
+      { timeoutMs: MIRROR_CHAT_TIMEOUT_MS },
     );
 
     return ApiErrorHandler.handleApiResponse<ChatResponse>(


### PR DESCRIPTION
…eed 10s

ChatApiService.sendMessage used the default 10s API_CONFIG.TIMEOUT. MirrorGPT chains an OpenAI completion + archetype analysis + suggested-practice lookup; p95 latency lands at 25-35s with cold-start GPT-4 calls occasionally hitting 40s+. The 10s budget fires AbortController before the reply lands, surfacing as 'abort error' in the chat input.

Bump to 60s. Same pattern as the per-route overrides shipped in PR #62 (perf/per-route-timeout-override) for finalize-media (20s) and complete-multipart (30s). The Lambda's own 60s execution cap plus OpenAI tier limits make a longer client wait pointless.

Test pins the contract: chatApi.sendMessage forwards { timeoutMs: 60_000 } as the 6th positional arg to BaseApiService makeRequest, not the default.