### PR TITLE
feat(soul-ping): report ping as seen on open (mark-read wiring)

### DIFF
--- a/MirrorCollectiveApp/src/constants/config/config.ts
+++ b/MirrorCollectiveApp/src/constants/config/config.ts
@@ -49,6 +49,11 @@ export const API_CONFIG = {
       ROOM_OVERRIDE: '/api/me/reflection/room',
       TELEMETRY_EVENT: '/api/telemetry/event',
     },
+    SOUL_PING: {
+      // Report a ping as seen/opened so the backend sends a re-engagement
+      // message next time instead of duplicating the same notification.
+      MARK_READ: '/api/soul-pings/{ping_id}/read',
+    },
   },
   TIMEOUT: 10000,
 };

--- a/MirrorCollectiveApp/src/screens/SoulPingScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/SoulPingScreen.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import SoulPingScreen from './SoulPingScreen';
+
+const mockMarkRead = jest.fn().mockResolvedValue({ success: true });
+jest.mock('@services/api', () => ({
+  soulPingApiService: {
+    markRead: (...args: unknown[]) => mockMarkRead(...args),
+  },
+}));
+
+let mockParams: Record<string, unknown> = {};
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+    useRoute: () => ({ params: mockParams }),
+  };
+});
+
+jest.mock('@components/LogoHeader', () => 'LogoHeader');
+jest.mock('@components/BackgroundWrapper', () => 'BackgroundWrapper');
+jest.mock('@components/Button', () => 'Button');
+
+describe('SoulPingScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockParams = {};
+  });
+
+  it('reports the ping as seen on mount when a pingId is present', () => {
+    mockParams = { pingId: 'ping-1', category: 'emotional', title: 'Hi', body: 'x' };
+
+    render(<SoulPingScreen />);
+
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
+    expect(mockMarkRead).toHaveBeenCalledWith('ping-1');
+  });
+
+  it('does not report when there is no pingId', () => {
+    mockParams = { category: 'emotional', title: 'Hi', body: 'x' };
+
+    render(<SoulPingScreen />);
+
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('renders the ping copy from params', () => {
+    mockParams = { pingId: 'p1', title: 'A pattern', body: 'You keep circling stress.' };
+
+    const { getByText } = render(<SoulPingScreen />);
+
+    expect(getByText('A pattern')).toBeTruthy();
+    expect(getByText('You keep circling stress.')).toBeTruthy();
+  });
+});

