### PR TITLE
fix: surface specific API validation messages instead of generic errors

### DIFF
--- a/MirrorCollectiveApp/src/services/api/base.test.ts
+++ b/MirrorCollectiveApp/src/services/api/base.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseApiService } from './base';
+import { ApiErrorHandler } from './errorHandler';
 
 // --- Mocks ---------------------------------------------------------------
 
@@ -28,6 +29,7 @@ jest.mock('./errorHandler', () => ({
     handleApiResponse: jest.fn(r => r),
     handleSystemError: jest.fn(() => ({ success: false, error: 'sys' })),
     shouldHandleGracefully: jest.fn(() => false),
+    formatValidationErrors: jest.fn(() => undefined),
   },
 }));
 
@@ -176,6 +178,41 @@ describe('BaseApiService — 429 retry-with-backoff', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('BaseApiService — validation errors (422)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws with the specific validation message and attaches the array', async () => {
+    (ApiErrorHandler.formatValidationErrors as jest.Mock).mockReturnValueOnce(
+      'Password must contain at least one special character',
+    );
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      makeResponse({
+        status: 422,
+        body: {
+          success: false,
+          error: 'Validation Error',
+          message: 'One or more fields contain invalid data',
+          validationErrors: [
+            { field: 'password', message: 'Password must contain at least one special character' },
+          ],
+        },
+      }),
+    );
+
+    await expect(svc.call('/api/auth/register', 'POST', {})).rejects.toMatchObject({
+      status: 422,
+      // The user-facing message is the specific field message, not the
+      // generic "Validation Error" envelope title.
+      message: 'Password must contain at least one special character',
+      validationErrors: [
+        { field: 'password', message: 'Password must contain at least one special character' },
+      ],
+    });
   });
 });
 

