### PR TITLE
fix: keep new users on the trial screen; Manage Subscription for paid…

### DIFF
--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { Linking } from 'react-native';
 
 import StartFreeTrialScreen from './StartFreeTrialScreen';
 
@@ -180,44 +181,32 @@ describe('StartFreeTrialScreen — App Store compliance', () => {
 });
 
 describe('StartFreeTrialScreen — entitlement handling', () => {
-  it('rescues an onboarding user who already has a trial (enters the app)', async () => {
-    // Post-verify, a trial user lands here as the navigator root with no back
-    // button — route them into the app instead of a dead-end paywall.
-    mockFlags.status = 'trial';
-    mockFlags.isAuthenticated = false;
-    render(<StartFreeTrialScreen />);
-    await waitFor(() => expect(mockSetAuthenticated).toHaveBeenCalled());
+  it('shows an enabled START FREE TRIAL for a brand-new user (kept on the paywall)', () => {
+    // New users see the trial screen after verification — they are NOT
+    // auto-routed into the app; the paywall is part of onboarding.
+    mockFlags.status = 'none';
+    mockFlags.hasUsedTrial = false;
+    const { getByText } = render(<StartFreeTrialScreen />);
+    expect(mockSetAuthenticated).not.toHaveBeenCalled();
+    expect(getByText('START FREE TRIAL')).toBeTruthy();
   });
 
-  it('lets an authenticated TRIAL user subscribe (button enabled, not bounced)', async () => {
-    // A trial user who navigates here to convert to paid must be able to buy.
+  it('lets a TRIAL user subscribe (CTA enabled, purchase fires)', async () => {
     mockFlags.status = 'trial';
-    mockFlags.isAuthenticated = true;
     const { getByText } = render(<StartFreeTrialScreen />);
-    // Not auto-routed away.
-    expect(mockSetAuthenticated).not.toHaveBeenCalled();
-    expect(mockGoBack).not.toHaveBeenCalled();
-    // CTA is enabled → tapping starts the purchase.
     fireEvent.press(getByText('SUBSCRIBE NOW'));
     await waitFor(() => expect(mockPurchase).toHaveBeenCalledWith(CORE_MONTHLY));
   });
 
-  it('blocks re-purchase only for a genuinely PAID subscription', async () => {
+  it('offers Manage Subscription (not a dead button) to a PAID subscriber', async () => {
     mockFlags.status = 'active';
-    mockFlags.isAuthenticated = true;
     const { getByText } = render(<StartFreeTrialScreen />);
-    fireEvent.press(getByText('SUBSCRIBE NOW')); // disabled — no-op
-    // Give any async a tick; purchase must NOT be attempted.
-    await Promise.resolve();
-    expect(mockPurchase).not.toHaveBeenCalled();
-  });
-
-  it('does NOT auto-route a brand-new user with no subscription', () => {
-    mockFlags.status = 'none';
-    mockFlags.hasUsedTrial = false; // fresh account → "START FREE TRIAL"
-    mockFlags.isAuthenticated = false;
-    const { getByText } = render(<StartFreeTrialScreen />);
-    expect(mockSetAuthenticated).not.toHaveBeenCalled();
-    expect(getByText('START FREE TRIAL')).toBeTruthy();
+    fireEvent.press(getByText('MANAGE SUBSCRIPTION'));
+    await waitFor(() =>
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        'https://apps.apple.com/account/subscriptions',
+      ),
+    );
+    expect(mockPurchase).not.toHaveBeenCalled(); // no re-purchase from the paywall
   });
 });

--- a/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
+++ b/MirrorCollectiveApp/src/screens/StartFreeTrialScreen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
     View,
     Text,
@@ -46,12 +46,15 @@ import type { RootStackParamList } from '@types';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'StartFreeTrial'>;
 
+// iOS Manage Subscriptions deep link — monthly↔yearly plan changes for an
+// active subscription are handled by Apple, not the in-app paywall.
+const MANAGE_SUBSCRIPTIONS_URL = 'https://apps.apple.com/account/subscriptions';
+
 const StartFreeTrialScreen = () => {
     const navigation = useNavigation<NavigationProp>();
     const canGoBack = navigation.canGoBack();
     const { status, hasUsedTrial, hasActiveSubscription, refreshSubscriptionStatus } = useSubscription();
-    const { setAuthenticated, state: sessionState } = useSession();
-    const { isAuthenticated } = sessionState;
+    const { setAuthenticated } = useSession();
     const { purchaseSubscription, restorePurchases, purchasing, PRODUCT_IDS, products } = useInAppPurchase({
         // A paid purchase is confirmed asynchronously (StoreKit listener →
         // backend verify). When that completes, refresh status and enter the
@@ -75,24 +78,18 @@ const StartFreeTrialScreen = () => {
     const buttonText = isTrialMode ? 'START FREE TRIAL' : 'SUBSCRIBE NOW';
 
     // Only a genuinely PAID subscription blocks re-purchasing. A trial counts as
-    // "active" for access purposes, but a trial user must still be able to
-    // convert to paid — so the CTA must NOT be disabled during a trial.
+    // "active" for access purposes, but the CTA must stay enabled so a new user
+    // can start their trial and a trial user can convert to paid. The paywall is
+    // intentionally shown to new users after verification — do NOT auto-route
+    // them into the app; the trial screen is part of onboarding.
     const isActivePaid = status === 'active';
-
-    // Onboarding rescue: a just-verified user can land here as the navigator
-    // ROOT (no back button). If they're already entitled (trial started), don't
-    // park them on the paywall — enter the app. Scoped to the pre-auth path
-    // only: an authenticated user who navigated here on purpose (e.g. to convert
-    // a trial to paid) is left alone so they can actually subscribe.
-    useEffect(() => {
-        if (!isAuthenticated && hasActiveSubscription) {
-            setAuthenticated();
-        }
-    }, [isAuthenticated, hasActiveSubscription, setAuthenticated]);
 
     const handleButtonPress = async () => {
         if (isActivePaid) {
-            Alert.alert('Already Subscribed', 'You already have an active subscription.');
+            // Already on a paid plan. Monthly↔yearly changes are an Apple-managed
+            // upgrade/downgrade — deep-link to Manage Subscriptions rather than
+            // showing a dead-end disabled button.
+            await openLink(MANAGE_SUBSCRIPTIONS_URL);
             return;
         }
 
@@ -347,9 +344,15 @@ const StartFreeTrialScreen = () => {
                   {/* CTA button — standard Button component, gradient variant */}
                   <Button
                     variant="gradient"
-                    title={loading || purchasing ? 'LOADING...' : buttonText}
+                    title={
+                      loading || purchasing
+                        ? 'LOADING...'
+                        : isActivePaid
+                          ? 'MANAGE SUBSCRIPTION'
+                          : buttonText
+                    }
                     onPress={handleButtonPress}
-                    disabled={loading || purchasing || isActivePaid}
+                    disabled={loading || purchasing}
                     style={styles.ctaButtonWrapper}
                     containerStyle={styles.ctaButtonContainer}
                     contentStyle={styles.ctaButtonContent}


### PR DESCRIPTION
… users

- Remove the onboarding auto-route: new users must SEE the Start-Your-Free-Trial screen after verification, not be skipped to home. Starting the trial (handleButtonPress) already enters the app on success.
- The CTA is disabled only for a genuinely PAID subscription; new/trial users keep an enabled button and can start a trial or convert to paid (incl. picking monthly/yearly).
- For an already-active subscriber the CTA becomes an enabled 'MANAGE SUBSCRIPTION' that deep-links to Apple's Manage Subscriptions (where monthly<->yearly plan changes happen) instead of a dead disabled button.