### PR TITLE
feat(mirrorgpt): add capture-your-reflection info modal + copy icon

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/mirror-gpt-info.md
+++ b/MirrorCollectiveApp/docs/visual-qa/mirror-gpt-info.md
@@ -1,0 +1,74 @@
+# Visual QA — MirrorGPT "Capture your reflection" info modal
+
+**Figma:** Dev-Master-File → header/screen node `7811-2866`, modal node `7915-4583`
+**Feature:** an `(i)` info button in the MirrorGPT header that opens a one-page
+modal explaining the copy-to-Echo-Vault flow.
+
+## Summary
+
+The MirrorGPT header title row gains a gold circled-`i` button (right side,
+title stays optically centered via a matching left spacer). Tapping it opens a
+centered card modal:
+
+```
+CAPTURE YOUR REFLECTION
+Tap the copy icon in Mirror GPT to grab the lesson, insight, or memory you
+want to keep. You’ll jump straight to the Echo Vault—just create a new Echo,
+and your copied content will already be there waiting for you.
+            [ content_copy glyph ]
+   “Learn something → copy it → save it for later.”
+```
+
+Dismisses on the top-right `×` or a backdrop tap.
+
+## Implementation
+
+- **`src/components/MirrorGptInfoModal.tsx`** (new): RN `Modal`
+  (`transparent`, `animationType="fade"`) → dimmed scrim (`modalColors.backdrop`)
+  → `GlassCard` (navy card + hairline border) with a gold glow shadow. Single
+  page: close row, heading, body, centered `content_copy` SVG glyph, italic
+  footer. Copy is authored verbatim from Figma node `7915-4583`.
+- **`src/screens/MirrorChatScreen.tsx`**: title `<Text>` → a `titleRow`
+  (`spacer | title(flex:1, centered) | (i) button`); `infoVisible` state;
+  renders `<MirrorGptInfoModal>`. New inline `InfoGlyph` (circled-i) SVG.
+
+Chose a focused component over reusing `features/reflection-room/InfoOverlay`
+because that overlay is paginated and has no inline icon slot — this design is a
+single page whose whole point is the centered copy glyph.
+
+## Tokens (Figma → app)
+
+| Figma | Value | App token |
+| --- | --- | --- |
+| Bg/Brand, Text/Paragraph-1 | `#f2e2b1` | `palette.gold.DEFAULT` — title, icons, footer |
+| Bg/Brand Subtlest | `#fdfdf9` | `palette.gold.subtlest` — body text |
+| Border/Subtle | `#a3b3cc` | `palette.navy.light` — GlassCard hairline |
+| Heading S (Cormorant) | 24 / lh 28 | `fontFamily.heading`, `fontSize.xl`, `lineHeight.l` |
+| Body S (Inter) | 16 / lh 24 | `fontFamily.body`, `fontSize.s`, `lineHeight.m` |
+| Body XS Italic (Inter) | 14 / lh 20 | `fontFamily.bodyItalic`, `fontSize.xs`, `lineHeight.s` |
+| Radius/M | 16 | `radius.m` |
+| Spacing/XL | 24 | `spacing.l` (card padding) |
+
+No token gaps.
+
+## Notes / deviations
+
+- **Gold glow shadow** approximates Figma's "Background Blur" effect
+  (drop shadow `#F2E2B1 @ 30%`, radius 15) via RN `shadow*`/`elevation` rather
+  than a real backdrop blur — consistent with `GlassCard`'s documented choice to
+  avoid `BlurView` (which blurs the night-sky background and reads as
+  transparent on device).
+- **`content_copy` glyph** is drawn inline (no copy icon existed in the app);
+  gold, 24×24, 1.6 stroke — matches the app's inline-SVG icon convention
+  (`MessageBubble` SaveIcon).
+- **RN screenshot capture pending**: drop the on-device render at
+  `docs/visual-qa/mirror-gpt-info/mirror-gpt-info-rn.png` for the side-by-side.
+  Reference Figma render: node `7915-4583`.
+
+## Checklist
+
+- [x] Tokens sourced from theme (no literals)
+- [x] Layout matches Figma (centered card, close top-right, icon centered)
+- [x] Copy verbatim from Figma
+- [x] Unit + integration tests pass
+- [ ] RN screenshot captured + side-by-side reviewed (manual, needs running app)

