### PR TITLE
fix: welcome screen typo and opaque iOS splash logo

### DIFF
--- a/MirrorCollectiveApp/src/screens/QuizWelcomeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/QuizWelcomeScreen.tsx
@@ -131,7 +131,7 @@ const QuizWelcomeScreen = () => {
               <Text style={styles.regularText}>
                 A few quick reflections to reveal your
               </Text>
-              <Text style={styles.italicHighlight}> starting parttern.</Text>
+              <Text style={styles.italicHighlight}> starting pattern.</Text>
               {'\n\n'}
               <Text style={styles.regularText}>No judgment. No labels. </Text>
               {'\n'}


### PR DESCRIPTION
- QuizWelcomeScreen: "starting parttern" -> "starting pattern".
- iOS launch screen: point AppLogo.imageset at Mirror_Collective_Logo_RGB.png (478x478, RGBA, transparent) instead of mc-logo.png (400x400, RGB, no alpha). The RGB asset rendered as an opaque square — looking like a JPG — and also didn't match the storyboard's declared 478x478 AppLogo size.