### PR TITLE
feat(chat): animated MirrorGPT typing indicator

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/mirrorgpt-typing-indicator.md
+++ b/MirrorCollectiveApp/docs/visual-qa/mirrorgpt-typing-indicator.md
@@ -1,0 +1,45 @@
+# Visual QA — MirrorGPT Typing Indicator ("MirrorGPT Processing")
+
+**Figma:** Dev-Master-File → node `7811-2866` (`?node-id=7811-2866`)
+**Component:** `src/components/ui/TypingIndicator/TypingIndicator.tsx`
+**Used by:** `src/screens/MirrorChatScreen.tsx` (rendered while `loading` is true)
+
+## Summary
+
+The design ("MirrorGPT Processing") is the chat screen while a reply is being
+generated. The only delta vs. the normal chat screen is the **`· · ·` typing
+bubble** that appears left-aligned above the input, in place of the previous
+centered `…thinking…` text (`LoadingIndicator`).
+
+`TypingIndicator` renders that bubble and **animates** the three dots: each dot
+pulses opacity `0.3 → 1 → 0.3` (with a subtle `0.8 → 1` scale), staggered by
+160ms so the row shimmers left-to-right in a continuous loop. The loop is built
+from recursive `Animated.timing().start()` calls (native driver) rather than
+`Animated.loop`, which keeps it driving cleanly under the hand-rolled RN test
+mock. The OS **"reduce motion"** setting is honoured — when enabled the dots
+render static at 0.7 opacity instead of animating.
+
+## Tokens
+
+The bubble mirrors `MessageBubble`'s assistant `systemBubble` so it reads as an
+incoming message, matching the design:
+
+| Property | Value | Source |
+|---|---|---|
+| Corner radius | `radius.s` = 12 | Figma `Radius/S` = 12 |
+| Border | 1px `rgba(155,170,194,0.5)` | matches `systemBubble` (Figma `Border/Subtle` #a3b3cc family) |
+| Background | `rgba(253,253,249,0.05)` | matches `systemBubble` |
+| Dot color | `palette.gold.DEFAULT` #f2e2b1 | Figma `Text/Paragraph-1` #f2e1b0 |
+| Shadow | `shadows.MEDIUM` | matches `systemBubble` |
+
+**Token gaps:** the dot geometry (6px circle, 6px gap) and the animation
+timing (500ms pulse, 160ms stagger, 0.3 min opacity) are not Figma variables —
+they're implementation values for a functional micro-animation the static design
+can't encode.
+
+## Notes / deviations
+
+- Replaces the old centered `LoadingIndicator` ("…thinking…") in the chat. The
+  `LoadingIndicator` component itself is left in place (still exported) as a
+  generic utility; it is no longer used by the chat screen.
+- Reference render: Figma node `7811-2866` (screenshot attached to the PR).

--- a/MirrorCollectiveApp/src/components/ui/TypingIndicator/TypingIndicator.test.tsx
+++ b/MirrorCollectiveApp/src/components/ui/TypingIndicator/TypingIndicator.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { TypingIndicator } from './TypingIndicator';
+
+describe('TypingIndicator', () => {
+  it('renders the typing bubble with three dots', () => {
+    const { getByTestId } = render(<TypingIndicator />);
+
+    expect(getByTestId('typing-indicator')).toBeTruthy();
+    expect(getByTestId('typing-dot-0')).toBeTruthy();
+    expect(getByTestId('typing-dot-1')).toBeTruthy();
+    expect(getByTestId('typing-dot-2')).toBeTruthy();
+  });
+
+  it('exposes an accessible label for screen readers', () => {
+    const { getByLabelText } = render(<TypingIndicator />);
+
+    expect(getByLabelText('MirrorGPT is thinking')).toBeTruthy();
+  });
+});

--- a/MirrorCollectiveApp/src/components/ui/TypingIndicator/TypingIndicator.tsx
+++ b/MirrorCollectiveApp/src/components/ui/TypingIndicator/TypingIndicator.tsx
@@ -1,0 +1,139 @@
+import { spacing, radius, shadows, palette } from '@theme';
+import React, { useEffect, useRef } from 'react';
+import { View, StyleSheet, Animated, AccessibilityInfo } from 'react-native';
+
+/**
+ * MirrorGPT "processing" typing indicator — the left-aligned `· · ·` bubble
+ * shown while a reply streams in (Figma Dev-Master-File node 7811-2866).
+ *
+ * The bubble mirrors the assistant MessageBubble (systemBubble) styling; the
+ * three gold dots pulse in a staggered loop so the wait feels alive. The loop
+ * is built from recursive `Animated.timing().start()` calls (rather than
+ * `Animated.loop`/`sequence`) so it drives cleanly under the hand-rolled RN
+ * test mock and honours the OS "reduce motion" setting.
+ */
+const DOT_COUNT = 3;
+const MIN_OPACITY = 0.3;
+const MAX_OPACITY = 1;
+const PULSE_MS = 500;
+const STAGGER_MS = 160;
+
+export const TypingIndicator: React.FC = () => {
+  const dots = useRef(
+    Array.from({ length: DOT_COUNT }, () => new Animated.Value(MIN_OPACITY)),
+  ).current;
+
+  useEffect(() => {
+    let mounted = true;
+
+    const pulse = (dot: Animated.Value, delay: number) => {
+      Animated.timing(dot, {
+        toValue: MAX_OPACITY,
+        duration: PULSE_MS,
+        delay,
+        useNativeDriver: true,
+      }).start(() => {
+        if (!mounted) return;
+        Animated.timing(dot, {
+          toValue: MIN_OPACITY,
+          duration: PULSE_MS,
+          useNativeDriver: true,
+        }).start(() => {
+          if (mounted) pulse(dot, 0);
+        });
+      });
+    };
+
+    const startAll = () => dots.forEach((dot, i) => pulse(dot, i * STAGGER_MS));
+
+    // Respect the OS "reduce motion" setting when the API is available;
+    // otherwise (older RN / test mock) just animate.
+    const reduceCheck = AccessibilityInfo?.isReduceMotionEnabled?.();
+    if (reduceCheck && typeof reduceCheck.then === 'function') {
+      reduceCheck
+        .then(reduce => {
+          if (!mounted) return;
+          if (reduce) {
+            dots.forEach(dot => dot.setValue(0.7));
+          } else {
+            startAll();
+          }
+        })
+        .catch(() => {
+          if (mounted) startAll();
+        });
+    } else {
+      startAll();
+    }
+
+    return () => {
+      mounted = false;
+      dots.forEach(dot => dot.stopAnimation?.());
+    };
+  }, [dots]);
+
+  return (
+    <View style={styles.row}>
+      <View
+        style={styles.bubble}
+        testID="typing-indicator"
+        accessibilityRole="text"
+        accessibilityLabel="MirrorGPT is thinking"
+      >
+        {dots.map((dot, i) => (
+          <Animated.View
+            key={i}
+            testID={`typing-dot-${i}`}
+            style={[
+              styles.dot,
+              i > 0 && styles.dotGap,
+              {
+                opacity: dot,
+                transform: [
+                  {
+                    scale: dot.interpolate({
+                      inputRange: [MIN_OPACITY, MAX_OPACITY],
+                      outputRange: [0.8, 1],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  // Full-width row so the bubble left-aligns like an incoming message.
+  row: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    marginVertical: spacing.xxs,
+  },
+  // Mirrors MessageBubble's systemBubble so it reads as an assistant bubble.
+  bubble: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 14,
+    paddingVertical: spacing.s,
+    paddingHorizontal: spacing.m,
+    borderRadius: radius.s,
+    borderWidth: 1,
+    borderColor: 'rgba(155, 170, 194, 0.5)',
+    backgroundColor: 'rgba(253, 253, 249, 0.05)',
+    ...shadows.MEDIUM,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: palette.gold.DEFAULT,
+  },
+  dotGap: {
+    marginLeft: 6,
+  },
+});

--- a/MirrorCollectiveApp/src/components/ui/TypingIndicator/index.ts
+++ b/MirrorCollectiveApp/src/components/ui/TypingIndicator/index.ts
@@ -1,0 +1,1 @@
+export * from './TypingIndicator';

--- a/MirrorCollectiveApp/src/components/ui/index.ts
+++ b/MirrorCollectiveApp/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 export * from './MessageBubble';
 export * from './ChatInput';
 export * from './LoadingIndicator';
+export * from './TypingIndicator';

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.test.tsx
@@ -48,7 +48,7 @@ jest.mock('@components/ui', () => {
         </View>
       );
     },
-    LoadingIndicator: () => <View testID="loading-indicator" />,
+    TypingIndicator: () => <View testID="typing-indicator" />,
   };
 });
 
@@ -125,7 +125,7 @@ describe('MirrorChatScreen', () => {
     });
 
     const { getByTestId } = render(<MirrorChatContent />);
-    expect(getByTestId('loading-indicator')).toBeTruthy();
+    expect(getByTestId('typing-indicator')).toBeTruthy();
   });
 
   it('disables input when loading', () => {

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
@@ -17,7 +17,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import AuthenticatedRoute from '@components/AuthenticatedRoute';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import LogoHeader from '@components/LogoHeader';
-import { MessageBubble, ChatInput, LoadingIndicator } from '@components/ui';
+import { MessageBubble, ChatInput, TypingIndicator } from '@components/ui';
 import { useChat } from '@hooks/useChat';
 import {
   TTS_FEATURE_ENABLED,
@@ -139,7 +139,7 @@ export function MirrorChatContent() {
                   {messages.map(message => (
                     <MessageBubble key={message.id} message={message} />
                   ))}
-                  {loading && <LoadingIndicator />}
+                  {loading && <TypingIndicator />}
                 </ScrollView>
 
                 <ChatInput


### PR DESCRIPTION
Replace the centered '…thinking…' text shown while a MirrorGPT reply is generated with the 'MirrorGPT Processing' design (Figma 7811-2866): a left-aligned bubble with three gold dots that pulse in a staggered loop.

- New TypingIndicator component styled to match the assistant MessageBubble (systemBubble): 12px radius, subtle border, translucent fill, gold dots.
- Dots animate opacity 0.3->1 (+ subtle scale), staggered 160ms, looped via recursive Animated.timing().start() (native driver); honours reduce-motion.
- MirrorChatScreen renders <TypingIndicator/> in place of <LoadingIndicator/>.
- Tests for the component + updated chat test; visual-QA report.