--- a/MirrorCollectiveApp/src/components/MirrorGptInfoModal.test.tsx
+++ b/MirrorCollectiveApp/src/components/MirrorGptInfoModal.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+
+import MirrorGptInfoModal from './MirrorGptInfoModal';
+
+describe('MirrorGptInfoModal', () => {
+  it('renders the "capture your reflection" copy', () => {
+    const { getByText } = render(
+      <MirrorGptInfoModal visible onClose={jest.fn()} />,
+    );
+    expect(getByText('CAPTURE YOUR REFLECTION')).toBeTruthy();
+    expect(getByText(/Tap the copy icon in Mirror GPT/)).toBeTruthy();
+    expect(getByText(/Learn something/)).toBeTruthy();
+  });
+
+  it('calls onClose when the close (×) button is pressed', () => {
+    const onClose = jest.fn();
+    const { getByLabelText } = render(
+      <MirrorGptInfoModal visible onClose={onClose} />,
+    );
+    fireEvent.press(getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the backdrop is pressed', () => {
+    const onClose = jest.fn();
+    const { getByLabelText } = render(
+      <MirrorGptInfoModal visible onClose={onClose} />,
+    );
+    fireEvent.press(getByLabelText('Close info'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/MirrorCollectiveApp/src/components/MirrorGptInfoModal.tsx
+++ b/MirrorCollectiveApp/src/components/MirrorGptInfoModal.tsx
@@ -1,0 +1,182 @@
+/**
+ * "CAPTURE YOUR REFLECTION" info modal for the MirrorGPT screen.
+ *
+ * Opened from the (i) icon in the MirrorGPT header. Explains the copy-to-Echo-
+ * Vault flow: tapping the copy icon on a reply carries that text straight into
+ * a new Echo. Figma: Dev-Master-File node 7915-4583.
+ *
+ * Mirrors the tokens/structure of features/reflection-room InfoOverlay, but is
+ * a focused single-page card with the content_copy glyph the design calls out
+ * (InfoOverlay is paginated and has no inline icon).
+ */
+
+import React from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import Svg, { Path, Rect } from 'react-native-svg';
+
+import GlassCard from '@components/_internal/GlassCard';
+import {
+  fontFamily,
+  fontSize,
+  lineHeight,
+  modalColors,
+  palette,
+  radius,
+  spacing,
+} from '@theme';
+
+// Copy exactly as authored in Figma (node 7915-4583).
+const HEADER = 'CAPTURE YOUR REFLECTION';
+const BODY =
+  'Tap the copy icon in Mirror GPT to grab the lesson, insight, or memory ' +
+  'you want to keep. You’ll jump straight to the Echo Vault—just create a ' +
+  'new Echo, and your copied content will already be there waiting for you.';
+const FOOTER = '“Learn something → copy it → save it for later.”';
+
+/** Material-style content_copy glyph, gold — matches the copy affordance the
+ *  modal is teaching the user about. */
+const CopyGlyph: React.FC<{ size?: number }> = ({ size = 24 }) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Rect
+      x={9}
+      y={9}
+      width={11}
+      height={11}
+      rx={2}
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.6}
+    />
+    <Path
+      d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+interface MirrorGptInfoModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const MirrorGptInfoModal: React.FC<MirrorGptInfoModalProps> = ({
+  visible,
+  onClose,
+}) => (
+  <Modal
+    visible={visible}
+    transparent
+    animationType="fade"
+    onRequestClose={onClose}
+  >
+    {/* Scrim tap dismisses; inner Pressable swallows taps on the card. */}
+    <Pressable
+      style={styles.scrim}
+      onPress={onClose}
+      accessibilityLabel="Close info"
+    >
+      <Pressable onPress={() => {}}>
+        <GlassCard
+          padding={spacing.l}
+          borderRadius={radius.m}
+          style={styles.card}
+        >
+          <View style={styles.closeRow}>
+            <Pressable
+              onPress={onClose}
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+              style={styles.closeButton}
+            >
+              <Text style={styles.closeText} allowFontScaling={false}>
+                ×
+              </Text>
+            </Pressable>
+          </View>
+
+          <Text style={styles.header} accessibilityRole="header">
+            {HEADER}
+          </Text>
+
+          <Text style={styles.body}>{BODY}</Text>
+
+          <View style={styles.iconRow}>
+            <CopyGlyph />
+          </View>
+
+          <Text style={styles.footer}>{FOOTER}</Text>
+        </GlassCard>
+      </Pressable>
+    </Pressable>
+  </Modal>
+);
+
+export default MirrorGptInfoModal;
+
+const styles = StyleSheet.create({
+  scrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: modalColors.backdrop,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.l,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 329, // Figma frame width
+    // Gold glow — Figma "Background Blur" drop shadow (#F2E2B1 @ 30%).
+    shadowColor: palette.gold.DEFAULT,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.3,
+    shadowRadius: 15,
+    elevation: 8,
+  },
+  closeRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  closeButton: {
+    width: 20,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeText: {
+    color: palette.gold.DEFAULT,
+    fontSize: fontSize.xl,
+    lineHeight: fontSize.xl,
+    fontFamily: fontFamily.body,
+  },
+  header: {
+    fontFamily: fontFamily.heading,
+    fontSize: fontSize.xl, // 24
+    lineHeight: lineHeight.l, // 28
+    color: palette.gold.DEFAULT,
+    textAlign: 'center',
+    letterSpacing: 1,
+    marginTop: spacing.s,
+  },
+  body: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.s, // 16
+    lineHeight: lineHeight.m, // 24
+    color: palette.gold.subtlest,
+    textAlign: 'center',
+    marginTop: spacing.l,
+  },
+  iconRow: {
+    alignItems: 'center',
+    marginTop: spacing.l,
+  },
+  footer: {
+    fontFamily: fontFamily.bodyItalic,
+    fontSize: fontSize.xs, // 14
+    lineHeight: lineHeight.s, // 20
+    color: palette.gold.DEFAULT,
+    textAlign: 'center',
+    marginTop: spacing.m,
+  },
+});

--- a/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/MirrorCollectiveApp/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -1,11 +1,11 @@
-import { theme, spacing, radius, shadows, palette } from '@theme';
-import type { Message } from '@types';
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import Svg, { Path, Rect } from 'react-native-svg';
 
 import { TTS_FEATURE_ENABLED, ttsService, useTtsActiveId } from '@services/speech';
+import { theme, spacing, radius, shadows, palette } from '@theme';
+import type { Message } from '@types';
 
 
 interface MessageBubbleProps {
@@ -18,11 +18,22 @@ interface MessageBubbleProps {
   onSave?: () => void;
 }
 
-// Download-into-tray glyph (Figma 7811-2866) — the "save this reply" affordance.
+// content_copy glyph (Figma 7811-2866) — the "copy this reply into an Echo"
+// affordance. The info modal (node 7915-4583) explicitly calls this "the copy
+// icon", so the design uses two overlapping sheets rather than a download arrow.
 const SaveIcon: React.FC = () => (
   <Svg width={20} height={20} viewBox="0 0 24 24" fill="none">
+    <Rect
+      x={9}
+      y={9}
+      width={11}
+      height={11}
+      rx={2}
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.6}
+    />
     <Path
-      d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"
+      d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
       stroke={palette.gold.DEFAULT}
       strokeWidth={1.6}
       strokeLinecap="round"

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.test.tsx
@@ -118,6 +118,14 @@ describe('MirrorChatScreen', () => {
     expect(mockUseChat.sendMessage).toHaveBeenCalled();
   });
 
+  it('exposes the header info button and wires the capture-reflection modal', () => {
+    const { getByLabelText, getByText } = render(<MirrorChatContent />);
+    // The (i) button lives in the header, next to the MirrorGPT title.
+    const infoButton = getByLabelText('How MirrorGPT works');
+    fireEvent.press(infoButton); // opens the modal — must not throw
+    expect(getByText('CAPTURE YOUR REFLECTION')).toBeTruthy();
+  });
+
   it('shows loading indicator when loading', () => {
     (useChat as jest.Mock).mockReturnValue({
       ...mockUseChat,

--- a/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MirrorChatScreen.tsx
@@ -1,5 +1,4 @@
 import { useNavigation } from '@react-navigation/native';
-import { theme, palette, spacing, shadows, textShadow } from '@theme';
 import React, { useCallback, useEffect } from 'react';
 import {
   View,
@@ -7,16 +6,19 @@ import {
   StyleSheet,
   ScrollView,
   Keyboard,
+  Pressable,
   type NativeSyntheticEvent,
   type TextInputContentSizeChangeEventData,
 } from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import Svg, { Circle, Path } from 'react-native-svg';
 
 import AuthenticatedRoute from '@components/AuthenticatedRoute';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import LogoHeader from '@components/LogoHeader';
+import MirrorGptInfoModal from '@components/MirrorGptInfoModal';
 import { MessageBubble, ChatInput, TypingIndicator } from '@components/ui';
 import { useChat } from '@hooks/useChat';
 import {
@@ -24,10 +26,32 @@ import {
   useAutoReadOnNewMessage,
   useAutoReadPreference,
 } from '@services/speech';
+import { theme, palette, spacing, shadows, textShadow } from '@theme';
+
+/** Circled "i" glyph (gold) — opens the "Capture your reflection" info modal. */
+const InfoGlyph: React.FC<{ size?: number }> = ({ size = 22 }) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Circle
+      cx={12}
+      cy={12}
+      r={9.25}
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.5}
+    />
+    <Circle cx={12} cy={7.9} r={1.05} fill={palette.gold.DEFAULT} />
+    <Path
+      d="M12 11.2v5.4"
+      stroke={palette.gold.DEFAULT}
+      strokeWidth={1.6}
+      strokeLinecap="round"
+    />
+  </Svg>
+);
 
 // Export content component for testing
 export function MirrorChatContent() {
   const navigation = useNavigation();
+  const [infoVisible, setInfoVisible] = React.useState(false);
   const {
     messages,
     draft,
@@ -124,7 +148,21 @@ export function MirrorChatContent() {
             >
               {/* Chat "card" */}
               <View style={styles.chatContainer}>
-                <Text style={styles.chatTitle}>MirrorGPT</Text>
+                <View style={styles.titleRow}>
+                  {/* Left spacer balances the info button so the title stays
+                      optically centered. */}
+                  <View style={styles.titleSpacer} />
+                  <Text style={styles.chatTitle}>MirrorGPT</Text>
+                  <Pressable
+                    onPress={() => setInfoVisible(true)}
+                    hitSlop={12}
+                    accessibilityRole="button"
+                    accessibilityLabel="How MirrorGPT works"
+                    style={styles.infoButton}
+                  >
+                    <InfoGlyph />
+                  </Pressable>
+                </View>
 
                 <ScrollView
                   ref={scrollViewRef}
@@ -173,6 +211,11 @@ export function MirrorChatContent() {
             </LinearGradient>
           </View>
         </KeyboardAvoidingView>
+
+        <MirrorGptInfoModal
+          visible={infoVisible}
+          onClose={() => setInfoVisible(false)}
+        />
       </SafeAreaView>
     </BackgroundWrapper>
   );
@@ -231,15 +274,34 @@ const styles = StyleSheet.create({
     ...shadows.LIGHT,
   },
 
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 30,
+    paddingHorizontal: spacing.xs,
+  },
+
+  titleSpacer: {
+    width: 24,
+    height: 24,
+  },
+
+  infoButton: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
   chatTitle: {
     ...theme.typography.styles.title,
+    flex: 1,
     fontFamily: 'CormorantGaramond-Regular',
     fontSize: 28,
     fontWeight: '300',
     lineHeight: 28,
     color: palette.gold.subtlest,
     textAlign: 'center',
-    paddingTop: 30,
   },
 
   messagesWrapper: {


### PR DESCRIPTION
Figma Dev-Master-File nodes 7811-2866 (screen) / 7915-4583 (modal).

- MirrorGptInfoModal: new one-page modal opened from an (i) button in the MirrorGPT header. Explains the copy-to-Echo-Vault flow (heading, body, content_copy glyph, italic footer). Built on GlassCard + theme tokens; copy verbatim from Figma. Dismisses on × or backdrop tap.
- MirrorChatScreen: header title row gains the gold circled-i button (title stays centered via a matching spacer) wired to the modal.
- MessageBubble: swap the reply action glyph from a download arrow to the content_copy icon the design (and the modal copy) call out.
- Tests for the modal + header wiring; visual-QA report.