### PR TITLE
fix: break circular import in @services/api token refresh

### DIFF
--- a/MirrorCollectiveApp/src/services/api/circularImport.test.ts
+++ b/MirrorCollectiveApp/src/services/api/circularImport.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression: the API layer had a circular import — auth.ts extends
+ * BaseApiService (base.ts), base.ts imports tokenManager, and tokenManager
+ * imported the api barrel back into auth.ts. When base.ts loaded first, auth's
+ * `class AuthApiService extends BaseApiService` evaluated before BaseApiService
+ * was exported → "Super expression must either be null or a function".
+ *
+ * tokenManager now imports authApiService lazily, breaking the load-time edge.
+ * This test loads base.ts first (the order that used to crash) and asserts the
+ * auth module still resolves AuthApiService.
+ */
+describe('API layer circular import', () => {
+  it('resolves AuthApiService when base.ts is loaded before auth.ts', () => {
+    jest.isolateModules(() => {
+      jest.requireActual('@services/api/base');
+      const auth = jest.requireActual('@services/api/auth') as {
+        AuthApiService?: unknown;
+      };
+      expect(auth.AuthApiService).toBeDefined();
+      expect(typeof auth.AuthApiService).toBe('function');
+    });
+  });
+});

--- a/MirrorCollectiveApp/src/services/tokenManager.ts
+++ b/MirrorCollectiveApp/src/services/tokenManager.ts
@@ -1,6 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import { authApiService } from './api';
+// NOTE: authApiService is imported lazily inside performTokenRefresh (not at
+// module load) to break a circular import: auth.ts extends BaseApiService
+// (base.ts), base.ts imports tokenManager, and tokenManager would import the
+// api barrel back into auth.ts — evaluating `class AuthApiService extends
+// BaseApiService` before base.ts finished exporting BaseApiService ("Super
+// expression must either be null or a function"). The refresh call only needs
+// authApiService at runtime, so a deferred import is sufficient and safe.
 
 class TokenManager {
   private refreshPromise: Promise<string | null> | null = null;
@@ -138,6 +144,7 @@ class TokenManager {
         return null;
       }
 
+      const { authApiService } = await import('./api');
       const response = await authApiService.refreshToken();
 
       if (response.success && response.data?.tokens) {


### PR DESCRIPTION
auth.ts extends BaseApiService (base.ts); base.ts imports tokenManager; and tokenManager imported the api barrel back into auth.ts. When base.ts loaded before auth.ts, `class AuthApiService extends BaseApiService` evaluated before BaseApiService was exported → "Super expression must either be null or a function" (e.g. the QuizQuestionsScreen suite crashed on load).

tokenManager only needs authApiService at runtime (in performTokenRefresh), so import it lazily via `await import('./api')` instead of at module load — the same deferred-import pattern already used in MirrorAnimationScreen. This breaks the load-time edge without changing behavior.

Adds a regression test that loads base.ts before auth.ts (the crashing order) and asserts AuthApiService resolves; it fails without this fix.