### PR TITLE
fix: wire up Terms of Service and Privacy links

### DIFF
--- a/MirrorCollectiveApp/src/constants/config/config.ts
+++ b/MirrorCollectiveApp/src/constants/config/config.ts
@@ -74,6 +74,15 @@ export const REFLECTION_ROOM_ENABLED =
 export const REFLECTION_ROOM_USE_MOCK =
   String(process.env.REFLECTION_ROOM_USE_MOCK ?? 'true').toLowerCase() !== 'false';
 
+/**
+ * Public legal pages, opened in the device browser via Linking.openURL.
+ * Hosted on the marketing site.
+ */
+export const LEGAL_LINKS = {
+  TERMS: 'https://www.themirrorcollective.com/termsandconditions',
+  PRIVACY: 'https://www.themirrorcollective.com/privacy',
+} as const;
+
 export const APP_CONFIG = {
   CHAT: {
     MAX_MESSAGE_LENGTH: 1000,

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
@@ -26,6 +26,7 @@ import {
     Image,
     Alert,
     ScrollView,
+    Linking,
     type ViewStyle,
     type TextStyle,
     type ImageStyle,
@@ -37,6 +38,7 @@ import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
 import StarIcon from '@components/StarIcon';
+import { LEGAL_LINKS } from '@constants/config';
 
 import { useSession } from '@/context/SessionContext';
 import { useSubscription } from '@/context/SubscriptionContext';
@@ -96,6 +98,14 @@ const StartFreeTrialScreen = () => {
             } catch (error: any) {
                 Alert.alert('Purchase Failed', error.message || 'Unable to complete purchase');
             }
+        }
+    };
+
+    const openLink = async (url: string) => {
+        try {
+            await Linking.openURL(url);
+        } catch {
+            Alert.alert('Unable to open link', 'Please try again later.');
         }
     };
 
@@ -260,9 +270,19 @@ const StartFreeTrialScreen = () => {
 
           {/* ── Footer ───────────────────────────────────────────────── */}
           <View style={styles.footerLinksRow}>
-            <Text style={styles.footerLinkText}>Terms</Text>
+            <TouchableOpacity
+              accessibilityRole="link"
+              onPress={() => openLink(LEGAL_LINKS.TERMS)}
+            >
+              <Text style={styles.footerLinkText}>Terms</Text>
+            </TouchableOpacity>
             <Text style={styles.footerLinkText}>•</Text>
-            <Text style={styles.footerLinkText}>Privacy</Text>
+            <TouchableOpacity
+              accessibilityRole="link"
+              onPress={() => openLink(LEGAL_LINKS.PRIVACY)}
+            >
+              <Text style={styles.footerLinkText}>Privacy</Text>
+            </TouchableOpacity>
             <Text style={styles.footerLinkText}>•</Text>
             <Text style={styles.footerLinkText}>Restore Purchase</Text>
           </View>

--- a/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Linking } from 'react-native';
+
+import { LEGAL_LINKS } from '@constants/config';
+
+import TermsAndConditionsScreen from './TermsAndConditionsScreen';
+
+// Stub context-heavy children so the screen renders in isolation.
+jest.mock('@components/LogoHeader', () => 'LogoHeader');
+jest.mock('@components/BackgroundWrapper', () => {
+  const react = require('react');
+  return ({ children }: { children: React.ReactNode }) =>
+    react.createElement('BackgroundWrapper', null, children);
+});
+jest.mock('@context/SessionContext', () => ({
+  useSession: () => ({ signUp: jest.fn() }),
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+  useRoute: () => ({
+    params: {
+      fullName: 'Ada Lovelace',
+      email: 'ada@example.com',
+      password: 'secret123',
+      phoneNumber: '',
+    },
+  }),
+}));
+
+describe('TermsAndConditionsScreen legal links', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('opens the Terms of Service URL when the Terms link is tapped', () => {
+    const { getByText } = render(<TermsAndConditionsScreen />);
+
+    fireEvent.press(getByText('• Terms of Service'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(LEGAL_LINKS.TERMS);
+  });
+
+  it('opens the Privacy Policy URL when the Privacy link is tapped', () => {
+    const { getByText } = render(<TermsAndConditionsScreen />);
+
+    fireEvent.press(getByText('• Privacy Policy'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(LEGAL_LINKS.PRIVACY);
+  });
+
+  it('points the legal links at the marketing site', () => {
+    expect(LEGAL_LINKS.TERMS).toBe(
+      'https://www.themirrorcollective.com/termsandconditions',
+    );
+    expect(LEGAL_LINKS.PRIVACY).toBe(
+      'https://www.themirrorcollective.com/privacy',
+    );
+  });
+});

--- a/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.tsx
@@ -15,6 +15,7 @@ import {
   modalColors,
 } from '@theme';
 import type { RootStackParamList } from '@types';
+import { LEGAL_LINKS } from '@constants/config';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -25,6 +26,7 @@ import {
     TouchableOpacity,
     Image,
     ScrollView,
+    Linking,
     type ViewStyle,
     type TextStyle,
     type ImageStyle,
@@ -50,6 +52,14 @@ const TermsAndConditionsScreen = () => {
     const { t } = useTranslation();
     const [agreed, setAgreed] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+
+    const openLink = async (url: string) => {
+        try {
+            await Linking.openURL(url);
+        } catch {
+            Alert.alert('Unable to open link', 'Please try again later.');
+        }
+    };
 
     return (
       <BackgroundWrapper
@@ -185,8 +195,22 @@ const TermsAndConditionsScreen = () => {
                   <Text style={styles.cardBody}>
                     You can review our full policies here:
                   </Text>
-                  <Text style={styles.cardBody}>• Terms of Service</Text>
-                  <Text style={styles.cardBody}>• Privacy Policy</Text>
+                  <TouchableOpacity
+                    accessibilityRole="link"
+                    onPress={() => openLink(LEGAL_LINKS.TERMS)}
+                  >
+                    <Text style={[styles.cardBody, styles.cardLink]}>
+                      • Terms of Service
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    accessibilityRole="link"
+                    onPress={() => openLink(LEGAL_LINKS.PRIVACY)}
+                  >
+                    <Text style={[styles.cardBody, styles.cardLink]}>
+                      • Privacy Policy
+                    </Text>
+                  </TouchableOpacity>
                   <Text style={styles.cardBody}>
                     • AI Transparency &amp; Use Policy
                   </Text>
@@ -323,6 +347,7 @@ const styles = StyleSheet.create<{
   cardHeading: TextStyle;
   cardEmphasis: TextStyle;
   cardBody: TextStyle;
+  cardLink: TextStyle;
   footer: ViewStyle;
   checkboxRow: ViewStyle;
   checkboxBox: ViewStyle;
@@ -459,6 +484,10 @@ const styles = StyleSheet.create<{
     lineHeight: moderateScale(fontSize.s) * 1.5,
     color: palette.gold.subtlest,
     textAlign: 'center',
+  },
+  cardLink: {
+    color: palette.gold.warm,
+    textDecorationLine: 'underline',
   },
 
   // ── Footer ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
The footer 'Terms'/'Privacy' on StartFreeTrialScreen and the 'Terms of Service'/'Privacy Policy' entries on the sign-up consent screen (TermsAndConditionsScreen) were plain Text with no handler, so tapping them did nothing.

Wrap them in TouchableOpacity that opens the public policy pages via Linking.openURL, with URLs centralized in a new LEGAL_LINKS constant:
- Terms:   https://www.themirrorcollective.com/termsandconditions
- Privacy: https://www.themirrorcollective.com/privacy

The consent-screen entries are also styled as underlined links so they read as tappable. Adds TermsAndConditionsScreen.test.tsx covering both link taps and the URL values.