### PR TITLE
feat(echo): disclose that an unset lock date sends immediately

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/echo-lock-date-disclaimer.md
+++ b/MirrorCollectiveApp/docs/visual-qa/echo-lock-date-disclaimer.md
@@ -1,0 +1,41 @@
+# Visual QA — Echo Lock Date "sends immediately" disclaimer
+
+**Figma:** Dev-Master-File → node `7820-2208` ("CHOOSE YOUR RECIPIENT")
+**Screen:** `src/screens/echoVault/ChooseRecipientScreen.tsx`
+
+## Problem
+
+When creating an echo, leaving the Lock Date empty makes the backend deliver
+the echo **immediately** (the auto-release rule: recipient set + no lock date →
+send now, enforced in `CreateEchoScreen.tsx` and mirrored server-side). Nothing
+in the UI told the user this, so an unset lock date could send a draft the user
+still considered a work-in-progress.
+
+## Change (matches node 7820-2208)
+
+- Added an italic-gold caption directly under the Lock Date field:
+  **"(echo is sent immediately if lock date is not set)"**.
+- Simplified the field label from "Lock Date (only if required)" to **"Lock Date"**
+  — the new caption now carries the optionality/behaviour, matching the design.
+
+No behavioural change — this is disclosure of existing behaviour at the point of
+decision (the single screen where the lock date is chosen for both the wizard
+and the unified compose flow).
+
+## Tokens
+
+| Property | Value | Source |
+|---|---|---|
+| Caption font | `fontFamily.bodyItalic` (Inter Italic) | Figma `Body XS Italic` |
+| Caption size / line-height | `fontSize.xs` 14 / `lineHeight.s` 20 | Figma `font/size/XS`, `font/line-height/S` |
+| Caption color | `palette.gold.DEFAULT` #f2e2b1 | Figma `Text/Paragraph-1` #f2e1b0 |
+
+No token gaps.
+
+## Notes
+
+- The deeper "let the user review/confirm the final version" concern is broader
+  than this microcopy; the design (7820-2208) scopes the fix to disclosure. A
+  dedicated confirm/review step before an immediate send would be a separate
+  change if desired.
+- Reference render: Figma node `7820-2208` (screenshot attached to the PR).

--- a/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import ChooseRecipientScreen from './ChooseRecipientScreen';
+
+jest.mock('@components/LogoHeader', () => 'LogoHeader');
+jest.mock('@components/BackgroundWrapper', () => {
+  const react = require('react');
+  return ({ children }: { children: React.ReactNode }) =>
+    react.createElement('BackgroundWrapper', null, children);
+});
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+jest.mock('react-native-keyboard-controller', () => ({
+  KeyboardAwareScrollView: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+jest.mock('@services/api/echo', () => ({
+  echoApiService: {
+    getRecipients: jest.fn().mockResolvedValue({ success: true, data: [] }),
+  },
+}));
+
+const nav = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  addListener: jest.fn(() => jest.fn()),
+};
+
+describe('ChooseRecipientScreen', () => {
+  it('warns that an unset lock date sends the echo immediately', () => {
+    const { getByText } = render(
+      <ChooseRecipientScreen
+        navigation={nav as never}
+        route={{ params: {} } as never}
+      />,
+    );
+
+    expect(
+      getByText('(echo is sent immediately if lock date is not set)'),
+    ).toBeTruthy();
+  });
+});

--- a/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
@@ -350,7 +350,7 @@ const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
                 >
                   <View pointerEvents="none">
                     <TextInputField
-                      label="Lock Date (only if required)"
+                      label="Lock Date"
                       placeholder="When do you want to open it?"
                       placeholderAlign="left"
                       value={lockDate ? formatDate(lockDate) : ''}
@@ -366,6 +366,12 @@ const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
                   />
                 </View>
               </View>
+
+              {/* Sending rule — surfaced so users know an unset lock date
+                  means the echo is delivered right away (Figma 7820-2208). */}
+              <Text style={styles.lockDateHint}>
+                (echo is sent immediately if lock date is not set)
+              </Text>
 
               {/* Android: native self-dismissing dialog. */}
               {Platform.OS === 'android' && showDatePicker && (
@@ -459,6 +465,7 @@ const styles = StyleSheet.create<{
   // Field groups
   fieldGroup: ViewStyle;
   fieldLabel: TextStyle;
+  lockDateHint: TextStyle;
   fieldWithIcon: ViewStyle;
   fieldTouchable: ViewStyle;
   fieldIcon: ViewStyle;
@@ -531,6 +538,16 @@ const styles = StyleSheet.create<{
 
   // ── Field groups ────────────────────────────────────────────────────────────
   fieldGroup: { gap: verticalScale(spacing.xs) },
+
+  // Sending-rule caption under the Lock Date field — Body XS Italic, gold
+  // (Figma Text/Paragraph-1 #f2e1b0), matching node 7820-2208.
+  lockDateHint: {
+    fontFamily: fontFamily.bodyItalic,
+    fontStyle: 'italic',
+    fontSize: moderateScale(fontSize.xs),
+    lineHeight: lineHeight.s,
+    color: palette.gold.DEFAULT,
+  },
 
   fieldLabel: {
     // Mirror the TextInputField label so the Recipient and Lock Date labels


### PR DESCRIPTION
Creating an echo with a recipient and no lock date triggers the auto-release rule (deliver now), but the UI never told the user — so a still-in-progress echo could be sent without a clear heads-up.

Add the italic-gold caption '(echo is sent immediately if lock date is not set)' under the Lock Date field on ChooseRecipientScreen, and simplify the label to 'Lock Date' (the caption now carries the meaning). Matches Figma 7820-2208. Disclosure only — no behavioural change.

Adds ChooseRecipientScreen.test.tsx asserting the disclaimer renders.