### PR TITLE
feat(subscription): show live App Store prices with $9.99/$89 fallback

### DIFF
--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
@@ -39,6 +39,24 @@ const PRODUCT_IDS = {
   })!,
 };
 
+/**
+ * Localized App Store / Play Store price for a product (e.g. "$9.99"), or the
+ * fallback when products haven't loaded yet or the id isn't found. Lets the UI
+ * show the real store price instead of a hard-coded one — a price change in
+ * App Store Connect then reflects automatically.
+ */
+export const localizedPrice = (
+  products: Subscription[],
+  productId: string,
+  fallback: string,
+): string => {
+  const product = products.find(p => p.productId === productId);
+  // localizedPrice is present on iOS subscriptions; the Android variant nests
+  // pricing under subscriptionOfferDetails, so read it defensively.
+  const price = (product as {localizedPrice?: string} | undefined)?.localizedPrice;
+  return price || fallback;
+};
+
 interface PurchaseState {
   products: Subscription[];
   loading: boolean;

--- a/MirrorCollectiveApp/src/screens/MySubscriptionScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/MySubscriptionScreen.test.tsx
@@ -12,7 +12,15 @@ jest.mock('@components/BackgroundWrapper', () => {
 });
 const mockRestore = jest.fn().mockResolvedValue(undefined);
 jest.mock('@hooks/useInAppPurchase', () => ({
-  useInAppPurchase: () => ({ restorePurchases: mockRestore }),
+  useInAppPurchase: () => ({
+    restorePurchases: mockRestore,
+    products: [],
+    PRODUCT_IDS: {
+      CORE_MONTHLY: 'com.themirrorcollective.mirror.monthly',
+      CORE_YEARLY: 'com.themirrorcollective.mirror.yearly',
+    },
+  }),
+  localizedPrice: (_products: unknown, _id: string, fallback: string) => fallback,
 }));
 let mockSub: Record<string, unknown> = {};
 jest.mock('@context/SubscriptionContext', () => ({

--- a/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
@@ -34,15 +34,13 @@ import LogoHeader from '@components/LogoHeader';
 import StarIcon from '@components/StarIcon';
 import { LEGAL_LINKS } from '@constants/config';
 import { useSubscription } from '@context/SubscriptionContext';
-import { useInAppPurchase } from '@hooks/useInAppPurchase';
+import { useInAppPurchase, localizedPrice } from '@hooks/useInAppPurchase';
 
 // iOS Manage Subscriptions deep link. Auto-renewable subscriptions cannot be
 // cancelled programmatically — Apple requires the user to do it in Settings /
 // the App Store, so END SUBSCRIPTION routes there.
 const MANAGE_SUBSCRIPTIONS_URL = 'https://apps.apple.com/account/subscriptions';
 
-const CORE_MONTHLY_PRICE = '$9.99';
-const CORE_YEARLY_PRICE = '$89';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MySubscription'>;
 
@@ -59,7 +57,9 @@ const Bullet: React.FC<{ lead: string; rest: string }> = ({ lead, rest }) => (
 const MySubscriptionScreen: React.FC<Props> = ({ navigation }) => {
   const { status, isInTrial, trialDaysRemaining, hasActiveSubscription, loading } =
     useSubscription();
-  const { restorePurchases } = useInAppPurchase();
+  const { restorePurchases, products, PRODUCT_IDS } = useInAppPurchase();
+  const monthlyPrice = localizedPrice(products, PRODUCT_IDS.CORE_MONTHLY, '$9.99');
+  const yearlyPrice = localizedPrice(products, PRODUCT_IDS.CORE_YEARLY, '$89');
   const [restoring, setRestoring] = useState(false);
 
   const statusLine = isInTrial
@@ -179,10 +179,10 @@ const MySubscriptionScreen: React.FC<Props> = ({ navigation }) => {
               />
 
               <View style={styles.priceLine}>
-                <Text style={styles.priceAmount}>{CORE_MONTHLY_PRICE}</Text>
+                <Text style={styles.priceAmount}>{monthlyPrice}</Text>
                 <Text style={styles.pricePer}> /month </Text>
                 <Text style={styles.priceOr}>or</Text>
-                <Text style={styles.priceYear}> {CORE_YEARLY_PRICE}</Text>
+                <Text style={styles.priceYear}> {yearlyPrice}</Text>
                 <Text style={styles.priceYearSuffix}> /year</Text>
               </View>
 

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/hooks/useInAppPurchase', () => ({
     return {
       purchaseSubscription: mockPurchase,
       purchasing: false,
+      products: [],
       PRODUCT_IDS: {
         CORE_MONTHLY: 'com.themirrorcollective.mirror.monthly',
         CORE_YEARLY: 'com.themirrorcollective.mirror.yearly',
@@ -52,6 +53,7 @@ jest.mock('@/hooks/useInAppPurchase', () => ({
       },
     };
   },
+  localizedPrice: (_products: unknown, _id: string, fallback: string) => fallback,
 }));
 // Trial already used + no active sub → button is "SUBSCRIBE NOW" (purchase path).
 jest.mock('@/context/SubscriptionContext', () => ({

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
@@ -42,7 +42,7 @@ import { LEGAL_LINKS } from '@constants/config';
 
 import { useSession } from '@/context/SessionContext';
 import { useSubscription } from '@/context/SubscriptionContext';
-import { useInAppPurchase } from '@/hooks/useInAppPurchase';
+import { useInAppPurchase, localizedPrice } from '@/hooks/useInAppPurchase';
 import { subscriptionApiService } from '@/services/api/subscriptionApi';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'StartFreeTrial'>;
@@ -52,7 +52,7 @@ const StartFreeTrialScreen = () => {
     const canGoBack = navigation.canGoBack();
     const { hasUsedTrial, hasActiveSubscription, refreshSubscriptionStatus } = useSubscription();
     const { setAuthenticated } = useSession();
-    const { purchaseSubscription, purchasing, PRODUCT_IDS } = useInAppPurchase({
+    const { purchaseSubscription, purchasing, PRODUCT_IDS, products } = useInAppPurchase({
         // A paid purchase is confirmed asynchronously (StoreKit listener →
         // backend verify). When that completes, refresh status and enter the
         // app — mirroring the trial path, which calls setAuthenticated()
@@ -65,6 +65,10 @@ const StartFreeTrialScreen = () => {
     });
     const [loading, setLoading] = useState(false);
     const [selectedPeriod, setSelectedPeriod] = useState<'monthly' | 'yearly'>('monthly');
+
+    // Live store prices (fall back to the confirmed defaults until IAP loads).
+    const monthlyPrice = localizedPrice(products, PRODUCT_IDS.CORE_MONTHLY, '$9.99');
+    const yearlyPrice = localizedPrice(products, PRODUCT_IDS.CORE_YEARLY, '$89');
 
     const isTrialMode = !hasUsedTrial && !hasActiveSubscription;
     const buttonText = isTrialMode ? 'START FREE TRIAL' : 'SUBSCRIBE NOW';
@@ -249,12 +253,12 @@ const StartFreeTrialScreen = () => {
 
                   {/* Pricing */}
                   <View style={styles.priceLine}>
-                    <Text style={styles.priceAmount}>$9.99</Text>
+                    <Text style={styles.priceAmount}>{monthlyPrice}</Text>
                     <Text style={styles.pricePerMonth}> /month </Text>
                     <View style={styles.priceOrContainer}>
                       <Text style={styles.priceOr}> or </Text>
                     </View>
-                    <Text style={styles.priceYearAmount}> $89</Text>
+                    <Text style={styles.priceYearAmount}> {yearlyPrice}</Text>
                     <Text style={styles.priceYearSuffix}> /year</Text>
                   </View>
 


### PR DESCRIPTION
Add a localizedPrice() helper reading each product's store-localized price from IAP, and use it on the paywall and My Subscription instead of hard-coded amounts. A price change in App Store Connect now reflects automatically; falls back to the confirmed $9.99/$89 until products load. Test mocks updated.