### PR TITLE
feat(echo): save a MirrorGPT reply into a new Echo

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/save-chat-to-echo.md
+++ b/MirrorCollectiveApp/docs/visual-qa/save-chat-to-echo.md
@@ -1,0 +1,45 @@
+# Visual QA — Save a MirrorGPT reply into an Echo
+
+**Figma:** Dev-Master-File → node `7811-2866` (MirrorGPT chat)
+**Feature:** copy/paste capability — save a MirrorGPT reply as a new Echo (V1 Must Have)
+
+## Summary
+
+Each MirrorGPT **assistant reply** now shows a **save (download) icon** beneath
+the bubble. Tapping it starts the create-Echo flow and carries the reply's text
+all the way through to the compose box:
+
+```
+[save icon on reply] → NewEchoScreen (title / category / recipient?)
+  → ChooseRecipientScreen (recipient + lock date)   [recipient path]
+  → CreateEchoScreen  ← message box prefilled with the reply text
+```
+
+The no-recipient path (`NewEchoScreen → CreateEchoScreen`) prefills the same way.
+
+## Implementation
+
+- **`MessageBubble`**: new optional `onSave` prop → renders a gold download-into-tray
+  icon (Figma 7811-2866) in an action row under **assistant** bubbles only. The
+  bubble/action row now stack in a left-aligned column (the column carries the
+  80% width cap so bubble width is unchanged).
+- **`MirrorChatScreen`**: `handleSaveToEcho(text)` navigates to `NewEchoScreen`
+  with `prefillContent`; `onSave` is passed only for assistant messages.
+- **Threading** (this is the plumbing that was missing): `prefillContent` flows
+  `NewEchoScreen → ChooseRecipientScreen → CreateEchoScreen.initialContent`.
+  `CreateEchoScreen` previously **ignored** `initialContent`; it now seeds the
+  message box from it (edit/view mode still overrides with the loaded echo).
+- Nav type: `NewEchoScreen` param gains `prefillContent?: string`.
+
+## Tokens
+
+Save icon: `palette.gold.DEFAULT`, 20×20, 1.6 stroke — matches the thin gold
+line icons in the design. Action row: 8px above the bubble's baseline, 16px gap
+(reserved for the thumbs icons, see below).
+
+## Notes / deviations
+
+- **Thumbs up / down (feedback) are shown in the Figma but NOT implemented here.**
+  They need a reply-feedback backend endpoint, and the V1 Must-Have scope is the
+  save-to-Echo capability. The action row is laid out to accept them later.
+- Reference render: Figma node `7811-2866` (screenshot attached to the PR).

--- a/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.test.tsx
+++ b/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.test.tsx
@@ -141,6 +141,40 @@ describe('MessageBubble', () => {
     expect(queryByTestId(`speaker-button-${mockSystemMessage.id}`)).toBeNull();
   });
 
+  describe('save to Echo Vault', () => {
+    it('shows the save icon on an assistant reply when onSave is provided', () => {
+      const onSave = jest.fn();
+      const { getByTestId } = render(
+        <MessageBubble message={mockSystemMessage} onSave={onSave} />,
+      );
+      expect(getByTestId(`save-echo-${mockSystemMessage.id}`)).toBeTruthy();
+    });
+
+    it('calls onSave when the save icon is pressed', () => {
+      const onSave = jest.fn();
+      const { getByTestId } = render(
+        <MessageBubble message={mockSystemMessage} onSave={onSave} />,
+      );
+      fireEvent.press(getByTestId(`save-echo-${mockSystemMessage.id}`));
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show the save icon on the user's own messages", () => {
+      const onSave = jest.fn();
+      const { queryByTestId } = render(
+        <MessageBubble message={mockUserMessage} onSave={onSave} />,
+      );
+      expect(queryByTestId(`save-echo-${mockUserMessage.id}`)).toBeNull();
+    });
+
+    it('shows no save icon when onSave is omitted', () => {
+      const { queryByTestId } = render(
+        <MessageBubble message={mockSystemMessage} />,
+      );
+      expect(queryByTestId(`save-echo-${mockSystemMessage.id}`)).toBeNull();
+    });
+  });
+
   // The speaker-button tests below describe the behavior the bubble has
   // when TTS_FEATURE_ENABLED is true. The feature is currently flagged
   // OFF (see src/services/speech/featureFlag.ts), so the assertions

