### PR TITLE
feat(home): surface expired trial/subscription on landing

### DIFF
--- a/MirrorCollectiveApp/docs/visual-qa/expired-login-prompt.md
+++ b/MirrorCollectiveApp/docs/visual-qa/expired-login-prompt.md
@@ -1,0 +1,38 @@
+# Visual QA — Expired subscription surfacing on Home
+
+**Feature:** proactively tell a returning user their trial/subscription lapsed,
+instead of only revealing it via My Subscription or a 403 wall.
+
+## Summary
+
+On the Home screen (`TalkToMirror`), driven by `useSubscription()`:
+
+- **Active trial** → the existing `TrialCountdown` banner renders under the
+  header ("N days left in trial — Tap to subscribe"). It self-gates (returns
+  `null` unless `isInTrial && trialDaysRemaining > 0`).
+- **Expired** (`status === 'trial_expired' || 'expired'`) → the existing
+  `UpgradePrompt` modal (`reason="trial_expired"`) appears on landing:
+  *"Trial Expired — Your 14-day trial has ended. Subscribe to continue…"* with
+  **UPGRADE NOW** (→ `StartFreeTrial`) and **Not Now**.
+
+## Behaviour
+
+- The prompt shows **once per mount** via a `useRef` latch. Home stays mounted
+  at the root of the stack, so this is effectively once per login session and
+  resets on the next login — it does **not** re-nag when navigating back to Home.
+- It waits for `loading` to clear before deciding, so it never flashes during
+  the initial status fetch.
+
+## Tests
+
+`TalkToMirrorScreen.test.tsx`: prompt shows for `trial_expired`/`expired`, is
+hidden for `active`/`trial`/`none`, and is suppressed while `loading`. Existing
+render/nav tests still pass (added a `SubscriptionContext` mock).
+
+## Notes
+
+- Both `trial_expired` and paid-`expired` reuse the `trial_expired` copy; the
+  CTA (subscribe) is correct for both. A dedicated paid-expired message can be
+  added if/when the Apple webhook drives that state.
+- Components were pre-built but previously rendered nowhere — this wires them in.
+- RN screenshot pending: capture `expired-login-prompt-rn.png` on device.

