### PR TITLE
fix(push): register raw APNs token on iOS (SNS-native, no FCM)

### DIFF
--- a/MirrorCollectiveApp/src/services/PushNotificationService.ts
+++ b/MirrorCollectiveApp/src/services/PushNotificationService.ts
@@ -38,7 +38,7 @@ class PushNotificationService {
     await this.requestPermission();
 
     // 5. Register the current token with the backend if we have one
-    const token = await this.getFCMToken();
+    const token = await this.getDeviceToken();
     if (token) {
       this.registerDeviceWithBackend(token);
     }
@@ -112,42 +112,60 @@ class PushNotificationService {
   }
 
   /**
-   * Get the FCM token for this device, prioritizing the live token.
+   * Get the push token to register with the backend (SNS).
+   *
+   * SNS-native delivery: iOS registers its RAW APNs device token directly
+   * against the SNS APNS platform application. We must NOT send the Firebase
+   * FCM token here — SNS's APNS app rejects it with `InvalidParameter` on
+   * CreatePlatformEndpoint (an FCM token isn't an APNs token). The APNs token
+   * can be momentarily null right after registration, so we retry once.
+   *
+   * Android is parked (iOS-only focus); it keeps the FCM token for if/when a
+   * GCM/FCM platform app is wired.
    */
-  async getFCMToken(): Promise<string | undefined> {
+  async getDeviceToken(): Promise<string | undefined> {
     try {
-      // On iOS, we must register for remote messages first
       if (Platform.OS === 'ios') {
         await messaging().registerDeviceForRemoteMessages();
+        let apns = await messaging().getAPNSToken();
+        if (!apns) {
+          // APNs may not have returned the token yet on a cold start.
+          await new Promise(res => setTimeout(res, 1500));
+          apns = await messaging().getAPNSToken();
+        }
+        if (apns) {
+          await AsyncStorage.setItem('deviceToken', apns);
+          return apns;
+        }
+        console.warn(
+          'No APNs token yet (iOS Simulator, or permission/registration pending). Push will not work until one is available.',
+        );
+        return (await AsyncStorage.getItem('deviceToken')) || undefined;
       }
 
-      // Always try to get the fresh token from Firebase first
+      // Android (parked) — FCM token.
       const fcmToken = await messaging().getToken();
       if (fcmToken) {
-        await AsyncStorage.setItem('fcmToken', fcmToken);
+        await AsyncStorage.setItem('deviceToken', fcmToken);
         return fcmToken;
       }
-
-      // Fallback to cached token if Firebase is unavailable
-      return await AsyncStorage.getItem('fcmToken') || undefined;
+      return (await AsyncStorage.getItem('deviceToken')) || undefined;
     } catch (error: any) {
-      if (error?.message?.includes('no apns token specified')) {
-        console.warn(
-          'FCM Warning: No APNs token available. This is expected on iOS Simulator. Push notifications will not work.',
-        );
-        return undefined;
-      }
-      console.error('Error getting FCM token:', error);
-      return await AsyncStorage.getItem('fcmToken') || undefined;
+      console.error('Error getting device token:', error);
+      return (await AsyncStorage.getItem('deviceToken')) || undefined;
     }
   }
 
   /**
-   * Listens for FCM token refreshes and syncs with the backend.
+   * Sync token changes to the backend. FCM token refresh only matters for
+   * Android (parked); on iOS we register the raw APNs token, which
+   * onTokenRefresh does NOT provide — so we skip iOS here to avoid ever
+   * registering an FCM token against the APNS platform app.
    */
   private listenToTokenRefresh(): void {
+    if (Platform.OS === 'ios') return;
     messaging().onTokenRefresh((token: string) => {
-      AsyncStorage.setItem('fcmToken', token);
+      AsyncStorage.setItem('deviceToken', token);
       if (this.userId) {
         this.registerDeviceWithBackend(token);
       }
@@ -194,7 +212,7 @@ class PushNotificationService {
                 try {
                   const enabled = await this.requestPermission();
                   if (enabled) {
-                    const token = await this.getFCMToken();
+                    const token = await this.getDeviceToken();
                     if (token) {
                       await this.registerDeviceWithBackend(token);
                     }
@@ -240,13 +258,13 @@ class PushNotificationService {
    */
   async unregisterDevice(): Promise<void> {
     try {
-      const token = await this.getFCMToken();
+      const token = await this.getDeviceToken();
       if (token) {
         await registerDeviceApiService.unregisterDevice(token);
         console.log('Device unregistered successfully from backend');
       }
       // Also clear local token cache
-      await AsyncStorage.removeItem('fcmToken');
+      await AsyncStorage.removeItem('deviceToken');
     } catch (error) {
       console.error('Failed to unregister device:', error);
     }


### PR DESCRIPTION
The app was sending the Firebase FCM token to the backend, which registers it against the SNS APNS platform application — but an FCM token is not an APNs token, so SNS rejects it: 'CreatePlatformEndpoint ... InvalidParameter'.

Switch iOS to register its RAW APNs device token (messaging().getAPNSToken(), with a one-shot retry since it can be briefly null). The SNS APNS platform apps already created are exactly right for this; the .p8 stays in SNS, no Firebase delivery involved. Skip the FCM onTokenRefresh sync on iOS so we never re-register an FCM token against the APNS app. Android (parked) keeps the FCM token.