--- a/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -10,7 +10,26 @@ import { TTS_FEATURE_ENABLED, ttsService, useTtsActiveId } from '@services/speec
 
 interface MessageBubbleProps {
   message: Message;
+  /**
+   * When provided, an assistant reply shows a "save to Echo Vault" icon that
+   * carries this reply's text into the create-Echo flow. Ignored for the
+   * user's own messages.
+   */
+  onSave?: () => void;
 }
+
+// Download-into-tray glyph (Figma 7811-2866) — the "save this reply" affordance.
+const SaveIcon: React.FC = () => (
+  <Svg width={20} height={20} viewBox="0 0 24 24" fill="none">
+    <Path
+      d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
 
 const SpeakerPlayIcon: React.FC = () => (
   <Svg width={18} height={18} viewBox="0 0 24 24" fill="none">
@@ -41,7 +60,10 @@ const SpeakerStopIcon: React.FC = () => (
   </Svg>
 );
 
-export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
+export const MessageBubble: React.FC<MessageBubbleProps> = ({
+  message,
+  onSave,
+}) => {
   const isUser = message.sender === 'user';
   const activeUtteranceId = useTtsActiveId();
   const isSpeaking = activeUtteranceId === message.id;
@@ -69,22 +91,39 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
           <Text style={[styles.text, styles.userText]}>{message.text}</Text>
         </LinearGradient>
       ) : (
-        <View style={[styles.bubble, styles.systemBubble]}>
-          <Text style={[styles.text, styles.systemText]}>{message.text}</Text>
-          {TTS_FEATURE_ENABLED && (
-            <TouchableOpacity
-              onPress={handleSpeakerPress}
-              style={styles.speakerBtn}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityRole="button"
-              accessibilityLabel={
-                isSpeaking ? 'Stop reading reply aloud' : 'Read reply aloud'
-              }
-              accessibilityState={{ selected: isSpeaking }}
-              testID={`speaker-button-${message.id}`}
-            >
-              {isSpeaking ? <SpeakerStopIcon /> : <SpeakerPlayIcon />}
-            </TouchableOpacity>
+        <View style={styles.systemColumn}>
+          <View style={[styles.bubble, styles.systemBubble, styles.systemBubbleWidth]}>
+            <Text style={[styles.text, styles.systemText]}>{message.text}</Text>
+            {TTS_FEATURE_ENABLED && (
+              <TouchableOpacity
+                onPress={handleSpeakerPress}
+                style={styles.speakerBtn}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  isSpeaking ? 'Stop reading reply aloud' : 'Read reply aloud'
+                }
+                accessibilityState={{ selected: isSpeaking }}
+                testID={`speaker-button-${message.id}`}
+              >
+                {isSpeaking ? <SpeakerStopIcon /> : <SpeakerPlayIcon />}
+              </TouchableOpacity>
+            )}
+          </View>
+
+          {onSave && (
+            <View style={styles.actionRow}>
+              <TouchableOpacity
+                onPress={onSave}
+                style={styles.actionBtn}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Save to Echo Vault"
+                testID={`save-echo-${message.id}`}
+              >
+                <SaveIcon />
+              </TouchableOpacity>
+            </View>
           )}
         </View>
       )}
@@ -104,6 +143,25 @@ const styles = StyleSheet.create({
   },
   rowSystem: {
     justifyContent: 'flex-start',
+  },
+  // Assistant messages stack the bubble + an action row (save icon) beneath it,
+  // left-aligned to the bubble edge. The column carries the 80% width cap.
+  systemColumn: {
+    maxWidth: '80%',
+    alignItems: 'flex-start',
+  },
+  systemBubbleWidth: {
+    maxWidth: '100%',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    marginTop: 8,
+    marginLeft: 4,
+  },
+  actionBtn: {
+    padding: 2,
   },
   bubble: {
     maxWidth: '80%',

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
@@ -70,6 +70,18 @@ export function MirrorChatContent() {
     [scrollViewRef],
   );
 
+  // Save a MirrorGPT reply into a new Echo: hand its text to the create-Echo
+  // flow (title/category/recipient → Create Echo, prefilled with this text).
+  const handleSaveToEcho = useCallback(
+    (text: string) => {
+      navigation.navigate(
+        'NewEchoScreen' as never,
+        { prefillContent: text } as never,
+      );
+    },
+    [navigation],
+  );
+
   // Re-anchor to the bottom whenever the keyboard appears. KeyboardAvoidingView
   // (from keyboard-controller) handles the layout shift — it adds bottom padding
   // equal to the keyboard height — but it does NOT adjust the ScrollView's
@@ -137,7 +149,15 @@ export function MirrorChatContent() {
                   }}
                 >
                   {messages.map(message => (
-                    <MessageBubble key={message.id} message={message} />
+                    <MessageBubble
+                      key={message.id}
+                      message={message}
+                      onSave={
+                        message.sender === 'user'
+                          ? undefined
+                          : () => handleSaveToEcho(message.text)
+                      }
+                    />
                   ))}
                   {loading && <TypingIndicator />}
                 </ScrollView>

--- a/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/ChooseRecipientScreen.tsx
@@ -180,7 +180,10 @@ const ChooseRecipientScreen: React.FC<Props> = ({ navigation, route }) => {
       recipientId: selectedRecipient.recipient_id,
       recipientName: selectedRecipient.name,
       lockDate: lockDate?.toISOString(),
-      ...(editEchoId ? { editEchoId, initialContent: prefillContent } : {}),
+      ...(editEchoId ? { editEchoId } : {}),
+      // Seed the compose box for both edit (existing draft) and the
+      // save-a-MirrorGPT-reply flow (fresh create with prefilled text).
+      ...(prefillContent ? { initialContent: prefillContent } : {}),
     });
   };
 

--- a/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.test.tsx
@@ -10,9 +10,10 @@ jest.mock('@components/BackgroundWrapper', () => {
   return ({ children }: { children: React.ReactNode }) =>
     react.createElement('BackgroundWrapper', null, children);
 });
+let mockRouteParams: Record<string, unknown> = {};
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn() }),
-  useRoute: () => ({ params: {} }),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 jest.mock('react-native-image-picker', () => ({
   launchCamera: jest.fn(),
@@ -44,7 +45,10 @@ jest.mock('@services/api/echo', () => ({
 }));
 
 describe('CreateEchoScreen — keyboard dismissal', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams = {};
+  });
 
   // The Message field is multiline, so its Return key can't dismiss the
   // keyboard. Opening an attachment option must drop the keyboard so the
@@ -63,5 +67,19 @@ describe('CreateEchoScreen — keyboard dismissal', () => {
     fireEvent.press(getByText('Add voice recording'));
 
     expect(Keyboard.dismiss).toHaveBeenCalled();
+  });
+
+  it('seeds the compose box from initialContent (a saved MirrorGPT reply)', () => {
+    mockRouteParams = {
+      title: 'Reflection',
+      category: 'Uncategorized',
+      initialContent: 'You might be protecting yourself from escalation.',
+    };
+
+    const { getByDisplayValue } = render(<CreateEchoScreen />);
+
+    expect(
+      getByDisplayValue('You might be protecting yourself from escalation.'),
+    ).toBeTruthy();
   });
 });

