### PR TITLE
fix(echo): add keyboard 'Done' bar so compose isn't a keyboard trap

### DIFF
--- a/MirrorCollectiveApp/src/__tests__/jest.setup.js
+++ b/MirrorCollectiveApp/src/__tests__/jest.setup.js
@@ -232,6 +232,7 @@ jest.mock('react-native-keyboard-controller', () => ({
   KeyboardProvider: ({ children }) => children,
   KeyboardAvoidingView: 'KeyboardAvoidingView',
   KeyboardAwareScrollView: 'KeyboardAwareScrollView',
+  KeyboardToolbar: 'KeyboardToolbar',
   KeyboardController: {
     dismiss: jest.fn(),
     setFocusTo: jest.fn(),

--- a/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Keyboard } from 'react-native';
+
+import CreateEchoScreen from './CreateEchoScreen';
+
+jest.mock('@components/LogoHeader', () => 'LogoHeader');
+jest.mock('@components/BackgroundWrapper', () => {
+  const react = require('react');
+  return ({ children }: { children: React.ReactNode }) =>
+    react.createElement('BackgroundWrapper', null, children);
+});
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
+  useRoute: () => ({ params: {} }),
+}));
+jest.mock('react-native-image-picker', () => ({
+  launchCamera: jest.fn(),
+  launchImageLibrary: jest.fn(),
+}));
+jest.mock('react-native-audio-recorder-player', () => ({
+  __esModule: true,
+  default: {
+    startRecorder: jest.fn(() => Promise.resolve('file:///rec.m4a')),
+    stopRecorder: jest.fn(() => Promise.resolve()),
+    startPlayer: jest.fn(() => Promise.resolve()),
+    stopPlayer: jest.fn(() => Promise.resolve()),
+    addRecordBackListener: jest.fn(),
+    removeRecordBackListener: jest.fn(),
+    addPlaybackEndListener: jest.fn(),
+    removePlaybackEndListener: jest.fn(),
+    setSubscriptionDuration: jest.fn(),
+  },
+}));
+jest.mock('@services/api/echo', () => ({
+  echoApiService: {
+    getEcho: jest.fn(),
+    createEcho: jest.fn(),
+    updateEcho: jest.fn(),
+    uploadEchoAttachment: jest.fn(),
+    releaseEcho: jest.fn(),
+    removeAttachment: jest.fn(),
+  },
+}));
+
+describe('CreateEchoScreen — keyboard dismissal', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // The Message field is multiline, so its Return key can't dismiss the
+  // keyboard. Opening an attachment option must drop the keyboard so the
+  // sheet/recorder isn't fighting it for space (and the cards stay reachable).
+  it('dismisses the keyboard when opening the photo/video sheet', () => {
+    const { getByText } = render(<CreateEchoScreen />);
+
+    fireEvent.press(getByText('Add photo or video'));
+
+    expect(Keyboard.dismiss).toHaveBeenCalled();
+  });
+
+  it('dismisses the keyboard when opening the voice recorder', () => {
+    const { getByText } = render(<CreateEchoScreen />);
+
+    fireEvent.press(getByText('Add voice recording'));
+
+    expect(Keyboard.dismiss).toHaveBeenCalled();
+  });
+});

--- a/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
@@ -40,6 +40,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Keyboard,
   Modal,
   Platform,
   ScrollView,