--- a/MirrorCollectiveApp/src/screens/SoulPingScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/SoulPingScreen.tsx
@@ -8,6 +8,13 @@
  * docs/SOUL_PINGS_PRD.md (Phase 2/3).
  */
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import BackgroundWrapper from '@components/BackgroundWrapper';
+import Button from '@components/Button';
+import LogoHeader from '@components/LogoHeader';
+import { soulPingApiService } from '@services/api';
 import {
   palette,
   spacing,
@@ -20,12 +27,6 @@ import {
   moderateScale,
 } from '@theme';
 import type { RootStackParamList } from '@types';
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-
-import BackgroundWrapper from '@components/BackgroundWrapper';
-import Button from '@components/Button';
-import LogoHeader from '@components/LogoHeader';
 
 const CATEGORY_LABEL: Record<string, string> = {
   emotional: 'A gentle check-in',
@@ -36,7 +37,18 @@ const CATEGORY_LABEL: Record<string, string> = {
 const SoulPingScreen: React.FC = () => {
   const navigation = useNavigation();
   const route = useRoute<RouteProp<RootStackParamList, 'SoulPing'>>();
-  const { category, title, body } = route.params ?? {};
+  const { pingId, category, title, body } = route.params ?? {};
+
+  // Viewing this screen is the truest "seen" signal — it's reached from every
+  // push entry point (background tap, cold start). Report it once, best-effort:
+  // never block or surface errors, since it's pure telemetry that shapes the
+  // next scheduled ping.
+  const markedRef = useRef(false);
+  useEffect(() => {
+    if (!pingId || markedRef.current) return;
+    markedRef.current = true;
+    soulPingApiService.markRead(pingId).catch(() => {});
+  }, [pingId]);
 
   const eyebrow =
     (category && CATEGORY_LABEL[category]) || 'A message from your Mirror';

--- a/MirrorCollectiveApp/src/services/api/index.ts
+++ b/MirrorCollectiveApp/src/services/api/index.ts
@@ -5,3 +5,4 @@ export * from './quiz';
 export * from './session';
 export * from './echo';
 export * from './user';
+export * from './soulPing';

--- a/MirrorCollectiveApp/src/services/api/soulPing.test.ts
+++ b/MirrorCollectiveApp/src/services/api/soulPing.test.ts
@@ -1,0 +1,61 @@
+import { SoulPingApiService } from './soulPing';
+
+global.fetch = jest.fn();
+
+jest.mock('@services/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('test-token'),
+    getAuthHeaders: jest.fn().mockResolvedValue({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+    }),
+  },
+}));
+
+describe('SoulPingApiService', () => {
+  let service: SoulPingApiService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SoulPingApiService();
+  });
+
+  it('POSTs to the mark-read endpoint with the ping id', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true, ping_id: 'ping-123' }),
+    });
+
+    const result = await service.markRead('ping-123');
+
+    expect(global.fetch).toHaveBeenCalled();
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(url)).toContain('/api/soul-pings/ping-123/read');
+    expect(init.method).toBe('POST');
+    expect(result.success).toBe(true);
+  });
+
+  it('encodes the ping id in the path', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    await service.markRead('a/b');
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(url)).toContain('/api/soul-pings/a%2Fb/read');
+  });
+
+  it('sends an authenticated request', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    await service.markRead('ping-123');
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer test-token');
+  });
+});

--- a/MirrorCollectiveApp/src/services/api/soulPing.ts
+++ b/MirrorCollectiveApp/src/services/api/soulPing.ts
@@ -1,0 +1,35 @@
+import { API_CONFIG } from '@constants/config';
+import type { ApiResponse } from '@types';
+
+import { BaseApiService } from './base';
+
+export interface MarkSoulPingReadResponse {
+  success: boolean;
+  ping_id: string;
+}
+
+/**
+ * Soul Ping API — reports engagement with proactive notifications.
+ *
+ * The backend uses "seen" state to decide the next scheduled ping: a fresh
+ * content nudge, a different re-engagement message, or skip — so the user
+ * stops getting duplicate notifications for a conversation they've already
+ * been nudged about. See the API's soul_ping_service.
+ */
+export class SoulPingApiService extends BaseApiService {
+  /**
+   * Mark a Soul Ping as seen/opened. Best-effort — callers should not block
+   * UI on the result. `pingId` comes from the push `data` payload.
+   */
+  async markRead(
+    pingId: string,
+  ): Promise<ApiResponse<MarkSoulPingReadResponse>> {
+    const endpoint = API_CONFIG.ENDPOINTS.SOUL_PING.MARK_READ.replace(
+      '{ping_id}',
+      encodeURIComponent(pingId),
+    );
+    return this.post<MarkSoulPingReadResponse>(endpoint, undefined, true);
+  }
+}
+
+export const soulPingApiService = new SoulPingApiService();


### PR DESCRIPTION
Wire the client side of the Soul Ping 'seen' tracking the API added.

- soulPing.ts: SoulPingApiService.markRead(pingId) → POST /api/soul-pings/{id}/read (path-encoded, authenticated), exported from services/api.
- config: SOUL_PING.MARK_READ endpoint.
- SoulPingScreen: on mount (the truest 'seen' signal — reached from every push entry point), fire-and-forget markRead(pingId); best-effort, never blocks UI. pingId already arrives via nav params from the push data payload.

This lets the backend send a re-engagement message next time instead of duplicating the same notification. Tests: service (URL/encode/auth) + screen (marks on mount with pingId, skips without).