### PR TITLE
fix: onboarding quiz UI glitches on iPhone 17 (text shift + glow clip)

### DIFF
--- a/MirrorCollectiveApp/src/components/OptionsButton.tsx
+++ b/MirrorCollectiveApp/src/components/OptionsButton.tsx
@@ -115,9 +115,12 @@ const styles = StyleSheet.create({
     borderColor:      palette.navy.border,  // #808fb2 (border/bold)
     overflow:         'hidden',
   },
-  // Frame 248 overrides — wider horizontal padding + lighter border.
+  // Frame 248 override — lighter border on select. NOTE: Figma also widens
+  // horizontal padding 8->16 on select, but with width:'100%' that shrinks the
+  // text's content box and re-wraps the label, making the card visibly
+  // shift/resize when tapped (reported on iPhone 17). Keep padding constant
+  // across states so selecting only changes the border + glow, never layout.
   buttonSelected: {
-    paddingHorizontal: scale(16),
     borderColor:       palette.navy.light,  // #a3b3cc (border/subtle)
   },
 

--- a/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/QuizQuestionsScreen.tsx
@@ -415,7 +415,7 @@ const styles = StyleSheet.create({
     alignSelf:         'center',
     textAlign:         'center',
     marginTop:         verticalScale(60),    // Figma 60px gap from progress bar
-    marginBottom:      verticalScale(44),    // 44 + scrollContent paddingTop:16 = 60 (Figma gap to first option)
+    marginBottom:      verticalScale(28),    // 28 + scrollContent paddingTop:32 = 60 (Figma gap to first option)
     textShadowColor:   textShadow.glow.color,
     textShadowOffset:  textShadow.glow.offset,
     textShadowRadius:  textShadow.glow.radius,
@@ -435,7 +435,11 @@ const styles = StyleSheet.create({
   scrollContent: {
     flexGrow:      1,
     alignItems:    'center',
-    paddingTop:    verticalScale(16),
+    // 32 gives the selected image-option halo (~28px beyond the 120px circle)
+    // room above the first row — the ScrollView viewport clips anything above
+    // its top edge, so 16 was cropping the top row's glow on iPhone 17.
+    // The question's marginBottom (28) is reduced to keep the 60px Figma gap.
+    paddingTop:    verticalScale(32),
     paddingBottom: verticalScale(60),
   },
 


### PR DESCRIPTION
Two reported issues on the onboarding quiz:

1. Selecting a text answer shifted/resized the card. OptionsButton.buttonSelected widened paddingHorizontal 8->16 on select; with width:'100%' that shrank the label's content box and re-wrapped the text, visibly reflowing the card. Keep horizontal padding constant across states — selection now only changes the border color + glow, never layout.

2. The selected image-option halo was clipped along the top. The glow extends ~28px beyond the 120px circle, but scrollContent.paddingTop was 16px and the ScrollView viewport clips anything above its top edge, cropping the top row's glow. Bump paddingTop 16->32 (covers the halo) and reduce the question's marginBottom 44->28 so the Figma 60px question-to-options gap is unchanged.

Visual-only style changes; no logic touched.