### PR TITLE
fix: app UI feedback — popup transparency, sticky scroll, gold top-ou…

### DIFF
--- a/MirrorCollectiveApp/App.tsx
+++ b/MirrorCollectiveApp/App.tsx
@@ -2,7 +2,7 @@ import '@i18n'; // Initialize i18n configuration
 import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
 
-import { NavigationContainer } from '@react-navigation/native';
+import { DarkTheme, NavigationContainer, type Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, StatusBar, StyleSheet, View } from 'react-native';
@@ -78,7 +78,7 @@ import VerifyEmailScreen from '@screens/VerifyEmailScreen';
 import { OnboardingService } from '@services';
 import { navigationRef, flushPendingNavigation } from '@services/navigationRef';
 import PushNotificationService from '@services/PushNotificationService';
-import { ThemeProvider } from '@theme';
+import { ThemeProvider, palette } from '@theme';
 import type { RootStackParamList } from '@types';
 
 // DEV-only: button visual QA + blur tuning screen. Loaded lazily so the
@@ -89,6 +89,28 @@ const ButtonShowcaseScreen = __DEV__
 
 import ErrorBoundary from './src/components/ErrorBoundary';
 const Stack = createNativeStackNavigator<RootStackParamList>();
+
+// Dark navigation theme. Without an explicit theme, React Navigation falls back
+// to the LIGHT DefaultTheme (≈white background). On a dark, full-bleed app whose
+// screens paint their own BackgroundWrapper, that light container can flash at
+// the screen's top edge during a native-stack push/pop — a transient pale/tinted
+// outline before the incoming screen's background paints. Anchoring the container
+// (and the per-screen content) to the app's deep navy removes that reveal.
+const navTheme: Theme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    background: palette.navy.deep, // #0b0f1c — deepest app background
+    card: palette.navy.deep,
+  },
+};
+
+// Screens own their full-bleed background, so keep the native-stack content
+// container transparent — nothing but the app's own background ever paints.
+const screenOptions = {
+  headerShown: false,
+  contentStyle: { backgroundColor: 'transparent' },
+} as const;
 // Wrapped MirrorChat component with error boundary
 const MirrorChatWithErrorBoundary = () => (
   <ChatErrorBoundary>
@@ -99,7 +121,7 @@ const MirrorChatWithErrorBoundary = () => (
 const AuthNavigator = () => (
   <Stack.Navigator
     initialRouteName="Splash"
-    screenOptions={{ headerShown: false }}
+    screenOptions={screenOptions}
   >
     <Stack.Screen
       name="ManageGuardianScreen"
@@ -197,7 +219,7 @@ interface AuthenticatedNavigatorProps {
 const AuthenticatedNavigator = ({ initialRouteName = 'EnterMirror' }: AuthenticatedNavigatorProps) => (
   <Stack.Navigator
     initialRouteName={initialRouteName}
-    screenOptions={{ headerShown: false }}
+    screenOptions={screenOptions}
   >
     <Stack.Screen name="EnterMirror" component={EnterMirrorScreen} />
     <Stack.Screen name="AppVideo" component={AppVideoScreen} />
@@ -306,6 +328,7 @@ const AppNavigator = () => {
   return (
     <NavigationContainer
       ref={navigationRef}
+      theme={navTheme}
       key={isAuthenticated ? 'authenticated' : 'unauthenticated'}
       // Replay any notification-tap navigation queued before the tree mounted
       // (cold-start taps land here before the container is ready).

--- a/MirrorCollectiveApp/src/components/BackgroundWrapper.tsx
+++ b/MirrorCollectiveApp/src/components/BackgroundWrapper.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { ImageBackground, StyleSheet, type StyleProp, type ViewStyle, type ImageStyle, TouchableWithoutFeedback, Keyboard, View } from 'react-native';
 
+import { palette } from '@theme';
+
 interface BackgroundWrapperProps {
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
@@ -48,6 +50,10 @@ const BackgroundWrapper: React.FC<BackgroundWrapperProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    // Opaque navy behind the background image so nothing lighter (e.g. the
+    // navigation container) can flash at the edges before the image decodes
+    // during a screen transition. Reinforces the dark navTheme in App.tsx.
+    backgroundColor: palette.navy.deep,
   },
   inner: {
     flex: 1,

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
@@ -117,6 +117,8 @@ export function MirrorChatContent() {
                   keyboardShouldPersistTaps="handled"
                   keyboardDismissMode="on-drag"
                   showsVerticalScrollIndicator={false}
+                  bounces={false}
+                  alwaysBounceVertical={false}
                   onContentSizeChange={() =>
                     scrollViewRef.current?.scrollToEnd({ animated: true })
                   }

--- a/MirrorCollectiveApp/src/screens/echoVault/EchoVaultHomeScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/EchoVaultHomeScreen.tsx
@@ -87,6 +87,8 @@ export function MirrorEchoContent() {
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          bounces={false}
+          alwaysBounceVertical={false}
         >
           {/* Figma 767:2844 — flex-col gap:20 items-center */}
           <View style={styles.content}>
@@ -401,6 +403,10 @@ const styles = StyleSheet.create<{
   infoCard: {
     width:        '100%',
     borderRadius: scale(13),
+    // Solid opaque base so the page behind never bleeds through. The subtle
+    // LinearGradient sheen sits on top of this fill. (#0b0f1c — opaque form of
+    // the modalOverlay scrim rgba(11,15,28,0.92).)
+    backgroundColor: palette.navy.deep,             // #0b0f1c (alpha 1)
     borderWidth:  borderWidth.hairline,             // 0.25px
     borderColor:  palette.navy.light,               // #a3b3cc
     padding:      scale(spacing.xl),                // 24px


### PR DESCRIPTION
…tline

Three reported issues (iPhone 16 Pro Max iOS 26.5 / iPhone 17):

1. "Welcome to Echo Vault" popup showed the page text through it. The infoCard drew only a near-transparent gradient (rgba 0.01->0) with no solid fill, so the page behind the `<Modal transparent>` bled through. Add an opaque backgroundColor (palette.navy.deep) to infoCard; gradient sheen + gold glow kept on top. (EchoVaultHomeScreen)

2. Echo Vault & MirrorGPT pages were "sticky / scrolled for no reason". On iOS ScrollView bounces even when content fits. Set bounces={false} + alwaysBounceVertical={false} on both screens' scrollers so they only scroll on genuine overflow (auto-scroll-to-latest in chat preserved). (EchoVaultHomeScreen, MirrorChatScreen)

3. Gold outline flashing at the top during navigation transitions. The NavigationContainer had no theme, so React Navigation used the light DefaultTheme — a near-white container behind the dark full-bleed screens, revealed at the top edge during the slide. Add a dark navTheme (palette.navy.deep) + a shared screenOptions with transparent contentStyle on both navigators, and an opaque navy backgroundColor behind BackgroundWrapper's image so nothing lighter can flash pre-decode. (App.tsx, BackgroundWrapper)

Visual-only changes; tests + lint green (no new lint).