--- a/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.test.tsx
@@ -18,6 +18,26 @@ jest.mock('@context/UserContext', () => ({
 jest.mock('@services', () => ({
   OnboardingService: { markOnboardingComplete: jest.fn().mockResolvedValue(undefined) },
 }));
+// TrialCountdown calls useNavigation() internally (no NavigationContainer here);
+// stub it. Its own active-trial logic is exercised by its own component.
+jest.mock('@components/TrialCountdown', () => 'TrialCountdown');
+// Render UpgradePrompt as a visibility marker so we can assert it appears.
+jest.mock('@components/UpgradePrompt', () => {
+  const react = require('react');
+  const { Text } = require('react-native');
+  return ({ visible, reason }: { visible: boolean; reason?: string }) =>
+    visible ? react.createElement(Text, null, `UPGRADE_PROMPT:${reason}`) : null;
+});
+// Drive subscription status per-test.
+let mockSubscription = {
+  status: 'active',
+  loading: false,
+  isInTrial: false,
+  trialDaysRemaining: 0,
+};
+jest.mock('@context/SubscriptionContext', () => ({
+  useSubscription: () => mockSubscription,
+}));
 
 import { useUser } from '@context/UserContext';
 
@@ -29,6 +49,12 @@ describe('TalkToMirrorScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (useUser as jest.Mock).mockReturnValue({ user: null });
+    mockSubscription = {
+      status: 'active',
+      loading: false,
+      isInTrial: false,
+      trialDaysRemaining: 0,
+    };
   });
 
   it('renders greeting, talk button, and all three categories', () => {
@@ -59,5 +85,29 @@ describe('TalkToMirrorScreen', () => {
     fireEvent.press(getByText(label));
 
     expect(mockNavigation.navigate).toHaveBeenCalledWith(route);
+  });
+
+  it.each(['trial_expired', 'expired'])(
+    'shows the upgrade prompt on landing when status is %s',
+    status => {
+      mockSubscription = { ...mockSubscription, status };
+      const { getByText } = render(<TalkToMirrorScreen navigation={mockNavigation} />);
+      expect(getByText('UPGRADE_PROMPT:trial_expired')).toBeTruthy();
+    },
+  );
+
+  it.each(['active', 'trial', 'none'])(
+    'does NOT show the upgrade prompt when status is %s',
+    status => {
+      mockSubscription = { ...mockSubscription, status };
+      const { queryByText } = render(<TalkToMirrorScreen navigation={mockNavigation} />);
+      expect(queryByText('UPGRADE_PROMPT:trial_expired')).toBeNull();
+    },
+  );
+
+  it('does not show the prompt until the subscription status has loaded', () => {
+    mockSubscription = { ...mockSubscription, status: 'trial_expired', loading: true };
+    const { queryByText } = render(<TalkToMirrorScreen navigation={mockNavigation} />);
+    expect(queryByText('UPGRADE_PROMPT:trial_expired')).toBeNull();
   });
 });

--- a/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/TalkToMirrorScreen.tsx
@@ -15,26 +15,8 @@
  */
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { OnboardingService } from '@services';
+import React, { useEffect, useRef, useState } from 'react';
 import {
-  palette,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  radius,
-  borderWidth,
-  textShadow,
-  spacing,
-  glassGradient,
-  scale,
-  verticalScale,
-  moderateScale,
-} from '@theme';
-import type { RootStackParamList } from '@types';
-import React, { useEffect } from 'react';
-import {
-  Image,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -56,7 +38,27 @@ import MirrorPledgeIcon from '@components/icons/MirrorPledgeIcon';
 import ReflectionRoomIcon from '@components/icons/ReflectionRoomIcon';
 import LogoHeader from '@components/LogoHeader';
 import StarIcon from '@components/StarIcon';
+import TrialCountdown from '@components/TrialCountdown';
+import UpgradePrompt from '@components/UpgradePrompt';
+import { useSubscription } from '@context/SubscriptionContext';
 import { useUser } from '@context/UserContext';
+import { OnboardingService } from '@services';
+import {
+  palette,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  radius,
+  borderWidth,
+  textShadow,
+  spacing,
+  glassGradient,
+  scale,
+  verticalScale,
+  moderateScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 
 interface Props {
   navigation: NativeStackNavigationProp<RootStackParamList, 'TalkToMirror'>;
@@ -103,6 +105,24 @@ const TalkToMirrorScreen: React.FC<Props> = ({ navigation }) => {
   const { user } = useUser();
   const firstName = user?.fullName ? user.fullName.split(' ')[0] : 'Friend';
 
+  // Surface an expired trial/subscription on landing so the user isn't left
+  // guessing (they'd otherwise only find out via My Subscription or by hitting
+  // the 403 wall). Shown once per mount — Home stays mounted at the root of the
+  // stack, so this fires once per login session and resets on the next login,
+  // not on every navigate-back. Active-trial users instead get the subtle
+  // TrialCountdown banner below.
+  const { status, loading: subscriptionLoading } = useSubscription();
+  const [expiredPromptVisible, setExpiredPromptVisible] = useState(false);
+  const expiredPromptShownRef = useRef(false);
+
+  useEffect(() => {
+    if (subscriptionLoading || expiredPromptShownRef.current) return;
+    if (status === 'trial_expired' || status === 'expired') {
+      expiredPromptShownRef.current = true;
+      setExpiredPromptVisible(true);
+    }
+  }, [status, subscriptionLoading]);
+
   useEffect(() => {
     OnboardingService.markOnboardingComplete().catch(() => {
       // non-fatal — onboarding flag is best-effort
@@ -131,6 +151,9 @@ const TalkToMirrorScreen: React.FC<Props> = ({ navigation }) => {
       <SafeAreaView style={styles.safe}>
         <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
         <LogoHeader />
+
+        {/* Self-gating: renders only during an active trial (days remaining). */}
+        <TrialCountdown />
 
         <ScrollView
           style={styles.scroll}
@@ -221,6 +244,13 @@ const TalkToMirrorScreen: React.FC<Props> = ({ navigation }) => {
 
           </View>
         </ScrollView>
+
+        {/* Expired trial/subscription → prompt to subscribe on landing. */}
+        <UpgradePrompt
+          visible={expiredPromptVisible}
+          onClose={() => setExpiredPromptVisible(false)}
+          reason="trial_expired"
+        />
       </SafeAreaView>
     </BackgroundWrapper>
   );


### PR DESCRIPTION
Previously an expired user got no signal on login — they only found out via My Subscription or by hitting the 403 wall on a gated action. The UpgradePrompt and TrialCountdown components existed but were rendered nowhere.

- TalkToMirror: wire TrialCountdown (self-gates to active trials) under the header, and show UpgradePrompt(reason='trial_expired') on landing when status is trial_expired/expired. Shown once per mount via a ref latch (once per login session; no re-nag on navigate-back), and only after status has loaded.
- tests: prompt shown for expired states, hidden otherwise + while loading; removed a pre-existing unused Image import.
- docs/visual-qa/expired-login-prompt.md.