--- a/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
@@ -515,11 +515,15 @@ const CreateEchoScreen: React.FC = () => {
     letterToRecipient,
     editEchoId,
     viewEchoId,
+    initialContent,
   } = params;
   // Read-only view mode (tap an echo to open). editEchoId takes precedence.
   const readOnly = !editEchoId && !!viewEchoId;
 
-  const [message, setMessage] = useState('');
+  // Seed the compose box with prefilled text (e.g. a saved MirrorGPT reply).
+  // In edit/view mode the loaded echo content overwrites this via the effect
+  // below, so it only matters for a fresh create.
+  const [message, setMessage] = useState(initialContent ?? '');
   const [viewEcho, setViewEcho] = useState<EchoResponse | null>(null);
   const [attachments, setAttachments] = useState<DraftAttachment[]>([]);
   const [isSaving, setIsSaving] = useState(false);

--- a/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/NewEchoVaultScreen.tsx
@@ -27,7 +27,7 @@
  *   Radius/S 12, Radius/M 16, Spacing/XS 8, Spacing/S 12, Spacing/M 16, Spacing/L 20
  */
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   borderWidth,
@@ -148,6 +148,9 @@ const VideoModeIcon: React.FC = () => (
 // ── Screen ────────────────────────────────────────────────────────────────────
 const NewEchoScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
+  const route = useRoute<RouteProp<RootStackParamList, 'NewEchoScreen'>>();
+  // Optional text to seed the new Echo with (e.g. a saved MirrorGPT reply).
+  const prefillContent = route.params?.prefillContent;
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState<string | null>(null);
   const [categoryOpen, setCategoryOpen] = useState(false);
@@ -158,12 +161,21 @@ const NewEchoScreen: React.FC = () => {
     if (!title.trim()) return;
     const cat = category || 'Uncategorized';
     if (hasRecipient === 'yes') {
-      navigation.navigate('ChooseRecipientScreen', { title, category: cat, mode });
+      navigation.navigate('ChooseRecipientScreen', {
+        title,
+        category: cat,
+        mode,
+        prefillContent,
+      });
     } else {
       // No-recipient create path uses the new unified CreateEchoScreen
       // (message + attachments). The recipient path routes here too, via
       // ChooseRecipientScreen.
-      navigation.navigate('CreateEchoScreen', { title, category: cat });
+      navigation.navigate('CreateEchoScreen', {
+        title,
+        category: cat,
+        ...(prefillContent ? { initialContent: prefillContent } : {}),
+      });
     }
   };
 

--- a/MirrorCollectiveApp/src/types/navigation.ts
+++ b/MirrorCollectiveApp/src/types/navigation.ts
@@ -84,7 +84,9 @@ export type RootStackParamList = {
   MirrorEchoVaultLibrary: undefined;
   EchoInboxScreen: undefined;
   NewEchoVault: undefined;
-  NewEchoScreen: undefined;
+  // prefillContent: seed the compose flow with text (e.g. saving a MirrorGPT
+  // reply into a new Echo). Threaded through to CreateEchoScreen.initialContent.
+  NewEchoScreen: { prefillContent?: string } | undefined;
   NewEchoCompose: {
     title: string;
     category: string;


### PR DESCRIPTION
Add a save (download) icon under each MirrorGPT assistant reply (Figma 7811-2866). Tapping it starts the create-Echo flow and carries the reply text through to the compose box.

- MessageBubble: optional onSave prop → gold download icon in an action row under assistant bubbles only; bubble + row now stack in a left-aligned column (column holds the 80% width cap, so bubble width is unchanged).
- MirrorChatScreen: handleSaveToEcho navigates to NewEchoScreen with prefillContent (assistant messages only).
- Thread prefillContent: NewEchoScreen -> ChooseRecipientScreen ->
  CreateEchoScreen.initialContent. CreateEchoScreen previously ignored initialContent; it now seeds the message box from it (edit/view still overrides with the loaded echo).
- nav: NewEchoScreen param gains prefillContent.
- Tests: MessageBubble save icon (assistant-only, press, omitted); CreateEcho seeds message from initialContent. Full suite green (628 passed).

Note: the Figma also shows thumbs up/down feedback icons — out of scope here (needs a feedback backend); the action row is laid out to accept them later.