### PR TITLE
fix(iap): treat Apple-sheet cancel as a no-op, not a failure

### DIFF
--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.test.tsx
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { useInAppPurchase } from './useInAppPurchase';
+
+// Control requestSubscription per-test; stub the rest of the IAP surface so the
+// hook mounts cleanly.
+const mockRequestSubscription = jest.fn();
+
+jest.mock('react-native-iap', () => ({
+  initConnection: jest.fn().mockResolvedValue(true),
+  endConnection: jest.fn().mockResolvedValue(undefined),
+  getSubscriptions: jest.fn().mockResolvedValue([]),
+  getAvailablePurchases: jest.fn().mockResolvedValue([]),
+  requestSubscription: (...args: unknown[]) => mockRequestSubscription(...args),
+  finishTransaction: jest.fn().mockResolvedValue(undefined),
+  purchaseUpdatedListener: jest.fn(() => ({ remove: jest.fn() })),
+  purchaseErrorListener: jest.fn(() => ({ remove: jest.fn() })),
+  ErrorCode: { E_USER_CANCELLED: 'E_USER_CANCELLED' },
+}));
+
+jest.mock('@/services/api/subscriptionApi', () => ({
+  subscriptionApiService: {
+    verifyPurchase: jest.fn(),
+    restorePurchases: jest.fn(),
+  },
+}));
+
+describe('useInAppPurchase — user cancel handling', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('treats a Cancel on the Apple sheet as a silent no-op', async () => {
+    const cancel = Object.assign(new Error('cancelled'), {
+      code: 'E_USER_CANCELLED',
+    });
+    mockRequestSubscription.mockRejectedValueOnce(cancel);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useInAppPurchase());
+    await act(async () => {
+      await result.current.purchaseSubscription('sku');
+    });
+
+    // No error surfaced, flag reset, and no "Purchase error" logged.
+    expect(result.current.purchasing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(errSpy).not.toHaveBeenCalledWith(
+      'Purchase error:',
+      expect.anything(),
+    );
+  });
+
+  it('still surfaces a genuine (non-cancel) purchase failure', async () => {
+    const fail = Object.assign(new Error('network down'), { code: 'E_UNKNOWN' });
+    mockRequestSubscription.mockRejectedValueOnce(fail);
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useInAppPurchase());
+    await act(async () => {
+      await result.current.purchaseSubscription('sku');
+    });
+
+    expect(result.current.error).toBe('network down');
+    expect(result.current.purchasing).toBe(false);
+  });
+});

--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
@@ -9,12 +9,22 @@ import {
   finishTransaction,
   purchaseUpdatedListener,
   purchaseErrorListener,
+  ErrorCode,
   type Subscription,
   type SubscriptionPurchase,
   type ProductPurchase,
 } from 'react-native-iap';
 
 import {subscriptionApiService} from '@/services/api/subscriptionApi';
+
+/**
+ * True when a purchase error is the user backing out of the Apple payment sheet
+ * (tapping Cancel). That's a normal action, not a failure — callers should reset
+ * the purchasing flag silently rather than surface an error.
+ */
+const isUserCancelled = (error: any): boolean =>
+  error?.code === ErrorCode.E_USER_CANCELLED ||
+  error?.code === 'E_USER_CANCELLED';
 
 // Product IDs
 const PRODUCT_IDS = {
@@ -162,6 +172,11 @@ export const useInAppPurchase = (options?: {
 
         // Listen for purchase errors
         purchaseErrorSubscription = purchaseErrorListener(error => {
+          // Cancel fires here too — treat it as a silent no-op.
+          if (isUserCancelled(error)) {
+            setState(prev => ({...prev, purchasing: false}));
+            return;
+          }
           console.warn('Purchase error:', error);
           setState(prev => ({
             ...prev,
@@ -202,6 +217,12 @@ export const useInAppPurchase = (options?: {
         sku: productId,
       });
     } catch (error: any) {
+      // User tapped Cancel on the Apple sheet — a normal action, not a failure.
+      // Reset the flag silently; don't log or set an error state.
+      if (isUserCancelled(error)) {
+        setState(prev => ({...prev, purchasing: false}));
+        return;
+      }
       console.error('Purchase error:', error);
       setState(prev => ({
         ...prev,


### PR DESCRIPTION
Cancelling the Apple payment sheet throws E_USER_CANCELLED. Both the purchaseSubscription catch and the purchaseErrorListener treated it like a real failure — logging 'Purchase error' and setting error state ('Purchase failed'). Cancel is a normal user action: now it silently resets purchasing=false with no error and no log. A genuine (non-cancel) failure still surfaces as before.

Adds useInAppPurchase.test.tsx covering both paths.