### PR TITLE
fix: send username on token refresh for Cognito SECRET_HASH

### DIFF
--- a/MirrorCollectiveApp/src/services/api/auth.test.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.test.ts
@@ -1,6 +1,19 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
 import { tokenManager } from '@services/tokenManager';
 
 import { AuthApiService } from './auth';
+
+/** Build a JWT-shaped token whose payload carries the given claims. */
+function makeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: object) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/[=]/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  return `${enc({ alg: 'none' })}.${enc(payload)}.sig`;
+}
 
 // Mock dependencies
 jest.mock('@services/tokenManager', () => ({
@@ -95,6 +108,57 @@ describe('AuthApiService', () => {
       // user tapping "Log out" should ALWAYS see the auth stack again,
       // even if the network is down.
       expect(tokenManager.clearTokens).toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshToken', () => {
+    const mockStore = (values: Record<string, string | null>) => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        Promise.resolve(key in values ? values[key] : null),
+      );
+    };
+
+    it('sends the username from the stored access token (for SECRET_HASH)', async () => {
+      mockStore({
+        refreshToken: 'r-tok',
+        accessToken: makeJwt({ username: 'user@example.com' }),
+      });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: { tokens: { accessToken: 'a', refreshToken: 'b' } },
+          }),
+      });
+
+      await authService.refreshToken();
+
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(String(url)).toContain('/api/auth/refresh');
+      expect(JSON.parse(init.body)).toEqual({
+        refreshToken: 'r-tok',
+        username: 'user@example.com',
+      });
+    });
+
+    it('omits username when no access token is available', async () => {
+      mockStore({ refreshToken: 'r-tok' });
+
+      await authService.refreshToken();
+
+      const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({ refreshToken: 'r-tok' });
+      expect(JSON.parse(init.body)).not.toHaveProperty('username');
+    });
+
+    it('does not call the API when there is no refresh token', async () => {
+      mockStore({});
+
+      const result = await authService.refreshToken();
+
+      expect(result.success).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/MirrorCollectiveApp/src/services/api/auth.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.ts
@@ -1,4 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { API_CONFIG } from '@constants/config';
+import { tokenManager } from '@services/tokenManager';
 import type {
   AuthCredentials,
   SignUpData,
@@ -6,9 +9,7 @@ import type {
   ResetPasswordData,
   ApiResponse,
 } from '@types';
-
-import { API_CONFIG } from '@constants/config';
-import { tokenManager } from '@services/tokenManager';
+import { getUsernameFromToken } from '@utils/jwt';
 
 import { BaseApiService } from './base';
 import { ApiErrorHandler } from './errorHandler';
@@ -179,11 +180,19 @@ export class AuthApiService extends BaseApiService {
       );
     }
 
+    // Cognito requires SECRET_HASH on REFRESH_TOKEN_AUTH because the app
+    // client has a secret. The backend computes it from the username, which
+    // we read from the stored access token's claims. Sending it is harmless
+    // when the backend doesn't need it (omitted if unavailable).
+    const accessToken = await AsyncStorage.getItem('accessToken');
+    const username = getUsernameFromToken(accessToken);
+
     const response = await this.makeRequest<any>(
       API_CONFIG.ENDPOINTS.AUTH.REFRESH,
       'POST',
       {
         refreshToken,
+        ...(username ? { username } : {}),
       },
     );
 

--- a/MirrorCollectiveApp/src/utils/jwt.test.ts
+++ b/MirrorCollectiveApp/src/utils/jwt.test.ts
@@ -1,0 +1,64 @@
+import { decodeJwtPayload, getUsernameFromToken } from './jwt';
+
+/** Build a JWT-shaped string (header.payload.signature) from a claims object. */
+function makeToken(payload: Record<string, unknown>): string {
+  const enc = (obj: object) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/[=]/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc(payload)}.signature`;
+}
+
+describe('getUsernameFromToken', () => {
+  it('reads the `username` claim from an access token', () => {
+    const token = makeToken({ username: 'user@example.com', sub: 'abc' });
+    expect(getUsernameFromToken(token)).toBe('user@example.com');
+  });
+
+  it('falls back to `cognito:username` (id token)', () => {
+    const token = makeToken({ 'cognito:username': 'user@example.com' });
+    expect(getUsernameFromToken(token)).toBe('user@example.com');
+  });
+
+  it('decodes even when the token is expired (no signature/expiry check)', () => {
+    const token = makeToken({ username: 'u@e.com', exp: 1 });
+    expect(getUsernameFromToken(token)).toBe('u@e.com');
+  });
+
+  it('tolerates non-ASCII values in other claims', () => {
+    const token = makeToken({ username: 'jose@example.com', name: 'José' });
+    expect(getUsernameFromToken(token)).toBe('jose@example.com');
+  });
+
+  it.each([null, undefined, '', 'not-a-jwt', 'only.two'])(
+    'returns null for invalid token: %p',
+    input => {
+      expect(getUsernameFromToken(input as string)).toBeNull();
+    },
+  );
+
+  it('returns null when no username claim is present', () => {
+    expect(getUsernameFromToken(makeToken({ sub: 'abc' }))).toBeNull();
+  });
+
+  it('returns null for an empty username claim', () => {
+    expect(getUsernameFromToken(makeToken({ username: '' }))).toBeNull();
+  });
+
+  it('returns null when the payload is not valid base64/JSON', () => {
+    expect(getUsernameFromToken('header.%%%notbase64%%%.sig')).toBeNull();
+  });
+});
+
+describe('decodeJwtPayload', () => {
+  it('returns the full claims object', () => {
+    const token = makeToken({ username: 'u', sub: 's', exp: 123 });
+    expect(decodeJwtPayload(token)).toEqual({ username: 'u', sub: 's', exp: 123 });
+  });
+
+  it('returns null for malformed input', () => {
+    expect(decodeJwtPayload('garbage')).toBeNull();
+  });
+});

--- a/MirrorCollectiveApp/src/utils/jwt.ts
+++ b/MirrorCollectiveApp/src/utils/jwt.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal, dependency-free JWT claim reader.
+ *
+ * This intentionally does NOT verify the signature or expiry — it only decodes
+ * the payload to read a claim. The single use case is extracting the Cognito
+ * `username` so it can be sent to the token-refresh endpoint, where the backend
+ * needs it to compute Cognito's SECRET_HASH (the app client has a secret).
+ *
+ * The username is non-sensitive routing data, never a credential: the refresh
+ * token remains the validated credential, and a wrong/missing username only
+ * results in Cognito rejecting the refresh.
+ */
+
+/** Decode a base64url segment to a UTF-8 string. */
+function decodeBase64UrlToUtf8(segment: string): string {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(padLength);
+
+  // atob exists on Hermes (RN 0.74+) and in Node 16+ (Jest). Fall back to
+  // Buffer where available (Node) for robustness.
+  let binary: string;
+  if (typeof atob === 'function') {
+    binary = atob(padded);
+  } else if (typeof Buffer !== 'undefined') {
+    binary = Buffer.from(padded, 'base64').toString('binary');
+  } else {
+    throw new Error('No base64 decoder available');
+  }
+
+  // Promote the binary string to UTF-8 so multi-byte claim values decode
+  // correctly (usernames are ASCII, but other claims may not be).
+  const percentEncoded = binary
+    .split('')
+    .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+    .join('');
+  return decodeURIComponent(percentEncoded);
+}
+
+/** Parse a JWT payload into a claims object, or null if it can't be read. */
+export function decodeJwtPayload(
+  token: string | null | undefined,
+): Record<string, unknown> | null {
+  if (!token) {
+    return null;
+  }
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+  try {
+    return JSON.parse(decodeBase64UrlToUtf8(parts[1])) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the Cognito username from an access or id token. Prefers the
+ * `username` claim (access token) and falls back to `cognito:username`
+ * (id token). Returns null if the token is missing/malformed or the claim
+ * is absent.
+ */
+export function getUsernameFromToken(
+  token: string | null | undefined,
+): string | null {
+  const claims = decodeJwtPayload(token);
+  if (!claims) {
+    return null;
+  }
+  const username = claims.username ?? claims['cognito:username'];
+  return typeof username === 'string' && username.length > 0 ? username : null;
+}


### PR DESCRIPTION
The Cognito app client has a secret, so REFRESH_TOKEN_AUTH requires a SECRET_HASH, which the backend computes from the user's username. The refresh request previously sent only the refresh token, so Cognito rejected it with 401 "Client is configured with secret but SECRET_HASH was not received", forcing re-logins.

- Add getUsernameFromToken (src/utils/jwt.ts): a dependency-free reader for the `username` / `cognito:username` claim. It does NOT verify signature or expiry — the claim is non-sensitive routing data, not a credential.
- refreshToken() reads the stored access token, extracts the username, and includes it in the refresh body (omitted if unavailable, so it degrades safely on older/edge states).

Pairs with backend fix/cognito-refresh-secret-hash. Adds unit tests for the JWT reader and for the refresh request body (username included/omitted).