### PR TITLE
fix(echo): normalize back-arrow size across echoVault screens

### DIFF
--- a/MirrorCollectiveApp/src/screens/echoVault/ChooseGuardianScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ChooseGuardianScreen.tsx
@@ -1,5 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
+import { palette, scale, textShadow } from '@theme';
 import { RootStackParamList } from '@types';
 import React, { useState, useEffect, useCallback } from 'react';
 import {
@@ -360,7 +360,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   backArrow: { fontSize: 22, color: GOLD },
-  backArrowImg: { width: 20, height: 20, tintColor: GOLD },
+  backArrowImg: { width: scale(20), height: scale(20), tintColor: GOLD },
   title: {
     textAlign: 'center',
     color: GOLD,

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoAudioPlaybackScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoAudioPlaybackScreen.tsx
@@ -427,7 +427,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
   },
   backIcon: { color: 'rgba(215,192,138,0.9)', fontSize: 30, marginLeft: 2 },
-  backArrowImg: { width: 20, height: 20, tintColor: 'rgba(215,192,138,0.9)' },
+  backArrowImg: { width: scale(20), height: scale(20), tintColor: palette.gold.mid },
   screenTitle: {
     color: 'rgba(215,192,138,0.92)',
     fontSize: 28,

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoInboxScreen.tsx
@@ -38,12 +38,14 @@ import type { RootStackParamList } from '@types';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Image,
   ScrollView,
   StatusBar,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
+  type ImageStyle,
   type TextStyle,
   type ViewStyle,
 } from 'react-native';
@@ -72,13 +74,17 @@ const LockIcon: React.FC = () => (
 );
 
 // ── Back arrow icon ───────────────────────────────────────────────────────────
+// Use the shared `back-arrow.png` asset (same one Compose / Detail / Audio /
+// Video / Recipient screens render) so the glyph is pixel-aligned across the
+// whole echoVault flow. An inline Material arrow_back SVG path only fills
+// ~67% of a 24-unit viewBox, so the visible glyph was visibly smaller here
+// than on the PNG-using screens.
 const BackIcon: React.FC = () => (
-  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-      fill={palette.gold.DEFAULT}
-    />
-  </Svg>
+  <Image
+    source={require('@assets/back-arrow.png')}
+    style={styles.backArrowImg}
+    resizeMode="contain"
+  />
 );
 
 // ── Screen ────────────────────────────────────────────────────────────────────
@@ -318,6 +324,7 @@ const styles = StyleSheet.create<{
   headerSection: ViewStyle;
   titleRow: ViewStyle;
   backBtn: ViewStyle;
+  backArrowImg: ImageStyle;
   title: TextStyle;
   titleSpacer: ViewStyle;
   subtitle: TextStyle;
@@ -378,6 +385,11 @@ const styles = StyleSheet.create<{
     height:         scale(44),
     alignItems:     'flex-start',
     justifyContent: 'center',
+  },
+  backArrowImg: {
+    width:     scale(20),
+    height:    scale(20),
+    tintColor: palette.gold.DEFAULT,
   },
 
   // Heading M: Cormorant Regular 28/32, #f2e1b0, glow shadow

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultLibraryScreen.tsx
@@ -116,14 +116,15 @@ type EchoLibraryNavigationProp = NativeStackNavigationProp<
   'MirrorEchoVaultLibrary'
 >;
 
-// ── Back arrow — matches ForgotPassword/ResetPassword (Figma 4928:7988) ────
+// ── Back arrow — uses the shared `back-arrow.png` asset so the glyph
+// matches Compose / Detail / Audio / Video / Recipient. Inline Material
+// SVG only fills ~67% of its viewBox and renders visibly smaller.
 const BackArrowIcon: React.FC = () => (
-  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-      fill={palette.gold.DEFAULT}
-    />
-  </Svg>
+  <Image
+    source={require('@assets/back-arrow.png')}
+    style={styles.backArrowImg}
+    resizeMode="contain"
+  />
 );
 
 // ── Lock icon — Figma node 1143:1360 (Vector) ───────────────────────────────
@@ -582,6 +583,7 @@ const styles = StyleSheet.create<{
   titleGroup: ViewStyle;
   headerRow: ViewStyle;
   backBtn: ViewStyle;
+  backArrowImg: ImageStyle;
   headerSpacer: ViewStyle;
   title: TextStyle;
   subtitle: TextStyle;
@@ -669,6 +671,11 @@ const styles = StyleSheet.create<{
   },
   backBtn: {
     paddingVertical: verticalScale(8),
+  },
+  backArrowImg: {
+    width:     scale(20),
+    height:    scale(20),
+    tintColor: palette.gold.DEFAULT,
   },
   headerSpacer: {
     width: scale(20),

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVideoPlaybackScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVideoPlaybackScreen.tsx
@@ -367,9 +367,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  backBtn: { width: 44, height: 44, justifyContent: 'center' },
+  backBtn: { width: scale(44), height: scale(44), justifyContent: 'center' },
   backIcon: { color: GOLD, fontSize: 30 },
-  backArrowImg: { width: 20, height: 20, tintColor: GOLD },
+  backArrowImg: { width: scale(20), height: scale(20), tintColor: GOLD },
   screenTitle: {
     color: GOLD,
     fontSize: 28,

--- a/MirrorCollectiveApp/src/screens/echoVault/ManageGuardianScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ManageGuardianScreen.tsx
@@ -1,5 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
+import { palette, scale, textShadow } from '@theme';
 import { RootStackParamList } from '@types';
 import React, { useState, useEffect, useCallback } from 'react';
 import {
@@ -206,7 +206,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   backArrow: { fontSize: 22, color: GOLD },
-  backArrowImg: { width: 20, height: 20, tintColor: GOLD },
+  backArrowImg: { width: scale(20), height: scale(20), tintColor: GOLD },
   title: {
     fontSize: 28,
     color: GOLD,

--- a/MirrorCollectiveApp/src/screens/echoVault/ManageRecipientScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ManageRecipientScreen.tsx
@@ -1,6 +1,6 @@
 
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, fontFamily, textShadow } from '@theme';
+import { palette, fontFamily, scale, textShadow } from '@theme';
 import { RootStackParamList } from '@types';
 import React, { useState, useEffect, useCallback } from 'react';
 import {
@@ -225,8 +225,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   backArrow: {
-    width: 20,
-    height: 20,
+    width: scale(20),
+    height: scale(20),
     tintColor: GOLD,
   },
   titleSpacer: { width: 20 },

--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoAudioScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoAudioScreen.tsx
@@ -1,7 +1,7 @@
 // NewEchoAudioScreen.tsx
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
+import { palette, scale, textShadow } from '@theme';
 import { RootStackParamList } from '@types';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
@@ -525,8 +525,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   backBtn: {
-    width: 44,
-    height: 44,
+    width: scale(44),
+    height: scale(44),
     justifyContent: 'center',
     alignItems: 'flex-start',
   },
@@ -536,9 +536,9 @@ const styles = StyleSheet.create({
     marginLeft: 2,
   },
   backArrowImg: {
-    width: 20,
-    height: 20,
-    tintColor: 'rgba(215,192,138,0.9)',
+    width: scale(20),
+    height: scale(20),
+    tintColor: GOLD,
   },
   screenTitle: {
     color: 'rgba(215,192,138,0.92)',

--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
@@ -95,13 +95,15 @@ const CheckboxIcon: React.FC<{ checked: boolean }> = ({ checked }) => (
 );
 
 // ── Back arrow icon ───────────────────────────────────────────────────────────
+// Use the shared `back-arrow.png` asset so the glyph is pixel-aligned with
+// every other echoVault screen. Inline Material arrow_back SVG only fills
+// ~67% of its 24-unit viewBox, producing a visibly smaller glyph.
 const BackIcon: React.FC = () => (
-  <Svg width={scale(20)} height={scale(20)} viewBox="0 0 24 24" fill="none">
-    <Path
-      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-      fill={palette.gold.DEFAULT}
-    />
-  </Svg>
+  <Image
+    source={require('@assets/back-arrow.png')}
+    style={styles.backArrowImg}
+    resizeMode="contain"
+  />
 );
 
 // ── Action button ─────────────────────────────────────────────────────────────
@@ -394,6 +396,7 @@ const styles = StyleSheet.create<{
   // Header
   headerRow: ViewStyle;
   backBtn: ViewStyle;
+  backArrowImg: ImageStyle;
   screenTitle: TextStyle;
   headerSpacer: ViewStyle;
   // Title input
@@ -475,6 +478,11 @@ const styles = StyleSheet.create<{
     height:         scale(44),
     justifyContent: 'center',
     alignItems:     'flex-start',
+  },
+  backArrowImg: {
+    width:     scale(20),
+    height:    scale(20),
+    tintColor: palette.gold.DEFAULT,
   },
   // Heading M: Cormorant Regular 28/32, #f2e1b0, glow text-shadow
   screenTitle: {


### PR DESCRIPTION
Three screens (EchoVaultLibrary, NewEchoVault, EchoInbox) rendered the back arrow as an inline Material arrow_back SVG with viewBox 0 0 24 24. The path only fills x=4..20, ~67% of the viewBox, so the rendered glyph at scale(20) was visibly smaller than on every other screen which uses the shared `back-arrow.png` asset that fills its frame edge-to-edge.

Six other screens had `width: 20, height: 20` (raw) instead of the project-standard `scale(20)` so on non-default-density devices the glyph drifted from neighbouring screens.

Changes
- EchoInbox / EchoVaultLibrary / NewEchoVault: replace inline SVG back-arrow with the shared PNG (with palette.gold.DEFAULT tint).
- NewEchoAudio / EchoAudioPlayback / EchoVideoPlayback / ChooseGuardian / ManageGuardian / ManageRecipient: normalize back-arrow width+height from raw `20` to `scale(20)`. Tint left untouched — each screen keeps its existing gold variant (DEFAULT vs mid) since the colour split is an older design decision not part of this fix.
- NewEchoAudioScreen + EchoVideoPlaybackScreen: also normalize the 44px back-button container to `scale(44)` to match the other screens.