### PR TITLE
fix(ios): remove square border on launch-screen logo

### DIFF
--- a/MirrorCollectiveApp/ios/MirrorCollectiveApp/Images.xcassets/AppLogo.imageset/Contents.json
+++ b/MirrorCollectiveApp/ios/MirrorCollectiveApp/Images.xcassets/AppLogo.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "idiom" : "universal",
-      "filename" : "mc-logo.png",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "filename" : "mirror-collective-logo-circle.png"
     }
   ],
   "info" : {


### PR DESCRIPTION
The native iOS launch screen (LaunchScreen.storyboard, shown on first install / cold start before JS loads) rendered AppLogo from an opaque 400x400 PNG (mc-logo.png, hasAlpha: no) with a flat dark-navy square baked in. Over the gradient starfield AppBackground, the square's edges showed as a visible border around the logo.

Point AppLogo.imageset at mirror-collective-logo-circle.png — the same gold circular mark with a transparent background — so the starfield shows through and there's no square. Matches the in-app JS splash (CircularLogoMark).