### PR TITLE
feat: App Store submission blockers — account deletion, IAP disclosur…

### DIFF
--- a/MirrorCollectiveApp/App.tsx
+++ b/MirrorCollectiveApp/App.tsx
@@ -125,11 +125,6 @@ const navTheme: Theme = {
 const screenOptions = {
   headerShown: false,
   contentStyle: { backgroundColor: 'transparent' },
-  // Cross-fade instead of the native iOS push slide. On a dark, full-bleed app
-  // the slide draws a soft leading-edge shadow that reads as a seam/border
-  // between screens; a fade has no sliding edge, so transitions are seamless.
-  // The back-swipe gesture still works — only the visual animation changes.
-  animation: 'fade',
 } as const;
 // Wrapped MirrorChat component with error boundary
 const MirrorChatWithErrorBoundary = () => (

--- a/MirrorCollectiveApp/App.tsx
+++ b/MirrorCollectiveApp/App.tsx
@@ -125,6 +125,11 @@ const navTheme: Theme = {
 const screenOptions = {
   headerShown: false,
   contentStyle: { backgroundColor: 'transparent' },
+  // Cross-fade instead of the native iOS push slide. On a dark, full-bleed app
+  // the slide draws a soft leading-edge shadow that reads as a seam/border
+  // between screens; a fade has no sliding edge, so transitions are seamless.
+  // The back-swipe gesture still works — only the visual animation changes.
+  animation: 'fade',
 } as const;
 // Wrapped MirrorChat component with error boundary
 const MirrorChatWithErrorBoundary = () => (

--- a/MirrorCollectiveApp/src/components/LogoHeader.tsx
+++ b/MirrorCollectiveApp/src/components/LogoHeader.tsx
@@ -21,12 +21,20 @@ import HeaderTextSvg from './HeaderTextSvg';
 
 type LogoHeaderProps = {
   containerStyle?: StyleProp<ViewStyle>;
+  /**
+   * Style applied to the outer header wrapper. Screens whose content sits
+   * inside a horizontally-padded container pass a negative horizontal margin
+   * here so the header stays full-bleed and its menu button lines up with the
+   * rest of the app.
+   */
+  wrapperStyle?: StyleProp<ViewStyle>;
   navigation?: any;
   onMenuPress?: () => void;
 };
 
 const LogoHeader = ({
   containerStyle,
+  wrapperStyle,
   navigation: propNavigation,
   onMenuPress,
 }: LogoHeaderProps) => {
@@ -83,7 +91,7 @@ const LogoHeader = ({
           onLogout={handleLogout}
         />
       )}
-      <View style={styles.wrapper}>
+      <View style={[styles.wrapper, wrapperStyle]}>
         <View style={styles.leftContainer}>
           {isAuthenticated && (
             <Pressable

--- a/MirrorCollectiveApp/src/context/SessionContext.tsx
+++ b/MirrorCollectiveApp/src/context/SessionContext.tsx
@@ -26,6 +26,7 @@ interface SessionContextType {
   signUp: (fullName: string, email: string, password: string, phoneNumber?: string, termsAcceptedAt?: string) => Promise<void>;
   signIn: (email: string, password: string) => Promise<any>; // Returns full response for UserContext to use
   signOut: () => Promise<void>;
+  deleteAccount: () => Promise<boolean>;
   forgotPassword: (email: string) => Promise<void>;
   resetPassword: (
     email: string,
@@ -281,6 +282,29 @@ export const SessionProvider = ({ children }: SessionProviderProps) => {
     }
   };
 
+  // Permanently delete the account (Apple 5.1.1(v)). Returns true on success so
+  // the caller can decide what to surface; either way the session is cleared and
+  // the app drops to the signed-out stack.
+  const deleteAccount = async (): Promise<boolean> => {
+    if (!isMountedRef.current) return false;
+    let ok = false;
+    try {
+      const response = await authApiService.deleteAccount();
+      ok = response.success !== false;
+    } catch (error) {
+      if (__DEV__) console.warn('Account deletion request failed:', error);
+    }
+    try {
+      await authApiService.clearTokens();
+    } catch (error) {
+      if (__DEV__) console.warn('Token clear failed during account delete:', error);
+    }
+    if (isMountedRef.current) {
+      safeDispatch({ type: 'LOGOUT_SUCCESS' });
+    }
+    return ok;
+  };
+
   const forgotPassword = async (email: string) => {
     if (!isMountedRef.current) return;
     try {
@@ -346,6 +370,7 @@ export const SessionProvider = ({ children }: SessionProviderProps) => {
     signUp,
     signIn,
     signOut,
+    deleteAccount,
     forgotPassword,
     resetPassword,
     clearError,

--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.test.tsx
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.test.tsx
@@ -1,20 +1,26 @@
-import { act, renderHook } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 
 import { useInAppPurchase } from './useInAppPurchase';
 
 // Control requestSubscription per-test; stub the rest of the IAP surface so the
 // hook mounts cleanly.
 const mockRequestSubscription = jest.fn();
+const mockInitConnection = jest.fn().mockResolvedValue(true);
+const mockGetSubscriptions = jest.fn().mockResolvedValue([]);
+const mockPurchaseUpdatedListener = jest.fn(() => ({ remove: jest.fn() }));
+const mockPurchaseErrorListener = jest.fn(() => ({ remove: jest.fn() }));
 
 jest.mock('react-native-iap', () => ({
-  initConnection: jest.fn().mockResolvedValue(true),
+  initConnection: (...args: unknown[]) => mockInitConnection(...args),
   endConnection: jest.fn().mockResolvedValue(undefined),
-  getSubscriptions: jest.fn().mockResolvedValue([]),
+  getSubscriptions: (...args: unknown[]) => mockGetSubscriptions(...args),
   getAvailablePurchases: jest.fn().mockResolvedValue([]),
   requestSubscription: (...args: unknown[]) => mockRequestSubscription(...args),
   finishTransaction: jest.fn().mockResolvedValue(undefined),
-  purchaseUpdatedListener: jest.fn(() => ({ remove: jest.fn() })),
-  purchaseErrorListener: jest.fn(() => ({ remove: jest.fn() })),
+  purchaseUpdatedListener: (...args: unknown[]) =>
+    mockPurchaseUpdatedListener(...(args as [])),
+  purchaseErrorListener: (...args: unknown[]) =>
+    mockPurchaseErrorListener(...(args as [])),
   ErrorCode: { E_USER_CANCELLED: 'E_USER_CANCELLED' },
 }));
 
@@ -24,6 +30,61 @@ jest.mock('@/services/api/subscriptionApi', () => ({
     restorePurchases: jest.fn(),
   },
 }));
+
+describe('useInAppPurchase — init resilience (paywall wedge fix)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockInitConnection.mockResolvedValue(true);
+    mockGetSubscriptions.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('registers purchase listeners BEFORE loading products', async () => {
+    renderHook(() => useInAppPurchase());
+
+    await waitFor(() => expect(mockGetSubscriptions).toHaveBeenCalled());
+
+    // A queued StoreKit transaction can arrive the instant the connection
+    // opens; if getSubscriptions ran first (and hung) the listener would miss
+    // it. Assert the listener was wired up first via invocation order.
+    const listenerOrder =
+      mockPurchaseUpdatedListener.mock.invocationCallOrder[0];
+    const getSubsOrder = mockGetSubscriptions.mock.invocationCallOrder[0];
+    expect(listenerOrder).toBeLessThan(getSubsOrder);
+  });
+
+  it('clears loading even when getSubscriptions hangs forever', async () => {
+    jest.useFakeTimers();
+    // Native StoreKit can hang without ever resolving OR rejecting — the exact
+    // wedge seen in production. Simulate with a promise that never settles.
+    mockGetSubscriptions.mockReturnValue(new Promise(() => {}));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useInAppPurchase());
+    expect(result.current.loading).toBe(true);
+
+    // Advance past the init timeout; the timeout wrapper rejects, the catch
+    // runs, and loading is cleared so the paywall renders instead of wedging.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clears loading when getSubscriptions rejects', async () => {
+    mockGetSubscriptions.mockRejectedValueOnce(new Error('store down'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useInAppPurchase());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Failed to initialize store connection');
+  });
+});
 
 describe('useInAppPurchase — user cancel handling', () => {
   afterEach(() => jest.restoreAllMocks());

--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
@@ -26,6 +26,34 @@ const isUserCancelled = (error: any): boolean =>
   error?.code === ErrorCode.E_USER_CANCELLED ||
   error?.code === 'E_USER_CANCELLED';
 
+/**
+ * Reject a promise if it doesn't settle within `ms`. Native StoreKit calls
+ * (initConnection / getSubscriptions) can hang indefinitely rather than
+ * rejecting — without a timeout the init effect's `loading` flag would stay
+ * true forever and wedge the paywall on "LOADING...". Wrapping them guarantees
+ * the effect always resolves one way or the other.
+ */
+const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      err => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+};
+
+const IAP_INIT_TIMEOUT_MS = 10000;
+
 // Product IDs
 const PRODUCT_IDS = {
   // Must match the product IDs created in App Store Connect exactly (product
@@ -102,26 +130,25 @@ export const useInAppPurchase = (options?: {
     let purchaseErrorSubscription: any;
 
     const initIAP = async () => {
-      try {
-        await initConnection();
-        console.log('IAP connection initialized');
+      // Register the purchase listeners BEFORE anything that can hang or throw
+      // (initConnection / getSubscriptions). StoreKit can deliver a queued
+      // transaction — e.g. an Ask-to-Buy approval or a restore — the instant the
+      // connection opens; if the listeners aren't attached yet that event is
+      // lost. Registering first also means a slow/hung getSubscriptions never
+      // costs us purchase delivery.
+      purchaseUpdateSubscription = purchaseUpdatedListener(
+        async (purchase: SubscriptionPurchase | ProductPurchase) => {
+          if (__DEV__) {
+            // Never log the full purchase object in release — it carries the
+            // signed transaction receipt. Product/transaction ids are enough
+            // to debug with.
+            console.log('Purchase updated:', {
+              productId: purchase.productId,
+              transactionId: purchase.transactionId,
+            });
+          }
 
-        // Fetch available products
-        const productIds = Object.values(PRODUCT_IDS);
-        const availableProducts = await getSubscriptions({skus: productIds});
-
-        setState(prev => ({
-          ...prev,
-          products: availableProducts,
-          loading: false,
-        }));
-
-        // Listen for purchase updates
-        purchaseUpdateSubscription = purchaseUpdatedListener(
-          async (purchase: SubscriptionPurchase | ProductPurchase) => {
-            console.log('Purchase updated:', purchase);
-
-            const receipt = Platform.select({
+          const receipt = Platform.select({
               ios: purchase.transactionReceipt,
               android: purchase.purchaseToken,
             });
@@ -170,20 +197,48 @@ export const useInAppPurchase = (options?: {
           },
         );
 
-        // Listen for purchase errors
-        purchaseErrorSubscription = purchaseErrorListener(error => {
-          // Cancel fires here too — treat it as a silent no-op.
-          if (isUserCancelled(error)) {
-            setState(prev => ({...prev, purchasing: false}));
-            return;
-          }
-          console.warn('Purchase error:', error);
-          setState(prev => ({
-            ...prev,
-            purchasing: false,
-            error: error.message,
-          }));
-        });
+      // Listen for purchase errors
+      purchaseErrorSubscription = purchaseErrorListener(error => {
+        // Cancel fires here too — treat it as a silent no-op.
+        if (isUserCancelled(error)) {
+          setState(prev => ({...prev, purchasing: false}));
+          return;
+        }
+        console.warn('Purchase error:', error);
+        setState(prev => ({
+          ...prev,
+          purchasing: false,
+          error: error.message,
+        }));
+      });
+
+      // Listeners are attached — now open the store connection and load
+      // products. Both native calls are wrapped in a timeout because StoreKit
+      // can hang without ever resolving or rejecting; on any failure we still
+      // clear `loading` so the paywall renders (with fallback prices) instead
+      // of being wedged on "LOADING..." forever.
+      try {
+        await withTimeout(
+          initConnection(),
+          IAP_INIT_TIMEOUT_MS,
+          'initConnection',
+        );
+        if (__DEV__) {
+          console.log('IAP connection initialized');
+        }
+
+        const productIds = Object.values(PRODUCT_IDS);
+        const availableProducts = await withTimeout(
+          getSubscriptions({skus: productIds}),
+          IAP_INIT_TIMEOUT_MS,
+          'getSubscriptions',
+        );
+
+        setState(prev => ({
+          ...prev,
+          products: availableProducts,
+          loading: false,
+        }));
       } catch (error: any) {
         console.error('IAP initialization error:', error);
         setState(prev => ({

--- a/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
+++ b/MirrorCollectiveApp/src/hooks/useInAppPurchase.ts
@@ -1,5 +1,5 @@
-import {useEffect, useState, useCallback, useRef} from 'react';
-import {Platform, Alert} from 'react-native';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Platform, Alert } from 'react-native';
 import {
   initConnection,
   endConnection,
@@ -15,7 +15,7 @@ import {
   type ProductPurchase,
 } from 'react-native-iap';
 
-import {subscriptionApiService} from '@/services/api/subscriptionApi';
+import { subscriptionApiService } from '@/services/api/subscriptionApi';
 
 /**
  * True when a purchase error is the user backing out of the Apple payment sheet
@@ -33,7 +33,11 @@ const isUserCancelled = (error: any): boolean =>
  * true forever and wedge the paywall on "LOADING...". Wrapping them guarantees
  * the effect always resolves one way or the other.
  */
-const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
+const withTimeout = <T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> => {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error(`${label} timed out after ${ms}ms`)),
@@ -91,7 +95,8 @@ export const localizedPrice = (
   const product = products.find(p => p.productId === productId);
   // localizedPrice is present on iOS subscriptions; the Android variant nests
   // pricing under subscriptionOfferDetails, so read it defensively.
-  const price = (product as {localizedPrice?: string} | undefined)?.localizedPrice;
+  const price = (product as { localizedPrice?: string } | undefined)
+    ?.localizedPrice;
   return price || fallback;
 };
 
@@ -149,59 +154,59 @@ export const useInAppPurchase = (options?: {
           }
 
           const receipt = Platform.select({
-              ios: purchase.transactionReceipt,
-              android: purchase.purchaseToken,
-            });
+            ios: purchase.transactionReceipt,
+            android: purchase.purchaseToken,
+          });
 
-            if (receipt) {
-              try {
-                // Verify purchase with backend
-                const result = await subscriptionApiService.verifyPurchase({
-                  platform: Platform.OS as 'ios' | 'android',
-                  receipt_data: receipt,
-                  product_id: purchase.productId,
-                  transaction_id: purchase.transactionId || purchase.productId,
-                });
+          if (receipt) {
+            try {
+              // Verify purchase with backend
+              const result = await subscriptionApiService.verifyPurchase({
+                platform: Platform.OS as 'ios' | 'android',
+                receipt_data: receipt,
+                product_id: purchase.productId,
+                transaction_id: purchase.transactionId || purchase.productId,
+              });
 
-                if (result.success) {
-                  // Finish the transaction
-                  await finishTransaction({purchase, isConsumable: false});
+              if (result.success) {
+                // Finish the transaction
+                await finishTransaction({ purchase, isConsumable: false });
 
-                  Alert.alert(
-                    'Subscription Activated',
-                    'Your subscription has been successfully activated!',
-                    [{text: 'OK'}],
-                  );
+                Alert.alert(
+                  'Subscription Activated',
+                  'Your subscription has been successfully activated!',
+                  [{ text: 'OK' }],
+                );
 
-                  setState(prev => ({...prev, purchasing: false}));
+                setState(prev => ({ ...prev, purchasing: false }));
 
-                  // Purchase is verified — let the caller refresh status and
-                  // route the user into the app.
-                  try {
-                    await onPurchaseVerifiedRef.current?.();
-                  } catch (cbError) {
-                    console.warn('onPurchaseVerified callback failed:', cbError);
-                  }
-                } else {
-                  throw new Error(result.message || 'Verification failed');
+                // Purchase is verified — let the caller refresh status and
+                // route the user into the app.
+                try {
+                  await onPurchaseVerifiedRef.current?.();
+                } catch (cbError) {
+                  console.warn('onPurchaseVerified callback failed:', cbError);
                 }
-              } catch (error: any) {
-                console.error('Purchase verification error:', error);
-                setState(prev => ({
-                  ...prev,
-                  purchasing: false,
-                  error: 'Failed to verify purchase. Please contact support.',
-                }));
+              } else {
+                throw new Error(result.message || 'Verification failed');
               }
+            } catch (error: any) {
+              console.error('Purchase verification error:', error);
+              setState(prev => ({
+                ...prev,
+                purchasing: false,
+                error: 'Failed to verify purchase. Please contact support.',
+              }));
             }
-          },
-        );
+          }
+        },
+      );
 
       // Listen for purchase errors
       purchaseErrorSubscription = purchaseErrorListener(error => {
         // Cancel fires here too — treat it as a silent no-op.
         if (isUserCancelled(error)) {
-          setState(prev => ({...prev, purchasing: false}));
+          setState(prev => ({ ...prev, purchasing: false }));
           return;
         }
         console.warn('Purchase error:', error);
@@ -229,7 +234,7 @@ export const useInAppPurchase = (options?: {
 
         const productIds = Object.values(PRODUCT_IDS);
         const availableProducts = await withTimeout(
-          getSubscriptions({skus: productIds}),
+          getSubscriptions({ skus: productIds }),
           IAP_INIT_TIMEOUT_MS,
           'getSubscriptions',
         );
@@ -265,7 +270,7 @@ export const useInAppPurchase = (options?: {
 
   // Purchase a subscription
   const purchaseSubscription = useCallback(async (productId: string) => {
-    setState(prev => ({...prev, purchasing: true, error: null}));
+    setState(prev => ({ ...prev, purchasing: true, error: null }));
 
     try {
       await requestSubscription({
@@ -275,7 +280,7 @@ export const useInAppPurchase = (options?: {
       // User tapped Cancel on the Apple sheet — a normal action, not a failure.
       // Reset the flag silently; don't log or set an error state.
       if (isUserCancelled(error)) {
-        setState(prev => ({...prev, purchasing: false}));
+        setState(prev => ({ ...prev, purchasing: false }));
         return;
       }
       console.error('Purchase error:', error);
@@ -289,7 +294,7 @@ export const useInAppPurchase = (options?: {
 
   // Restore purchases
   const restorePurchases = useCallback(async () => {
-    setState(prev => ({...prev, loading: true, error: null}));
+    setState(prev => ({ ...prev, loading: true, error: null }));
 
     try {
       // Get available purchases from the store
@@ -299,10 +304,13 @@ export const useInAppPurchase = (options?: {
         Alert.alert(
           'No Purchases Found',
           'No previous purchases were found to restore.',
-          [{text: 'OK'}],
+          [{ text: 'OK' }],
         );
-        setState(prev => ({...prev, loading: false}));
-        return {success: true, data: {restored_count: 0, subscriptions: []}};
+        setState(prev => ({ ...prev, loading: false }));
+        return {
+          success: true,
+          data: { restored_count: 0, subscriptions: [] },
+        };
       }
 
       // Format receipts based on platform
@@ -329,11 +337,11 @@ export const useInAppPurchase = (options?: {
         Alert.alert(
           'Purchases Restored',
           `${result.data.restored_count} subscription(s) restored successfully.`,
-          [{text: 'OK'}],
+          [{ text: 'OK' }],
         );
       }
 
-      setState(prev => ({...prev, loading: false}));
+      setState(prev => ({ ...prev, loading: false }));
       return result;
     } catch (error: any) {
       console.error('Restore error:', error);

--- a/MirrorCollectiveApp/src/screens/CheckoutScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/CheckoutScreen.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
 import React from 'react';
 import {
   View,
@@ -14,10 +13,10 @@ import {
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { RootStackParamList } from '@/types';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import LogoHeader from '@components/LogoHeader';
-
-import { RootStackParamList } from '@/types';
+import { palette, textShadow } from '@theme';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Checkout'>;
 
@@ -235,9 +234,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   backArrow: {
-    width: rs(24),
-    height: rs(24),
-    tintColor: CHECKOUT_COLORS.gold,
+    // Align with the app-wide header back arrow (Terms / StartFreeTrial):
+    // 20px, contained, warm gold — not the brighter gold.DEFAULT used elsewhere
+    // in this screen.
+    width: rs(20),
+    height: rs(20),
+    resizeMode: 'contain',
+    tintColor: palette.gold.warm,
   },
   title: {
     fontFamily: 'CormorantGaramond-Regular',

--- a/MirrorCollectiveApp/src/screens/CheckoutScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/CheckoutScreen.tsx
@@ -57,8 +57,9 @@ const CheckoutScreen: React.FC = () => {
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          {/* Logo Header */}
-          <LogoHeader />
+          {/* Logo Header — negative margin cancels scrollContent's horizontal
+              padding so the menu button lines up with other screens. */}
+          <LogoHeader wrapperStyle={styles.headerBleed} />
 
           {/* Header Row: Back Arrow + Title */}
           <View style={styles.headerRow}>
@@ -217,6 +218,8 @@ const styles = StyleSheet.create({
     paddingBottom: rs(40),
     alignItems: 'center',
   },
+  // Cancels scrollContent's horizontal padding so LogoHeader is full-bleed.
+  headerBleed: { marginHorizontal: -rs(24), alignSelf: 'stretch' },
 
   // Header
   headerRow: {

--- a/MirrorCollectiveApp/src/screens/EchoVaultStorageScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/EchoVaultStorageScreen.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { palette, textShadow } from '@theme';
 import React, { useState } from 'react';
 import {
   View,
@@ -16,11 +15,11 @@ import {
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { RootStackParamList } from '@/types';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import LogoHeader from '@components/LogoHeader';
 import StarIcon from '@components/StarIcon';
-
-import { RootStackParamList } from '@/types';
+import { palette, textShadow } from '@theme';
 
 type NavigationProp = NativeStackNavigationProp<
   RootStackParamList,
@@ -66,7 +65,10 @@ const EchoVaultStorageScreen = () => {
     <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage}>
       <SafeAreaView style={styles.safe}>
         <View style={styles.outerBoxContainer}>
-          <LogoHeader />
+          {/* Negative margin cancels outerBoxContainer's horizontal padding so
+              the header is full-bleed and its menu button lines up with other
+              screens. */}
+          <LogoHeader wrapperStyle={styles.headerBleed} />
 
           <View style={styles.outerBox}>
             <View style={styles.headerRow}>
@@ -245,6 +247,7 @@ const styles = StyleSheet.create<{
   bgImage: ImageStyle;
   safe: ViewStyle;
   outerBoxContainer: ViewStyle;
+  headerBleed: ViewStyle;
   outerBox: ViewStyle;
   headerRow: ViewStyle;
   backButton: ViewStyle;
@@ -303,6 +306,11 @@ const styles = StyleSheet.create<{
       paddingTop: 20,
       paddingBottom: outerContainerPaddingBottom,
       alignItems: 'center',
+    },
+    // Cancels outerBoxContainer's horizontal padding so LogoHeader is full-bleed.
+    headerBleed: {
+      marginHorizontal: -outerContainerPaddingHorizontal,
+      alignSelf: 'stretch',
     },
 
     outerBox: {

--- a/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
@@ -111,7 +111,13 @@ const MySubscriptionScreen: React.FC<Props> = ({ navigation }) => {
     <BackgroundWrapper style={styles.bg}>
       <SafeAreaView style={styles.safe}>
         <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
-        <LogoHeader navigation={navigation} />
+        {/* Negative margin cancels `safe`'s 24px padding so the header is
+            full-bleed and its menu button sits at the same inset as every
+            other screen. */}
+        <LogoHeader
+          navigation={navigation}
+          wrapperStyle={styles.headerBleed}
+        />
 
         {/* Header row: ← | SUBSCRIPTION | spacer */}
         <View style={styles.headerRow}>
@@ -245,6 +251,8 @@ const GOLD = palette.gold.DEFAULT;
 const styles = StyleSheet.create({
   bg: { flex: 1 },
   safe: { flex: 1, backgroundColor: 'transparent', paddingHorizontal: 24 },
+  // Cancels `safe`'s 24px horizontal padding so LogoHeader spans edge-to-edge.
+  headerBleed: { marginHorizontal: -24 },
 
   headerRow: {
     flexDirection: 'row',

--- a/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/MySubscriptionScreen.tsx
@@ -10,8 +10,6 @@
  * Subscription data comes from SubscriptionContext (server = source of truth).
  */
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { palette, fontFamily, fontSize, spacing, scale, radius } from '@theme';
-import type { RootStackParamList } from '@types';
 import React, { useState } from 'react';
 import {
   View,
@@ -35,6 +33,8 @@ import StarIcon from '@components/StarIcon';
 import { LEGAL_LINKS } from '@constants/config';
 import { useSubscription } from '@context/SubscriptionContext';
 import { useInAppPurchase, localizedPrice } from '@hooks/useInAppPurchase';
+import { palette, fontFamily, fontSize, scale, radius } from '@theme';
+import type { RootStackParamList } from '@types';
 
 // iOS Manage Subscriptions deep link. Auto-renewable subscriptions cannot be
 // cancelled programmatically — Apple requires the user to do it in Settings /
@@ -252,8 +252,22 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     marginTop: 8,
   },
-  backBtn: { width: scale(24), height: scale(24), justifyContent: 'center' },
-  backArrow: { width: scale(20), height: scale(20), tintColor: palette.gold.DEFAULT },
+  // Match the canonical header back-button treatment used across the app
+  // (TermsAndConditionsScreen / StartFreeTrialScreen): a 40px touch box with a
+  // 20px warm-gold arrow. The symmetric 40px spacer on the right keeps the
+  // flex:1 title centred.
+  backBtn: {
+    width: scale(40),
+    height: scale(40),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backArrow: {
+    width: scale(20),
+    height: scale(20),
+    resizeMode: 'contain',
+    tintColor: palette.gold.warm,
+  },
   title: {
     flex: 1,
     textAlign: 'center',

--- a/MirrorCollectiveApp/src/screens/ProfileScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/ProfileScreen.tsx
@@ -1,19 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  borderWidth,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  moderateScale,
-  palette,
-  scale,
-  spacing,
-  textShadow,
-  verticalScale,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 import React, { useState, useEffect, useCallback } from 'react';
 import {
   ActivityIndicator,
@@ -40,11 +26,27 @@ import Button from '@components/Button/Button';
 import { CachedImage } from '@components/CachedImage';
 import LogoHeader from '@components/LogoHeader';
 import TextInputField from '@components/TextInputField';
+import { useSession } from '@context/SessionContext';
 import { useUser } from '@context/UserContext';
 import { authApiService } from '@services/api';
 import { echoApiService } from '@services/api/echo';
-import { pickProfilePhoto } from '@utils/media/pickProfilePhoto';
 import { TTS_FEATURE_ENABLED } from '@services/speech';
+import {
+  borderWidth,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  moderateScale,
+  palette,
+  scale,
+  spacing,
+  textShadow,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
+import { pickProfilePhoto } from '@utils/media/pickProfilePhoto';
+
 import { SpeechSettingsRow } from './settings/SpeechSettingsRow';
 
 const AVATAR_SIZE = moderateScale(160);
@@ -61,12 +63,14 @@ const formatPhoneDisplay = (e164: string): string => {
 const ProfileScreen: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { user, refreshUser } = useUser();
+  const { deleteAccount } = useSession();
 
   // E.164 stored internally — displayed via formatPhoneDisplay (matches SignUpScreen)
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('+1');
   const [localImageUri, setLocalImageUri] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [refreshed, setRefreshed] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
@@ -135,6 +139,45 @@ const ProfileScreen: React.FC = () => {
       setIsSaving(false);
     }
   }, [localImageUri, name, phone, refreshUser]);
+
+  const performDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      const ok = await deleteAccount();
+      if (!ok) {
+        Alert.alert(
+          'Deletion failed',
+          'We could not delete your account. Please try again, or contact support if the problem persists.',
+        );
+      }
+      // On success the SessionContext dispatches LOGOUT_SUCCESS, which unmounts
+      // the authenticated navigator and returns the app to the sign-in flow.
+    } catch {
+      Alert.alert(
+        'Deletion failed',
+        'Something went wrong deleting your account. Please try again.',
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [deleteAccount]);
+
+  const handleDeleteAccount = useCallback(() => {
+    Alert.alert(
+      'Delete account?',
+      'This permanently deletes your account and all associated data. This cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            void performDelete();
+          },
+        },
+      ],
+    );
+  }, [performDelete]);
 
   return (
     <BackgroundWrapper style={styles.bg} imageStyle={styles.bgImage}>
@@ -263,6 +306,24 @@ const ProfileScreen: React.FC = () => {
                 />
               )}
 
+              {/* Delete account — Apple Guideline 5.1.1(v) requires an in-app
+                  path to permanently delete the account. */}
+              {isDeleting ? (
+                <ActivityIndicator
+                  color={palette.gold.DEFAULT}
+                  style={styles.loader}
+                />
+              ) : (
+                <TouchableOpacity
+                  onPress={handleDeleteAccount}
+                  style={styles.deleteButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Delete account"
+                >
+                  <Text style={styles.deleteButtonText}>Delete Account</Text>
+                </TouchableOpacity>
+              )}
+
             </View>
           </TouchableWithoutFeedback>
         </ScrollView>
@@ -279,6 +340,7 @@ const styles = StyleSheet.create<{
   subtitle: TextStyle; avatarRing: ViewStyle;
   avatarImage: ImageStyle; avatarPlaceholder: TextStyle;
   form: ViewStyle; loader: ViewStyle;
+  deleteButton: ViewStyle; deleteButtonText: TextStyle;
 }>({
   bg:   { flex: 1 },
   bgImage: { resizeMode: 'cover' },
@@ -376,6 +438,22 @@ const styles = StyleSheet.create<{
   },
 
   loader: { marginVertical: verticalScale(spacing.m) },
+
+  // ── Delete account ─────────────────────────────────────────────────────────
+  deleteButton: {
+    marginTop: verticalScale(spacing.s),
+    paddingVertical: verticalScale(spacing.s),
+    alignItems: 'center',
+  },
+  deleteButtonText: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.s),
+    fontWeight: fontWeight.regular,
+    lineHeight: moderateScale(lineHeight.m),
+    color: palette.status.error,
+    textAlign: 'center',
+    textDecorationLine: 'underline',
+  },
 });
 
 export default ProfileScreen;

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
@@ -33,6 +33,10 @@ jest.mock('@react-navigation/native', () => ({
 const CORE_MONTHLY = 'com.themirrorcollective.mirror.monthly';
 const CORE_YEARLY = 'com.themirrorcollective.mirror.yearly';
 const mockPurchase = jest.fn().mockResolvedValue(undefined);
+const mockRestore = jest.fn().mockResolvedValue({
+  success: true,
+  data: { restored_count: 0, subscriptions: [] },
+});
 const mockRefresh = jest.fn().mockResolvedValue(undefined);
 const mockSetAuthenticated = jest.fn();
 // Holder (mock-prefixed so the jest.mock factory may reference it) that captures
@@ -43,6 +47,7 @@ jest.mock('@/hooks/useInAppPurchase', () => ({
     mockHook.onVerified = opts?.onPurchaseVerified;
     return {
       purchaseSubscription: mockPurchase,
+      restorePurchases: mockRestore,
       purchasing: false,
       products: [],
       PRODUCT_IDS: {
@@ -103,5 +108,49 @@ describe('StartFreeTrialScreen — monthly/yearly toggle', () => {
     await mockHook.onVerified?.();
     expect(mockRefresh).toHaveBeenCalled();
     expect(mockSetAuthenticated).toHaveBeenCalled();
+  });
+});
+
+describe('StartFreeTrialScreen — App Store compliance', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('shows the auto-renewal disclosure (Guideline 3.1.2)', () => {
+    const { getByText } = render(<StartFreeTrialScreen />);
+    // Must state charge to Apple ID, auto-renew, and 24h cancellation window.
+    expect(
+      getByText(/Payment is charged to your Apple ID/i),
+    ).toBeTruthy();
+    expect(
+      getByText(/automatically renews unless auto-renew is turned off/i),
+    ).toBeTruthy();
+  });
+
+  it('renders a Restore Purchase control', () => {
+    const { getByText } = render(<StartFreeTrialScreen />);
+    expect(getByText('Restore Purchase')).toBeTruthy();
+  });
+
+  it('invokes restorePurchases when the control is pressed', async () => {
+    const { getByText } = render(<StartFreeTrialScreen />);
+    fireEvent.press(getByText('Restore Purchase'));
+    await waitFor(() => expect(mockRestore).toHaveBeenCalled());
+  });
+
+  it('enters the app when a restore finds an active subscription', async () => {
+    mockRestore.mockResolvedValueOnce({
+      success: true,
+      data: { restored_count: 1, subscriptions: [{ id: 'sub-1' }] },
+    });
+    const { getByText } = render(<StartFreeTrialScreen />);
+    fireEvent.press(getByText('Restore Purchase'));
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+    expect(mockSetAuthenticated).toHaveBeenCalled();
+  });
+
+  it('does not enter the app when a restore finds nothing', async () => {
+    const { getByText } = render(<StartFreeTrialScreen />);
+    fireEvent.press(getByText('Restore Purchase'));
+    await waitFor(() => expect(mockRestore).toHaveBeenCalled());
+    expect(mockSetAuthenticated).not.toHaveBeenCalled();
   });
 });

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
@@ -1,22 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  palette,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  radius,
-  borderWidth,
-  textShadow,
-  glassGradient,
-  semantic,
-  scale,
-  verticalScale,
-  moderateScale,
-  modalColors,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 import React, { useState } from 'react';
 import {
     View,
@@ -34,16 +17,32 @@ import {
 import LinearGradient from 'react-native-linear-gradient';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { useSession } from '@/context/SessionContext';
+import { useSubscription } from '@/context/SubscriptionContext';
+import { useInAppPurchase, localizedPrice } from '@/hooks/useInAppPurchase';
+import { subscriptionApiService } from '@/services/api/subscriptionApi';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
 import StarIcon from '@components/StarIcon';
 import { LEGAL_LINKS } from '@constants/config';
-
-import { useSession } from '@/context/SessionContext';
-import { useSubscription } from '@/context/SubscriptionContext';
-import { useInAppPurchase, localizedPrice } from '@/hooks/useInAppPurchase';
-import { subscriptionApiService } from '@/services/api/subscriptionApi';
+import {
+  palette,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  radius,
+  borderWidth,
+  textShadow,
+  glassGradient,
+  semantic,
+  scale,
+  verticalScale,
+  moderateScale,
+  modalColors,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'StartFreeTrial'>;
 
@@ -52,7 +51,7 @@ const StartFreeTrialScreen = () => {
     const canGoBack = navigation.canGoBack();
     const { hasUsedTrial, hasActiveSubscription, refreshSubscriptionStatus } = useSubscription();
     const { setAuthenticated } = useSession();
-    const { purchaseSubscription, purchasing, PRODUCT_IDS, products } = useInAppPurchase({
+    const { purchaseSubscription, restorePurchases, purchasing, PRODUCT_IDS, products } = useInAppPurchase({
         // A paid purchase is confirmed asynchronously (StoreKit listener →
         // backend verify). When that completes, refresh status and enter the
         // app — mirroring the trial path, which calls setAuthenticated()
@@ -64,6 +63,7 @@ const StartFreeTrialScreen = () => {
         },
     });
     const [loading, setLoading] = useState(false);
+    const [restoring, setRestoring] = useState(false);
     const [selectedPeriod, setSelectedPeriod] = useState<'monthly' | 'yearly'>('monthly');
 
     // Live store prices (fall back to the confirmed defaults until IAP loads).
@@ -122,6 +122,26 @@ const StartFreeTrialScreen = () => {
             await Linking.openURL(url);
         } catch {
             Alert.alert('Unable to open link', 'Please try again later.');
+        }
+    };
+
+    // Apple requires a visible "Restore Purchases" control on any screen that
+    // sells a subscription. Re-syncs any prior purchase on this Apple ID and,
+    // if one is active, routes the user into the app.
+    const handleRestore = async () => {
+        if (restoring) return;
+        try {
+            setRestoring(true);
+            const result = await restorePurchases();
+            if (result && result.success && (result.data?.restored_count ?? 0) > 0) {
+                await refreshSubscriptionStatus();
+                setAuthenticated();
+            }
+            // The hook already surfaces "no purchases found" / success alerts.
+        } catch (error: any) {
+            Alert.alert('Restore Failed', error?.message || 'Unable to restore purchases.');
+        } finally {
+            setRestoring(false);
         }
     };
 
@@ -321,7 +341,23 @@ const StartFreeTrialScreen = () => {
                     ]}
                   />
 
-                  <Text style={styles.cancelText}>Cancel anytime.</Text>
+                  {/* Auto-renewal disclosure — required by App Store Review
+                      Guideline 3.1.2. Must state price + cadence, that payment
+                      is charged to the Apple ID, that it auto-renews unless
+                      turned off ≥24h before period end, and how to manage. */}
+                  <Text style={styles.disclosureText}>
+                    {selectedPeriod === 'monthly'
+                      ? `Mirror Basic is ${monthlyPrice} per month`
+                      : `Mirror Basic is ${yearlyPrice} per year`}
+                    {isTrialMode
+                      ? ', billed after your 14-day free trial. '
+                      : '. '}
+                    Payment is charged to your Apple ID at confirmation of
+                    purchase. Your subscription automatically renews unless
+                    auto-renew is turned off at least 24 hours before the end of
+                    the current period. Manage or cancel anytime in your Apple ID
+                    Account Settings.
+                  </Text>
                 </ScrollView>
               </View>
             </View>
@@ -343,7 +379,16 @@ const StartFreeTrialScreen = () => {
               <Text style={styles.footerLinkText}>Privacy</Text>
             </TouchableOpacity>
             <Text style={styles.footerLinkText}>•</Text>
-            <Text style={styles.footerLinkText}>Restore Purchase</Text>
+            <TouchableOpacity
+              accessibilityRole="button"
+              accessibilityLabel="Restore purchase"
+              disabled={restoring}
+              onPress={handleRestore}
+            >
+              <Text style={styles.footerLinkText}>
+                {restoring ? 'Restoring…' : 'Restore Purchase'}
+              </Text>
+            </TouchableOpacity>
           </View>
         </SafeAreaView>
       </BackgroundWrapper>
@@ -392,7 +437,7 @@ const styles = StyleSheet.create<{
   ctaButtonContainer: ViewStyle;
   ctaButtonContent: ViewStyle;
   ctaButtonText: TextStyle;
-  cancelText: TextStyle;
+  disclosureText: TextStyle;
   footerLinksRow: ViewStyle;
   footerLinkText: TextStyle;
 }>({
@@ -673,11 +718,16 @@ const styles = StyleSheet.create<{
     textTransform: 'none',
   },
   // semantic.typography.styles.label — italic Inter 14px — with gold.subtlest colour override
-  cancelText: {
-    ...semantic.typography.styles.label,
+  disclosureText: {
+    fontFamily: fontFamily.body,
+    fontSize: moderateScale(fontSize.xs),
+    fontWeight: fontWeight.light,
+    lineHeight: moderateScale(fontSize.xs) * 1.5,
     color: palette.gold.subtlest,
     textAlign: 'center',
-    opacity: 0.85,
+    opacity: 0.8,
+    marginTop: verticalScale(8),
+    paddingHorizontal: scale(8),
   },
 
   // ── Footer ────────────────────────────────────────────────────────────────

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
@@ -159,7 +159,9 @@ const StartFreeTrialScreen = () => {
       >
         <SafeAreaView style={styles.safe}>
           {/* ── Logo ────────────────────────────────────────────────── */}
-          <LogoHeader />
+          {/* Negative margin cancels `safe`'s horizontal padding so the header
+              is full-bleed and its menu button lines up with other screens. */}
+          <LogoHeader wrapperStyle={styles.headerBleed} />
 
           {/* ── Back + Title ─────────────────────────────────────────── */}
           {/* Single-element header — matches TermsAndConditionsScreen's
@@ -401,6 +403,7 @@ const styles = StyleSheet.create<{
   bg: ViewStyle;
   bgImage: ImageStyle;
   safe: ViewStyle;
+  headerBleed: ViewStyle;
   headerRow: ViewStyle;
   backButton: ViewStyle;
   backArrow: ImageStyle;
@@ -458,6 +461,9 @@ const styles = StyleSheet.create<{
     paddingBottom: verticalScale(24),
     gap: verticalScale(16),
   },
+
+  // Cancels `safe`'s horizontal padding so LogoHeader spans edge-to-edge.
+  headerBleed: { marginHorizontal: -scale(24) },
 
   // ── Header row — matches TermsAndConditionsScreen pattern exactly ─────────
   // back button is absolute so the title Text is the sole layout child

--- a/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/TermsAndConditionsScreen.tsx
@@ -1,21 +1,5 @@
 import { useNavigation, useRoute, type RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  palette,
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  radius,
-  borderWidth,
-  textShadow,
-  scale,
-  verticalScale,
-  moderateScale,
-  modalColors,
-} from '@theme';
-import type { RootStackParamList } from '@types';
-import { LEGAL_LINKS } from '@constants/config';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -36,8 +20,24 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import BackgroundWrapper from '@components/BackgroundWrapper';
 import Button from '@components/Button/Button';
 import LogoHeader from '@components/LogoHeader';
+import { LEGAL_LINKS } from '@constants/config';
 import { useSession } from '@context/SessionContext';
 import { authApiService } from '@services/api';
+import {
+  palette,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  radius,
+  borderWidth,
+  textShadow,
+  scale,
+  verticalScale,
+  moderateScale,
+  modalColors,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 import { getApiErrorMessage } from '@utils/apiErrorUtils';
 import { setPendingVerification } from '@utils/verificationState';
 
@@ -78,7 +78,9 @@ const TermsAndConditionsScreen = () => {
             */}
         <SafeAreaView style={styles.safe}>
           {/* ── Logo ─────────────────────────────────────────────── */}
-          <LogoHeader />
+          {/* Negative margin cancels `safe`'s horizontal padding so the header
+              is full-bleed and its menu button lines up with other screens. */}
+          <LogoHeader wrapperStyle={styles.headerBleed} />
 
           {/* ── Back + Title ──────────────────────────────────────── */}
           <View style={styles.headerRow}>
@@ -335,6 +337,7 @@ const styles = StyleSheet.create<{
   bg: ViewStyle;
   bgImage: ImageStyle;
   safe: ViewStyle;
+  headerBleed: ViewStyle;
   headerRow: ViewStyle;
   backButton: ViewStyle;
   backArrow: ImageStyle;
@@ -373,6 +376,8 @@ const styles = StyleSheet.create<{
     paddingBottom: verticalScale(24),
     gap: verticalScale(24),
   },
+  // Cancels `safe`'s horizontal padding so LogoHeader spans edge-to-edge.
+  headerBleed: { marginHorizontal: -scale(24) },
 
   // ── Header row ──────────────────────────────────────────────────────────
   headerRow: {

--- a/MirrorCollectiveApp/src/screens/VerifyEmailScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/VerifyEmailScreen.tsx
@@ -1,18 +1,6 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
 import type { RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  fontFamily,
-  fontSize,
-  fontWeight,
-  lineHeight,
-  moderateScale,
-  palette,
-  scale,
-  textShadow,
-  verticalScale,
-} from '@theme';
-import type { RootStackParamList } from '@types';
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -32,6 +20,18 @@ import LogoHeader from '@components/LogoHeader';
 import TextInputField from '@components/TextInputField';
 import { authApiService } from '@services/api';
 import { QuizStorageService } from '@services/quizStorageService';
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  moderateScale,
+  palette,
+  scale,
+  textShadow,
+  verticalScale,
+} from '@theme';
+import type { RootStackParamList } from '@types';
 import { getApiErrorMessage } from '@utils/apiErrorUtils';
 import { clearPendingVerification } from '@utils/verificationState';
 
@@ -86,11 +86,6 @@ const VerifyEmailScreen = () => {
     }
 
     setIsVerifying(true);
-
-    if (__DEV__) {
-      console.log('VerifyEmailScreen - verificationCode:', verificationCode);
-      console.log('VerifyEmailScreen - email:', normalizedEmail);
-    }
 
     try {
       // Get anonymousId for linking quiz data

--- a/MirrorCollectiveApp/src/services/PushNotificationService.ts
+++ b/MirrorCollectiveApp/src/services/PushNotificationService.ts
@@ -183,7 +183,9 @@ class PushNotificationService {
         device_token: token,
         platform: Platform.OS,
       });
-      console.log(`Device registered successfully for user ${this.userId} on ${Platform.OS}`);
+      if (__DEV__) {
+        console.log(`Device registered successfully on ${Platform.OS}`);
+      }
     } catch (error) {
       console.error('Failed to register device with backend:', error);
     }

--- a/MirrorCollectiveApp/src/services/api/auth.test.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.test.ts
@@ -111,6 +111,46 @@ describe('AuthApiService', () => {
     });
   });
 
+  describe('deleteAccount', () => {
+    beforeEach(() => {
+      // DELETE /api/auth/account is an authenticated call — provide a token so
+      // makeRequest doesn't short-circuit with "Session expired".
+      (tokenManager.getValidToken as jest.Mock).mockResolvedValue(
+        'mock-jwt-token',
+      );
+    });
+
+    it('sends DELETE to /api/auth/account', async () => {
+      await authService.deleteAccount();
+
+      expect(global.fetch).toHaveBeenCalled();
+      const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+      const path = String(url).replace(/^https?:\/\/[^/]+/, '');
+      expect(path.startsWith('/api/auth/account')).toBe(true);
+      expect(init.method).toBe('DELETE');
+    });
+
+    it('clears local tokens after deletion (returns to signed-out state)', async () => {
+      await authService.deleteAccount();
+
+      // The account is gone server-side — the app must not keep using a
+      // now-invalid session, so tokens are always cleared.
+      expect(tokenManager.clearTokens).toHaveBeenCalled();
+    });
+
+    it('still clears tokens when the server call fails', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'boom' }),
+      });
+
+      await authService.deleteAccount();
+
+      expect(tokenManager.clearTokens).toHaveBeenCalled();
+    });
+  });
+
   describe('refreshToken', () => {
     const mockStore = (values: Record<string, string | null>) => {
       (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>

--- a/MirrorCollectiveApp/src/services/api/auth.ts
+++ b/MirrorCollectiveApp/src/services/api/auth.ts
@@ -139,6 +139,30 @@ export class AuthApiService extends BaseApiService {
     );
   }
 
+  /**
+   * Permanently delete the current user's account (Apple Guideline 5.1.1(v)
+   * requires in-app account deletion). Calls DELETE /api/auth/account, then
+   * clears local tokens so the app returns to the signed-out state.
+   */
+  async deleteAccount(): Promise<ApiResponse> {
+    const response = await this.makeRequest<any>(
+      '/api/auth/account',
+      'DELETE',
+      undefined,
+      true,
+    );
+
+    // The account is gone server-side — always clear local tokens so the app
+    // can't keep using a now-invalid session.
+    await this.clearTokens();
+
+    return ApiErrorHandler.handleApiResponse(
+      response,
+      'Account deleted',
+      'UnknownError',
+    );
+  }
+
   // Token management
   async storeTokens(tokens: {
     accessToken: string;


### PR DESCRIPTION
…e, restore, wedge fix, log scrub

Five fixes required before first App Store submission:

1. In-app account deletion (Guideline 5.1.1(v)): authApiService.deleteAccount() (DELETE /api/auth/account + token clear), SessionContext.deleteAccount, and a confirm-dialog "Delete Account" control on ProfileScreen.
2. Auto-renewal disclosure (Guideline 3.1.2) on the paywall near the buy button: price/cadence, charge to Apple ID, auto-renew + 24h cancellation window, manage.
3. Restore Purchase wired on the paywall (was dead text) → restorePurchases(), routes into the app when an active sub is found.
4. IAP init wedge: register purchase listeners BEFORE getSubscriptions and wrap initConnection/getSubscriptions in timeouts so a hung native StoreKit call no longer leaves the paywall stuck on "LOADING..." forever.
5. Scrub sensitive logs: drop verification-code/email logs, gate/redact the full purchase-object log (receipt), and stop logging userId on device registration.

Tests: deleteAccount API behavior; restore + disclosure rendering/flow on the paywall; IAP listener-ordering, hang-timeout, and reject paths.