--- a/MirrorCollectiveApp/src/services/api/base.ts
+++ b/MirrorCollectiveApp/src/services/api/base.ts
@@ -189,9 +189,22 @@ export class BaseApiService {
         if (ApiErrorHandler.shouldHandleGracefully(endpoint, response.status)) {
           return { ...responseData, statusCode: response.status };
         }
-        // Extract error message from response data
-        const errorMessage = responseData?.error || responseData?.message || `Server error: ${response.status}`;
+        // Extract error message from response data. Prefer the specific
+        // field-level validation message (e.g. "Password must contain at least
+        // one special character") over the generic "Validation Error" title so
+        // the user knows what to fix instead of seeing "Registration Failed".
+        const validationMessage = ApiErrorHandler.formatValidationErrors(
+          responseData?.validationErrors,
+        );
+        const errorMessage =
+          validationMessage ||
+          responseData?.error ||
+          responseData?.message ||
+          `Server error: ${response.status}`;
         const err = this.createApiError(errorMessage, response.status);
+        if (Array.isArray(responseData?.validationErrors)) {
+          err.validationErrors = responseData.validationErrors;
+        }
         // Attach Retry-After (if present) so the outer retry loop can
         // honor it. Only meaningful for 429, but always attaching is
         // cheap and avoids a branch.

--- a/MirrorCollectiveApp/src/services/api/errorHandler.test.ts
+++ b/MirrorCollectiveApp/src/services/api/errorHandler.test.ts
@@ -1,0 +1,70 @@
+import { ApiErrorHandler } from './errorHandler';
+
+describe('ApiErrorHandler.formatValidationErrors', () => {
+  it('returns the single field message', () => {
+    expect(
+      ApiErrorHandler.formatValidationErrors([
+        { field: 'password', message: 'Password must contain at least one special character' },
+      ]),
+    ).toBe('Password must contain at least one special character');
+  });
+
+  it('joins multiple distinct messages on separate lines', () => {
+    expect(
+      ApiErrorHandler.formatValidationErrors([
+        { field: 'password', message: 'Password too weak' },
+        { field: 'fullName', message: 'Name has invalid characters' },
+      ]),
+    ).toBe('Password too weak\nName has invalid characters');
+  });
+
+  it('de-duplicates repeated messages', () => {
+    expect(
+      ApiErrorHandler.formatValidationErrors([
+        { field: 'a', message: 'Same problem' },
+        { field: 'b', message: 'Same problem' },
+      ]),
+    ).toBe('Same problem');
+  });
+
+  it.each([undefined, null, [], 'nope', {}, [{ field: 'x' }], [{ message: '' }]])(
+    'returns undefined for unusable input: %p',
+    input => {
+      expect(ApiErrorHandler.formatValidationErrors(input)).toBeUndefined();
+    },
+  );
+});
+
+describe('ApiErrorHandler.handleApiResponse', () => {
+  it('surfaces the validation message instead of the generic envelope title', () => {
+    const result = ApiErrorHandler.handleApiResponse(
+      {
+        success: false,
+        error: 'Validation Error',
+        message: 'One or more fields contain invalid data',
+        validationErrors: [
+          { field: 'password', message: 'Password must contain at least one special character' },
+        ],
+        statusCode: 422,
+      },
+      'Account created successfully',
+      'SignUpError',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe(
+      'Password must contain at least one special character',
+    );
+    expect(result.validationErrors).toHaveLength(1);
+    expect(result.statusCode).toBe(422);
+  });
+
+  it('falls back to error/message when there are no validation errors', () => {
+    const result = ApiErrorHandler.handleApiResponse(
+      { success: false, error: 'Server error', statusCode: 500 },
+      'ok',
+      'ServerError',
+    );
+    expect(result.message).toBe('Server error');
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/errorHandler.ts
+++ b/MirrorCollectiveApp/src/services/api/errorHandler.ts
@@ -35,13 +35,23 @@ export class ApiErrorHandler {
   ): ApiResponse<T> {
     // Handle API failure responses (when server returns success: false)
     if (response && response.success === false) {
+      // Prefer the specific field-level validation message over the generic
+      // envelope title ("Validation Error") so the user sees what to fix.
+      const validationMessage = this.formatValidationErrors(
+        response.validationErrors,
+      );
       return {
         success: false,
         data: undefined,
-        message: response.error || response.message || this.getDefaultErrorMessage(errorType),
+        message:
+          validationMessage ||
+          response.error ||
+          response.message ||
+          this.getDefaultErrorMessage(errorType),
         error: response.error || errorType,
         errorCode: response.errorCode,
         statusCode: response.statusCode,
+        validationErrors: response.validationErrors,
       };
     }
 
@@ -127,6 +137,36 @@ export class ApiErrorHandler {
       'UnknownError',
       context,
     );
+  }
+
+  /**
+   * Turn the API's `validationErrors` array into a single user-facing message.
+   *
+   * The backend returns field-level failures like
+   * `[{ field: 'password', message: 'Password must contain at least one
+   * special character' }]`. We surface those specific, already human-readable
+   * messages instead of the generic "Validation Error" envelope title.
+   * Returns undefined when there's nothing usable to show.
+   */
+  static formatValidationErrors(validationErrors: unknown): string | undefined {
+    if (!Array.isArray(validationErrors) || validationErrors.length === 0) {
+      return undefined;
+    }
+    const messages = validationErrors
+      .map(item =>
+        item && typeof item === 'object'
+          ? (item as { message?: unknown }).message
+          : undefined,
+      )
+      .filter(
+        (message): message is string =>
+          typeof message === 'string' && message.length > 0,
+      );
+    if (messages.length === 0) {
+      return undefined;
+    }
+    // De-duplicate while preserving order, then join for display.
+    return Array.from(new Set(messages)).join('\n');
   }
 
   /**

--- a/MirrorCollectiveApp/src/types/api.ts
+++ b/MirrorCollectiveApp/src/types/api.ts
@@ -1,3 +1,9 @@
+/** A single field-level validation failure returned by the API. */
+export interface ValidationFieldError {
+  field: string;
+  message: string;
+}
+
 export interface ApiResponse<T = any> {
   success: boolean;
   data?: T;
@@ -5,12 +11,14 @@ export interface ApiResponse<T = any> {
   errorCode?: string;
   message?: string;
   statusCode?: number;
+  validationErrors?: ValidationFieldError[];
 }
 
 export interface ApiError {
   message: string;
   status?: number;
   code?: string;
+  validationErrors?: ValidationFieldError[];
 }
 
 export interface AuthCredentials {


### PR DESCRIPTION
Registration (and any validated endpoint) showed a generic "Registration Failed" because the client dropped the backend's field-level details. A 422 returns:
  { error: "Validation Error", validationErrors: [{ field, message }] }
but base.ts threw using only `error` (the envelope title), so the user never saw the actual reason (e.g. an unsupported password symbol).

- ApiErrorHandler.formatValidationErrors(): build a user-facing message from the validationErrors array (de-duped, newline-joined).
- base.ts non-OK path and handleApiResponse now prefer that specific message over the generic title, and carry validationErrors through on the error.
- Add ValidationFieldError type; ApiResponse/ApiError gain validationErrors.

Pairs with backend fix/registration-validation, which logs and returns the failing field. Adds tests for the formatter, the response path, and a 422 thrown through makeRequest.