### PR TITLE
chore: remove Code Library from home menu, nav menu, and FAQ

### DIFF
--- a/MirrorCollectiveApp/src/screens/FAQScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/FAQScreen.tsx
@@ -216,28 +216,6 @@ const SECTIONS: Section[] = [
     ],
   },
   {
-    title: 'Code Library',
-    initiallyOpen: false,
-    items: [
-      {
-        q: 'What is the Code Library?',
-        a: 'A living library of ideas, research, and real human insight — blending psychology, consciousness, and pattern science to help you understand yourself, the world, and how meaning actually forms. It includes short, readable entries, micro-practices, and community-shared reflections — so learning isn\'t abstract, it\'s lived.',
-      },
-      {
-        q: 'How do I use it?',
-        a: 'Search by how you feel, or browse by theme. Try one small practice.',
-      },
-      {
-        q: 'Is everything long-form?',
-        a: 'No. Most entries take minutes.',
-      },
-      {
-        q: 'Can I contribute?',
-        a: 'When enabled, yes. Shared reflections help others feel less alone.',
-      },
-    ],
-  },
-  {
     title: 'Mirror Pledge',
     initiallyOpen: false,
     items: [

--- a/MirrorCollectiveApp/src/screens/NavigationMenuScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/NavigationMenuScreen.tsx
@@ -55,7 +55,6 @@ const PRIMARY_ITEMS = [
   { label: 'MirrorGPT',       route: 'MirrorChat' },
   { label: 'Echo Vault',      route: 'MirrorEchoVaultHome' },
   { label: 'Reflection Room', route: 'ReflectionRoomCommingsoon' },
-  { label: 'Code Library',    route: 'MirrorCodeLibrary' },
   { label: 'Pledge',          route: 'TheMirrorPledge' },
 ] as const;
 

--- a/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.test.tsx
@@ -38,7 +38,6 @@ describe('TalkToMirrorScreen', () => {
     expect(getByText('TALK TO MIRROR')).toBeTruthy();
     expect(getByText('MIRROR ECHO')).toBeTruthy();
     expect(getByText('REFLECTION ROOM')).toBeTruthy();
-    expect(getByText('CODE LIBRARY')).toBeTruthy();
     expect(getByText('MIRROR PLEDGE')).toBeTruthy();
   });
 
@@ -53,7 +52,6 @@ describe('TalkToMirrorScreen', () => {
   it.each([
     ['MIRROR ECHO',     'MirrorEchoVaultHome'],
     ['REFLECTION ROOM', 'ReflectionRoom'],
-    ['CODE LIBRARY',    'MirrorCodeLibrary'],
     ['MIRROR PLEDGE',   'MirrorPledgeIntro'],
   ])('navigates to the correct route when %s is pressed', (label, route) => {
     const { getByText } = render(<TalkToMirrorScreen navigation={mockNavigation} />);

--- a/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.tsx
@@ -8,7 +8,7 @@
  *   2. Oval mirror    — 183×275 elliptical centerpiece (gold rim + gradient fill)
  *   3. Talk button    — bordered pill flanked by 20px stars, gap 16
  *   4. Category row   — horizontal scroll: Mirror Echo / Reflection Room /
- *                       Code Library / Mirror Pledge (100×100 circles + labels)
+ *                       Mirror Pledge (100×100 circles + labels)
  *
  * Outer column (Figma 4326:2301): h-[654px] flex-col items-center
  * justify-between, w-345 — distributes the 4 sections vertically.
@@ -51,7 +51,6 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import OvalMirrorSvg from '@assets/talk-to-mirror/oval-mirror.svg';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import { CachedImage } from '@components/CachedImage';
-import CodeLibraryIcon from '@components/icons/CodeLibraryIcon';
 import MirrorEchoIcon from '@components/icons/MirrorEchoIcon';
 import MirrorPledgeIcon from '@components/icons/MirrorPledgeIcon';
 import ReflectionRoomIcon from '@components/icons/ReflectionRoomIcon';
@@ -73,7 +72,6 @@ const ICON_RING   = moderateScale(100);
 const CATEGORIES = [
   { key: 'mirror-echo',     label: 'ECHO VAULT',     route: 'MirrorEchoVaultHome' as const },
   { key: 'reflection-room', label: 'REFLECTION ROOM', route: 'ReflectionRoomCommingsoon' as const },
-  { key: 'code-library',    label: 'CODE LIBRARY',    route: 'MirrorCodeLibrary' as const },
   { key: 'mirror-pledge',   label: 'MIRROR PLEDGE',   route: 'TheMirrorPledge' as const },
 ];
 
@@ -121,8 +119,6 @@ const TalkToMirrorScreen: React.FC<Props> = ({ navigation }) => {
         return <MirrorEchoIcon size={ICON_RING} />;
       case 'reflection-room':
         return <ReflectionRoomIcon size={ICON_RING} />;
-      case 'code-library':
-        return <CodeLibraryIcon size={ICON_RING} />;
       case 'mirror-pledge':
         return <MirrorPledgeIcon size={ICON_RING} />;
       default:


### PR DESCRIPTION
Removes the Code Library entry from the three user-facing surfaces:
- TalkToMirrorScreen: drop the CODE LIBRARY category tile (+ its icon case and now-unused CodeLibraryIcon import).
- NavigationMenuScreen: drop the Code Library nav row.
- FAQScreen: drop the Code Library Q&A section.

The MirrorCodeLibrary route and its screen/icon are left defined but unlinked, so the feature can be re-enabled without rebuilding it. Updates TalkToMirrorScreen tests to drop the Code Library assertions.