### PR TITLE
fix(auth): don't let push-unregister hang block logout

### DIFF
--- a/MirrorCollectiveApp/src/context/SessionContext.tsx
+++ b/MirrorCollectiveApp/src/context/SessionContext.tsx
@@ -243,33 +243,41 @@ export const SessionProvider = ({ children }: SessionProviderProps) => {
   };
   const signOut = async () => {
     if (!isMountedRef.current) return;
-    try {
-      safeDispatch({ type: 'SET_LOADING', payload: true });
-      
-      // Unregister push notifications before clearing tokens
+    safeDispatch({ type: 'SET_LOADING', payload: true });
+
+    // Push-unregister and the server sign-out call are best-effort and MUST NOT
+    // block the user from actually logging out. Notably, unregisterDevice()
+    // resolves the device token via messaging().registerDeviceForRemoteMessages(),
+    // which can HANG indefinitely on the iOS Simulator (no APNs) — awaiting it
+    // directly leaves the user stuck on the current screen with no way back to
+    // sign-in. Time-box the whole remote cleanup so logout always proceeds.
+    const remoteCleanup = (async () => {
       try {
         await PushNotificationService.unregisterDevice();
       } catch (error) {
         if (__DEV__) console.warn('Push unregistration failed:', error);
       }
-
       try {
         await authApiService.signOut();
       } catch (error) {
         if (__DEV__) console.warn('Server logout failed:', error);
       }
+    })();
+    await Promise.race([
+      remoteCleanup,
+      new Promise<void>(resolve => setTimeout(resolve, 3000)),
+    ]);
+
+    // Local token clear is fast and authoritative — it's what actually ends the
+    // session. Always run it, then flip auth state so the navigator swaps to the
+    // sign-in stack.
+    try {
       await authApiService.clearTokens();
-      if (isMountedRef.current) {
-        safeDispatch({ type: 'LOGOUT_SUCCESS' });
-      }
-    } catch (error: any) {
-      console.error('Logout error:', error);
-      try {
-        await authApiService.clearTokens();
-      } catch (e) {}
-      if (isMountedRef.current) {
-        safeDispatch({ type: 'LOGOUT_SUCCESS' });
-      }
+    } catch (error) {
+      if (__DEV__) console.warn('Token clear failed during logout:', error);
+    }
+    if (isMountedRef.current) {
+      safeDispatch({ type: 'LOGOUT_SUCCESS' });
     }
   };
 

--- a/MirrorCollectiveApp/src/screens/NavigationMenuScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/NavigationMenuScreen.tsx
@@ -53,6 +53,7 @@ type MirrorSideMenuProps = {
 // ── Nav item definitions ────────────────────────────────────────────────────
 // Figma node 2336:3805 — primary items with dividers between each
 const PRIMARY_ITEMS = [
+  { label: 'Home',            route: 'TalkToMirror' },
   { label: 'MirrorGPT',       route: 'MirrorChat' },
   { label: 'Echo Vault',      route: 'MirrorEchoVaultHome' },
   { label: 'Reflection Room', route: 'ReflectionRoomCommingsoon' },


### PR DESCRIPTION
signOut() awaited PushNotificationService.unregisterDevice() before dispatching LOGOUT_SUCCESS. unregisterDevice() resolves the device token via messaging().registerDeviceForRemoteMessages(), which can hang indefinitely on the iOS Simulator (no APNs) — a hang the try/catch can't catch — so logout never completed and the user was never returned to the sign-in stack.

Time-box the remote cleanup (push-unregister + server sign-out) to 3s via a Promise.race, then always clear tokens locally and dispatch LOGOUT_SUCCESS. Logout now completes promptly regardless of push/network state. Also fixes the inactivity-timeout logout, which used the same blocking path.