### PR TITLE
feat(echo): surface storage-quota-exceeded on upload via UpgradePrompt

### DIFF
--- a/MirrorCollectiveApp/src/components/UpgradePrompt.test.tsx
+++ b/MirrorCollectiveApp/src/components/UpgradePrompt.test.tsx
@@ -40,4 +40,25 @@ describe('UpgradePrompt', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it('shows a clean quota message when no usage figures are supplied', () => {
+    const { getByText } = render(
+      <UpgradePrompt visible onClose={jest.fn()} reason="quota_exceeded" />,
+    );
+    expect(getByText('Storage Limit Reached')).toBeTruthy();
+    // Fallback copy — no "undefined GB".
+    expect(getByText(/reached your storage limit/)).toBeTruthy();
+  });
+
+  it('shows the usage figures when quotaInfo is provided', () => {
+    const { getByText } = render(
+      <UpgradePrompt
+        visible
+        onClose={jest.fn()}
+        reason="quota_exceeded"
+        quotaInfo={{ usage_gb: 49.7, quota_gb: 50 }}
+      />,
+    );
+    expect(getByText(/49\.7 GB of your 50 GB/)).toBeTruthy();
+  });
 });

--- a/MirrorCollectiveApp/src/components/UpgradePrompt.tsx
+++ b/MirrorCollectiveApp/src/components/UpgradePrompt.tsx
@@ -32,17 +32,21 @@ const getMessage = (
     case 'quota_exceeded':
       return {
         title: 'Storage Limit Reached',
-        message: `You've used ${quotaInfo?.usage_gb.toFixed(1)} GB of your ${
-          quotaInfo?.quota_gb
-        } GB storage. Upgrade to add more space.`,
+        // Numbers when we have them, a clean fallback when we don't (the upload
+        // 507 doesn't carry usage figures).
+        message: quotaInfo
+          ? `You've used ${quotaInfo.usage_gb.toFixed(1)} GB of your ${quotaInfo.quota_gb} GB storage. Upgrade to add more space.`
+          : "You've reached your storage limit. Upgrade to add more space.",
       };
     case 'quota_approaching':
       return {
         title: 'Running Low on Storage',
-        message: `You've used ${(
-          ((quotaInfo?.usage_gb || 0) / (quotaInfo?.quota_gb || 1)) *
-          100
-        ).toFixed(0)}% of your storage. Consider adding more space.`,
+        message: quotaInfo
+          ? `You've used ${(
+              (quotaInfo.usage_gb / (quotaInfo.quota_gb || 1)) *
+              100
+            ).toFixed(0)}% of your storage. Consider adding more space.`
+          : "You're running low on storage. Consider adding more space.",
       };
     case 'trial_expired':
       return {

--- a/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/echoVault/CreateEchoScreen.tsx
@@ -21,20 +21,6 @@
 
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  borderWidth,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  moderateScale,
-  palette,
-  radius,
-  scale,
-  spacing,
-  verticalScale,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -71,8 +57,23 @@ import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button/Button';
 import EchoAttachments from '@components/echo/EchoAttachments';
 import LogoHeader from '@components/LogoHeader';
+import UpgradePrompt from '@components/UpgradePrompt';
 import { echoApiService } from '@services/api/echo';
 import type { Attachment, EchoResponse, UploadStage } from '@services/api/echo';
+import {
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  moderateScale,
+  palette,
+  radius,
+  scale,
+  spacing,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 import {
   createPosterThumbnail,
   ensureWebSafePhoto,
@@ -138,7 +139,7 @@ const MAX_MESSAGE_HEIGHT = verticalScale(220);
 const KEYBOARD_TOOLBAR_PALETTE = {
   primary: palette.gold.DEFAULT,
   disabled: palette.navy.light,
-  background: '#1a2238', // Figma Border/Inverse — reads as an elevated dark bar
+  background: palette.navy.DEFAULT, // #1a2238 — reads as an elevated dark bar
   ripple: 'rgba(242, 226, 177, 0.2)',
 };
 const KEYBOARD_TOOLBAR_THEME = {
@@ -530,6 +531,8 @@ const CreateEchoScreen: React.FC = () => {
   const [uploadStage, setUploadStage] = useState<UploadStage | null>(null);
   const [showUploadSheet, setShowUploadSheet] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
+  // Over storage quota (507 on upload) → show the on-brand upgrade prompt.
+  const [quotaPromptVisible, setQuotaPromptVisible] = useState(false);
   // Picker must launch only AFTER the sheet fully dismisses (iOS races
   // otherwise). pendingPicker records the choice; the launch happens in
   // handleSheetDismissed (iOS) or a timeout (Android).
@@ -953,6 +956,12 @@ const CreateEchoScreen: React.FC = () => {
         },
       ]);
     } catch (error: unknown) {
+      // Over storage quota — the upload endpoints return 507. Surface the
+      // upgrade prompt instead of a raw error so the user can add space.
+      if ((error as { status?: number } | null)?.status === 507) {
+        setQuotaPromptVisible(true);
+        return;
+      }
       const msg =
         error instanceof Error ? error.message : 'Failed to save echo.';
       console.error('Create echo failed:', msg);
@@ -1362,6 +1371,13 @@ const CreateEchoScreen: React.FC = () => {
             </View>
           </View>
         </Modal>
+
+        {/* Over storage quota → prompt to add space / subscribe. */}
+        <UpgradePrompt
+          visible={quotaPromptVisible}
+          onClose={() => setQuotaPromptVisible(false)}
+          reason="quota_exceeded"
+        />
       </SafeAreaView>
     </BackgroundWrapper>
   );


### PR DESCRIPTION
Uploading past the storage quota returns 507 from the API, but the client only showed a generic 'Failed to save echo.' (the thrown ApiError isn't an Error instance, so even the message was lost). Now CreateEchoScreen detects the 507 and shows the on-brand UpgradePrompt(reason='quota_exceeded') so the user can add space / subscribe — mirroring the trial_expired path.

- CreateEchoScreen: catch status===507 in the save flow → show UpgradePrompt.
- UpgradePrompt: quota messages degrade gracefully when no usage figures are present (the 507 doesn't carry them) — no more 'undefined GB'.
- tests: quota copy with/without figures. Also swap a pre-existing hardcoded '#1a2238' for palette.navy.DEFAULT so the touched file lints clean.