@@ -57,7 +58,10 @@ import {
 import AudioRecorderPlayer from 'react-native-audio-recorder-player';
 import DocumentPicker from 'react-native-document-picker';
 import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
-import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import {
+  KeyboardAvoidingView,
+  KeyboardToolbar,
+} from 'react-native-keyboard-controller';
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
@@ -126,6 +130,21 @@ function formatDuration(ms: number): string {
 // internally so it never dominates the screen (keeps the page scrollable).
 const MIN_MESSAGE_HEIGHT = verticalScale(120);
 const MAX_MESSAGE_HEIGHT = verticalScale(220);
+
+// Gold-on-navy "Done" bar shown above the keyboard while the multiline Message
+// field is focused, so the user can dismiss the keyboard and reach the
+// attachment cards (a multiline Return key can't act as Done). Same palette for
+// light/dark so it stays on-brand regardless of the OS appearance.
+const KEYBOARD_TOOLBAR_PALETTE = {
+  primary: palette.gold.DEFAULT,
+  disabled: palette.navy.light,
+  background: '#1a2238', // Figma Border/Inverse — reads as an elevated dark bar
+  ripple: 'rgba(242, 226, 177, 0.2)',
+};
+const KEYBOARD_TOOLBAR_THEME = {
+  light: KEYBOARD_TOOLBAR_PALETTE,
+  dark: KEYBOARD_TOOLBAR_PALETTE,
+};
 
 // Non-canonical MIME types pickers report, mapped to what the backend accepts.
 const MIME_ALIASES: Record<string, string> = {
@@ -688,6 +707,7 @@ const CreateEchoScreen: React.FC = () => {
 
   // ── Record a video ────────────────────────────────────────────────────────
   const recordVideo = async () => {
+    Keyboard.dismiss();
     try {
       const result = await launchCamera({
         mediaType: 'video',
@@ -714,8 +734,16 @@ const CreateEchoScreen: React.FC = () => {
     }
   };
 
+  // Open the photo/video sheet, dismissing the keyboard first so the sheet
+  // isn't fighting the keyboard for space.
+  const openUploadSheet = () => {
+    Keyboard.dismiss();
+    setShowUploadSheet(true);
+  };
+
   // ── Voice recording ───────────────────────────────────────────────────────
   const openRecorder = () => {
+    Keyboard.dismiss();
     setRecordMs(0);
     recordUri.current = null;
     setIsRecording(false);
@@ -1126,7 +1154,7 @@ const CreateEchoScreen: React.FC = () => {
                     key={att.id}
                     attachment={att}
                     onRemove={() => removeAttachment(att)}
-                    onAddMore={() => setShowUploadSheet(true)}
+                    onAddMore={openUploadSheet}
                     onPlayVideo={() => setPreviewVideo(att)}
                     onToggleAudio={() => toggleAudioPlayback(att)}
                     isPlayingAudio={playingAudioId === att.id}
@@ -1147,7 +1175,7 @@ const CreateEchoScreen: React.FC = () => {
                 <AddCard
                   icon={<PhotoIcon />}
                   label="Add photo or video"
-                  onPress={() => setShowUploadSheet(true)}
+                  onPress={openUploadSheet}
                   disabled={isSaving}
                 />
                 <AddCard
@@ -1186,6 +1214,12 @@ const CreateEchoScreen: React.FC = () => {
             )}
           </View>
         </KeyboardAvoidingView>
+
+        {/* "Done" bar above the keyboard — the multiline Message field can't use
+            the Return key to dismiss, so this gives an explicit way out to reach
+            the attachment cards. Sits outside the KeyboardAvoidingView; its own
+            keyboard-sticky positioning doesn't compound with the KAV. */}
+        <KeyboardToolbar showArrows={false} theme={KEYBOARD_TOOLBAR_THEME} />
 
         {/* Photo/video upload bottom sheet (Figma 7544:2839) */}
         <Modal


### PR DESCRIPTION
On CreateEchoScreen the Message field is multiline, so its Return key inserts a newline and can't dismiss the keyboard. With no dismiss affordance, the keyboard covered the 'Add to your Echo' cards and the KeyboardAvoidingView left SAVE as the only visible action — users saved an incomplete echo and had to re-open it to attach media.

- Mount react-native-keyboard-controller's <KeyboardToolbar> (Done only, showArrows=false), themed gold-on-navy, outside the KAV so its keyboard-sticky positioning doesn't compound with the lifted SAVE footer. Gives an explicit way to dismiss and reach the attachment cards.
- Dismiss the keyboard when opening the photo/video sheet, voice recorder, or video capture so those surfaces aren't fighting the keyboard.
- Add KeyboardToolbar to the shared RN-keyboard-controller jest mock.

Adds CreateEchoScreen.test.tsx covering the reach-through dismissal.